### PR TITLE
Fix typos in build_dsc_merkle_tree.ts and extract_pubkeys.ts

### DIFF
--- a/registry/src/dsc/build_dsc_merkle_tree.ts
+++ b/registry/src/dsc/build_dsc_merkle_tree.ts
@@ -12,7 +12,7 @@ import { LeanIMT } from '@openpassport/zk-kit-lean-imt';
 let tbs_max_bytes = 0;
 let key_length_max_bytes = 0;
 const countryKeyBitLengths: { [countryCode: string]: number } = {};
-let cscaDescriptions: { [cscaDesciption: string]: number } = {};
+let cscaDescriptions: { [cscaDescription: string]: number } = {};
 let dscDescriptions: { [dscDescription: string]: number } = {};
 let undefinedFilePathsCsca: string[] = [];
 let undefinedFilePathsDsc: string[] = [];

--- a/registry/src/dsc/extract_pubkeys.ts
+++ b/registry/src/dsc/extract_pubkeys.ts
@@ -3,7 +3,7 @@ import * as util from 'util';
 import { exec } from 'child_process';
 const execAsync = util.promisify(exec);
 
-// Extract public keys from pem certicates
+// Extract public keys from pem certificates
 const numCertificates = fs.readdirSync('outputs/certificates/').length;
 const concurrencyLimit = 500; // Number of tasks to run at once
 
@@ -159,7 +159,7 @@ function hexToDecimal(hexString: string): string {
 
 main();
 
-// Signature Algorithm and an example of occurence:
+// Signature Algorithm and an example of occurrence:
 // sha256WithRSAEncryption 0
 // rsassaPss 317
 // sha1WithRSAEncryption 493


### PR DESCRIPTION
This PR fixes several typos in the codebase:

- In build_dsc_merkle_tree.ts:
  - Fixed typo in variable name: cscaDesciption -> cscaDescription

- In extract_pubkeys.ts:
  - Fixed typo: "certicates" -> "certificates" in comments
  - Fixed typo: "occurence" -> "occurrence" in comments

No functional changes, only documentation and comment fixes.