### PR TITLE
fix: incorrect use of `perspective` on the same element

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -7,7 +7,6 @@
     background-clip: text;
     animation: rotate3D 3s infinite linear;
     transform-style: preserve-3d;
-    perspective: 800px;
     padding: 1.5rem;
     position: relative;
     display: inline-block;
@@ -46,6 +45,11 @@
     100% {
         transform: rotateY(0deg) rotateX(0deg);
     }
+}
+
+.rotatingWrapper {
+    perspective: 800px;
+    display: inline-block;
 }
 
 .rotatingTitle:hover {


### PR DESCRIPTION
`perspective` was being applied directly to the element being transformed, which doesn't have any effect according to the CSS spec.
`perspective` should be set on the parent instead.

updated the structure so that transforms now happen on a child element with the perspective correctly applied to its parent.  