### PR TITLE
chore: fix address handling by replacing `unknown` with `undefined`

### DIFF
--- a/contracts/scripts/setVerifiers.ts
+++ b/contracts/scripts/setVerifiers.ts
@@ -27,7 +27,7 @@ try {
 
     const contractAbiPath = path.join(__dirname, "../ignition/deployments/chain-11155111/artifacts");
 
-    function getContractAddressByPartialName(partialName: string): string | unknown {
+    function getContractAddressByPartialName(partialName: string): string | undefined {
         for (const [key, value] of Object.entries(deployedAddresses)) {
             if (key.includes(partialName)) {
                 return value;


### PR DESCRIPTION
### Description
Replaced `unknown` with `undefined` for address handling to avoid unnecessary checks and align with TypeScript's standard for missing values. This improves safety and clarity.