### PR TITLE
remove biometrics.createKeys()

### DIFF
--- a/app/src/screens/SplashScreen.tsx
+++ b/app/src/screens/SplashScreen.tsx
@@ -21,10 +21,7 @@ const SplashScreen: React.FC = ({}) => {
     checkBiometricsAvailable()
       .then(setBiometricsAvailable)
       .catch(err => {
-        console.warn(
-          'Error checking biometrics availability',
-          err,
-        );
+        console.warn('Error checking biometrics availability', err);
       });
   }, []);
 

--- a/app/src/screens/SplashScreen.tsx
+++ b/app/src/screens/SplashScreen.tsx
@@ -14,15 +14,15 @@ import { isUserRegistered } from '../utils/proving/payload';
 
 const SplashScreen: React.FC = ({}) => {
   const navigation = useNavigation();
-  const { createSigningKeyPair } = useAuth();
+  const { checkBiometricsAvailable } = useAuth();
   const { setBiometricsAvailable } = useSettingStore();
 
   useEffect(() => {
-    createSigningKeyPair()
+    checkBiometricsAvailable()
       .then(setBiometricsAvailable)
       .catch(err => {
         console.warn(
-          'Something ELSE and totally unexpected went wrong during keypair creation',
+          'Error checking biometrics availability',
           err,
         );
       });


### PR DESCRIPTION
I’m getting `Error generating public private keys` on open on a Redmi 14C.

It looks like we used to use `biometrics.createKeys()` and `biometrics.createSignature()`; instead of simply calling `biometrics.simplePrompt()` to check biometrics.
It’s unclear to me why we needed to create a keypair and sign the passport data/secret when it’s retrieved from the keychain, especially since it looks like the signature was always disregarded.
Rémi solved issues he was having on Android [here](https://github.com/selfxyz/self/commit/14495732a3112b62dbf49fdbfd047c1765095138) by replacing `biometrics.createSignature()` by `biometrics.simplePrompt()`
This PR also removes `biometrics.createKeys()` which causes issues on my side.

Wanted to confirm first with @nicolasbrugneaux before merging anything as I don't want to break stuff.