### PR TITLE
removed next dependency on sdk

### DIFF
--- a/sdk/qrcode/SelfQRcode.tsx
+++ b/sdk/qrcode/SelfQRcode.tsx
@@ -8,13 +8,9 @@ import { REDIRECT_URL, WS_DB_RELAYER } from '../../common/src/constants/constant
 import { v4 as uuidv4 } from 'uuid';
 import { QRcodeSteps } from './utils/utils';
 import { containerStyle, ledContainerStyle, qrContainerStyle } from './utils/styles';
-import dynamic from 'next/dynamic';
+import { QRCodeSVG } from 'qrcode.react';
 import { initWebSocket } from './utils/websocket';
 import { SelfApp, SelfAppBuilder } from '../../common/src/utils/appType';
-
-const QRCodeSVG = dynamic(() => import('qrcode.react').then((mod) => mod.QRCodeSVG), {
-  ssr: false,
-});
 
 interface SelfQRcodeProps {
   selfApp: SelfApp;

--- a/sdk/qrcode/package.json
+++ b/sdk/qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/qrcode",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/selfxyz/self"


### PR DESCRIPTION
We should take a look again to know how to prevent server-side rendering in next while supporting react without next, cuz I'm still sometimes getting SSR errors.