### PR TITLE
Fix/proving machine endpoint type

### DIFF
--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -286,7 +286,9 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           }
           const endpointType = get().endpointType;
           if (!endpointType) {
-            console.error('Cannot start Socket.IO listener: endpointType not set.');
+            console.error(
+              'Cannot start Socket.IO listener: endpointType not set.',
+            );
             actor!.send({ type: 'PROVE_ERROR' });
             return;
           }

--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -123,6 +123,7 @@ interface ProvingState {
   circuitType: provingMachineCircuitType | null;
   error_code: string | null;
   reason: string | null;
+  endpointType: EndpointType | null;
   init: (circuitType: 'dsc' | 'disclose' | 'register') => Promise<void>;
   startFetchingData: () => Promise<void>;
   validatingDocument: () => Promise<void>;
@@ -238,6 +239,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
     selfApp: null,
     error_code: null,
     reason: null,
+    endpointType: null,
     _handleWebSocketMessage: async (event: MessageEvent) => {
       if (!actor) {
         console.error('Cannot process message: State machine not initialized.');
@@ -282,25 +284,13 @@ export const useProvingStore = create<ProvingState>((set, get) => {
               }). Using received UUID.`,
             );
           }
-          const { passportData } = get();
-          if (!statusUuid) {
-            console.error(
-              'Cannot start Socket.IO listener: UUID missing from state or response.',
-            );
+          const endpointType = get().endpointType;
+          if (!endpointType) {
+            console.error('Cannot start Socket.IO listener: endpointType not set.');
             actor!.send({ type: 'PROVE_ERROR' });
             return;
           }
-          if (!passportData) {
-            console.error(
-              'Cannot start Socket.IO listener: passportData missing from state.',
-            );
-            actor!.send({ type: 'PROVE_ERROR' });
-            return;
-          }
-
-          const socketEndpointType =
-            passportData.documentType === 'passport' ? 'celo' : 'staging_celo';
-          get()._startSocketIOStatusListener(statusUuid, socketEndpointType);
+          get()._startSocketIOStatusListener(statusUuid, endpointType);
         } else if (result.error) {
           console.error('Received error from TEE:', result.error);
           actor!.send({ type: 'PROVE_ERROR' });
@@ -461,6 +451,8 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         userConfirmed: false,
         passportData: null,
         secret: null,
+        circuitType,
+        endpointType: null,
       });
 
       actor = createActor(provingMachine);
@@ -683,6 +675,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         serverPublicKey: null,
         sharedKey: null,
         uuid: null,
+        endpointType: null,
       });
     },
 
@@ -734,6 +727,9 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         JSON.stringify(payload),
         forgeKey,
       );
+
+      // Persist endpointType for later Socket.IO connection
+      set({ endpointType: endpointType as EndpointType });
       return {
         jsonrpc: '2.0',
         method: 'openpassport_submit_request',


### PR DESCRIPTION
adds a new endpointType field to the proving store, persists its value when generating the TEE payload, and clears it whenever connections are reset.
_handleWebSocketMessage now uses this stored endpointType to start the Socket-IO status listener; if it’s missing, the flow aborts with PROVE_ERROR.

**issue fixed**: after multiple disclosure proofs in a row, the second run could hang because the listener subscribed with an undefined or wrong endpoint, leaving the app stuck at “status 2”.

**tldr**: prevent a weird race issue if your're using mock passports on the production infra.