### PR TITLE
fix spelling issues 

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -19,7 +19,7 @@
 | Android SDK                 | Latest        | See instructions for Android below                                                    |
 | Android NDK                 | 26.1.10909125 | See instructions for Android below                                                    |
 
-\* To facilitate the installation of the SDK and the NDK, and to pair with development devices with a conventient QR code, you can use Android Studio.
+\* To facilitate the installation of the SDK and the NDK, and to pair with development devices with a convenient QR code, you can use Android Studio.
 
 ### iOS
 

--- a/app/android/android-passport-reader/README.md
+++ b/app/android/android-passport-reader/README.md
@@ -2,7 +2,7 @@
 
 Sample project to read Passports using MRZ or manual entry. Currently I am using ML KIT for the OCR.
 
-I don't read the the whole MRZ as ML KIT for now it's unable to read it (it's struggling with "<<<"), but I use it to read the second line and after that use a regular expression to match the rigth format.
+I don't read the the whole MRZ as ML KIT for now it's unable to read it (it's struggling with "<<<"), but I use it to read the second line and after that use a regular expression to match the right format.
 
 You can use the example images stored under `examples` to test the application or download any sample passport document from https://www.consilium.europa.eu/prado/EN/prado-start-page.html
 


### PR DESCRIPTION
Hey team! Fixed errors in `app/README.md` and `app/android/android-passport-reader/README.md`

`conventient` - `convenient`
`rigth` - `right`