### PR TITLE
chore: fix inconsistent quote usage

### DIFF
--- a/common/src/constants/constants.ts
+++ b/common/src/constants/constants.ts
@@ -5,7 +5,7 @@ export const COMMITMENT_TREE_DEPTH = 33;
 export const DEFAULT_USER_ID_TYPE = 'uuid';
 
 export const REDIRECT_URL = 'https://redirect.self.xyz';
-export const WS_RPC_URL_VC_AND_DISCLOSE = "ws://disclose.proving.self.xyz:8888/";
+export const WS_RPC_URL_VC_AND_DISCLOSE = 'ws://disclose.proving.self.xyz:8888/';
 export const WS_DB_RELAYER = 'wss://websocket.self.xyz';
 export const WS_DB_RELAYER_STAGING = 'wss://websocket.staging.self.xyz';
 export const API_URL = 'https://api.self.xyz';


### PR DESCRIPTION
**Description:**  
I noticed that double quotes (`"`) were used in a few places in `script.js`, while the rest of the file consistently uses single quotes (`'`).