### PR TITLE
SEL-296: update react-native-keychain, to fix account recovery

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1714,8 +1714,27 @@ PODS:
   - RNGoogleSignin (13.2.0):
     - GoogleSignIn (~> 7.1)
     - React-Core
-  - RNKeychain (8.2.0):
+  - RNKeychain (10.0.0):
+    - DoubleConversion
+    - glog
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNLocalize (3.4.1):
     - React-Core
   - RNReactNativeHapticFeedback (2.3.3):
@@ -2206,7 +2225,7 @@ SPEC CHECKSUMS:
   RNFBMessaging: 92325b0d5619ac90ef023a23cfd16fd3b91d0a88
   RNGestureHandler: 9c3877d98d4584891b69d16ebca855ac46507f4d
   RNGoogleSignin: b8760528f2a7cbe157ecfdcc13bdb7d2745c9389
-  RNKeychain: bbe2f6d5cc008920324acb49ef86ccc03d3b38e4
+  RNKeychain: 4990d9be2916c60f9ed4f8c484fcd7ced4828b86
   RNLocalize: 15463c4d79c7da45230064b4adcf5e9bb984667e
   RNReactNativeHapticFeedback: e19b9b2e2ecf5593de8c4ef1496e1e31ae227514
   RNScreens: b7e8d29c6be98f478bc3fb4a97cc770aa9ba7509

--- a/app/package.json
+++ b/app/package.json
@@ -88,7 +88,7 @@
     "react-native-gesture-handler": "^2.22.1",
     "react-native-get-random-values": "^1.11.0",
     "react-native-haptic-feedback": "^2.3.3",
-    "react-native-keychain": "^8.2.0",
+    "react-native-keychain": "^10.0.0",
     "react-native-localize": "^3.4.1",
     "react-native-nfc-manager": "^3.15.1",
     "react-native-passport-reader": "^1.0.3",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -12164,7 +12164,7 @@ __metadata:
     react-native-gesture-handler: "npm:^2.22.1"
     react-native-get-random-values: "npm:^1.11.0"
     react-native-haptic-feedback: "npm:^2.3.3"
-    react-native-keychain: "npm:^8.2.0"
+    react-native-keychain: "npm:^10.0.0"
     react-native-localize: "npm:^3.4.1"
     react-native-nfc-manager: "npm:^3.15.1"
     react-native-passport-reader: "npm:^1.0.3"
@@ -12830,10 +12830,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-keychain@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "react-native-keychain@npm:8.2.0"
-  checksum: 10c0/7c32335f673c60bd64576bd21b087cdf601087f1588296367546b5fca15aa83be86723d5414ea90667ebc251237918853f65147de7f8df0707b228e6a13ab829
+"react-native-keychain@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "react-native-keychain@npm:10.0.0"
+  checksum: 10c0/a632ad27e58264506d2b373d329a867f042fb014e8a78db3a63031e953d61b5c98066eed1be238ee6c186d3f213d0efaa2a26526fb3a1d36a624c4460e982230
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
According to this [issue thread](https://github.com/oblador/react-native-keychain/issues/458), this error is tied to samsung android phones and occurs after samsung pushes a security update to their phones.

Ways to fix this issue:
- update `react-native-keychain`
- optionally their may be or a patch from google that a user can run on their phone
- last option: recreate app master keys