### PR TITLE
SEL-424 fix: forbidden countries

### DIFF
--- a/contracts/contracts/libraries/Formatter.sol
+++ b/contracts/contracts/libraries/Formatter.sol
@@ -165,33 +165,41 @@ library Formatter {
         }
 
         for (uint256 j = 0; j < MAX_FORBIDDEN_COUNTRIES_LIST_LENGTH; j++) {
-            uint256 byteIndex = j * 3;
+            uint256 byteIndex = (j * 3) % 93;
+            uint256 index = j / 31;
 
-            if (byteIndex + 2 < 32) {
+            if (byteIndex + 2 < 31) {
                 uint256 shift = byteIndex * 8;
                 uint256 mask = 0xFFFFFF;
-                uint256 packedData = (publicSignals[0] >> shift) & mask;
-                forbiddenCountries[j] = string(abi.encodePacked(uint24(packedData)));
-            } else if (byteIndex < 32) {
-                uint256 bytesFrom0 = 32 - byteIndex;
-                uint256 bytesTo1 = 3 - bytesFrom0;
-
-                uint256 shift0 = byteIndex * 8;
-                uint256 mask0 = (1 << (bytesFrom0 * 8)) - 1;
-                uint256 part0 = (publicSignals[0] >> shift0) & mask0;
-
-                uint256 shift1 = 0;
-                uint256 mask1 = (1 << (bytesTo1 * 8)) - 1;
-                uint256 part1 = (publicSignals[1] >> shift1) & mask1;
-
-                uint256 combined = (part1 << (bytesFrom0 * 8)) | part0;
+                uint256 packedData = (publicSignals[index * 3] >> shift) & mask;
+                uint256 reversedPackedData = ((packedData & 0xff) << 16) | ((packedData & 0xff00)) | ((packedData & 0xff0000) >> 16);
+                forbiddenCountries[j] = string(abi.encodePacked(uint24(reversedPackedData)));
+            } else if (byteIndex < 31) {
+                uint256 part0 = (publicSignals[0] >> (byteIndex * 8));
+                uint256 part1 = publicSignals[1] & 0x00ffff;
+                uint256 reversedPart1 = ((part1 & 0xff) << 8) | ((part1 & 0xff00) >> 8);
+                uint256 combined = reversedPart1 | (part0 << 16);
                 forbiddenCountries[j] = string(abi.encodePacked(uint24(combined)));
-            } else {
-                uint256 byteIndexIn1 = byteIndex - 32;
+            } else if (byteIndex + 2 < 62) {
+                uint256 byteIndexIn1 = byteIndex - 31;
                 uint256 shift = byteIndexIn1 * 8;
                 uint256 mask = 0xFFFFFF;
                 uint256 packedData = (publicSignals[1] >> shift) & mask;
-                forbiddenCountries[j] = string(abi.encodePacked(uint24(packedData)));
+                uint256 reversedPackedData = ((packedData & 0xff) << 16) | ((packedData & 0xff00)) | ((packedData & 0xff0000) >> 16);
+                forbiddenCountries[j] = string(abi.encodePacked(uint24(reversedPackedData)));
+            } else if (byteIndex < 62) {
+                uint256 part0 = (publicSignals[1] >> ((byteIndex - 31) * 8)) & 0x00ffff;
+                uint256 reversedPart0 = ((part0 & 0xff) << 8) | ((part0 & 0xff00) >> 8);
+                uint256 part1 = publicSignals[2] & 0x0000ff;
+                uint256 combined = part1 | (reversedPart0 << 8);
+                forbiddenCountries[j] = string(abi.encodePacked(uint24(combined)));
+            } else if (byteIndex < 93) {
+                uint256 byteIndexIn1 = byteIndex - 62;
+                uint256 shift = byteIndexIn1 * 8;
+                uint256 mask = 0xFFFFFF;
+                uint256 packedData = (publicSignals[2] >> shift) & mask;
+                uint256 reversedPackedData = ((packedData & 0xff) << 16) | ((packedData & 0xff00)) | ((packedData & 0xff0000) >> 16);
+                forbiddenCountries[j] = string(abi.encodePacked(uint24(reversedPackedData)));
             }
         }
 

--- a/contracts/test/unit/formatter.test.ts
+++ b/contracts/test/unit/formatter.test.ts
@@ -150,13 +150,19 @@ describe("Formatter", function () {
 
   describe("extractForbiddenCountriesFromPacked", function () {
     it("should match contract and ts implementation", async function () {
-      const input = "0x414141424242434343";
-      const contractResult = await testFormatter.testExtractForbiddenCountriesFromPacked([input, 0n, 0n, 0n]);
-      const tsResult = Formatter.extractForbiddenCountriesFromPacked(BigInt(input));
-      expect(contractResult).to.deep.equal(tsResult);
-      expect(contractResult[0]).to.equal("CCC");
-      expect(contractResult[1]).to.equal("BBB");
-      expect(contractResult[2]).to.equal("AAA");
+      const input1 = "0x414754414154414149414f4741444e414d5341415a44424c41414c41474641";
+      const input2 = "0x4542524c42425242444742524842534842455a415355415742414d52414752";
+      const input3 = "0x4e41434d484b5650434e52424c4f424e5442554d424e45425a4c42554d424c";
+      const input4 = "0x4853454d4559424d5a45575a5455564b4e445453454e4843564943";
+      const contractResult = await testFormatter.testExtractForbiddenCountriesFromPacked([input1, input2, input3, input4]);
+      const tsResult: string[] = Formatter.extractForbiddenCountriesFromPacked([input1, input2, input3, input4], "id");
+      let formattedTsResult = tsResult.map((item: string, index: number) => {
+        if (index % 3 === 0) {
+          return item + tsResult[index + 1] + tsResult[index + 2];
+        }
+        return undefined;
+      }).filter(Boolean);
+      expect(contractResult).to.deep.equal(formattedTsResult);
     });
 
     it("should revert when field element is out of range", async function () {

--- a/contracts/test/utils/formatter.ts
+++ b/contracts/test/utils/formatter.ts
@@ -88,19 +88,26 @@ export class Formatter {
     );
   }
 
-  static extractForbiddenCountriesFromPacked(publicSignal: bigint): string[] {
-    const forbiddenCountries: string[] = new Array(Formatter.MAX_FORBIDDEN_COUNTRIES_LIST_LENGTH);
-    for (let j = 0; j < Formatter.MAX_FORBIDDEN_COUNTRIES_LIST_LENGTH; j++) {
-      const byteIndex = BigInt(j * 3);
-      const shift = byteIndex * 8n;
-      const mask = 0xffffffn;
-      const packedData = (publicSignal >> shift) & mask;
-      const char1 = String.fromCharCode(Number((packedData >> 16n) & 0xffn));
-      const char2 = String.fromCharCode(Number((packedData >> 8n) & 0xffn));
-      const char3 = String.fromCharCode(Number(packedData & 0xffn));
-      forbiddenCountries[j] = char1 + char2 + char3;
-    }
-    return forbiddenCountries;
+  static extractForbiddenCountriesFromPacked(revealedData_packed: string | string[],
+    id_type: 'passport' | 'id'
+  ): string[] {
+    // If revealedData_packed is not an array, convert it to an array
+    const packedArray = Array.isArray(revealedData_packed)
+      ? revealedData_packed
+      : [revealedData_packed];
+
+    const bytesCount = id_type === 'passport' ? [31, 31, 31] : [31, 31, 31, 27]; // nb of bytes in each of the first three field elements
+    const bytesArray = packedArray.flatMap((element: string, index: number) => {
+      const bytes = bytesCount[index] || 31; // Use 31 as default if index is out of range
+      const elementBigInt = BigInt(element);
+      const byteMask = BigInt(255); // 0xFF
+      const bytesOfElement = [...Array(bytes)].map((_, byteIndex) => {
+        return (elementBigInt >> (BigInt(byteIndex) * BigInt(8))) & byteMask;
+      });
+      return bytesOfElement;
+    });
+
+    return bytesArray.map((byte: bigint) => String.fromCharCode(Number(byte)));
   }
 
   static proofDateToUnixTimestamp(dateNum: number[]): number {


### PR DESCRIPTION
- handles forbidden countries in the 3rd and 4th index of public signals
- fixes reverse ordering of countries