### PR TITLE
fix: vc_and_disclose_id test

### DIFF
--- a/circuits/circuits/utils/passport/disclose/disclose_id.circom
+++ b/circuits/circuits/utils/passport/disclose/disclose_id.circom
@@ -42,9 +42,9 @@ template DISCLOSE_ID(
     signal input ofac_nameyob_smt_leaf_key;
     signal input ofac_nameyob_smt_root;
     signal input ofac_nameyob_smt_siblings[nameyobTreeLevels];
-    
+
     signal input selector_ofac;
-    
+
     // assert selectors are 0 or 1
     for (var i = 0; i < 90; i++) {
         selector_dg1[i] * (selector_dg1[i] - 1) === 0;
@@ -64,11 +64,11 @@ template DISCLOSE_ID(
     older_than_verified[0] <== isOlderThan.out * majority[0];
     older_than_verified[1] <== isOlderThan.out * majority[1];
 
-    signal revealedData[94]; // mrz: 88 bytes | older_than: 2 bytes | ofac: 3 byte
+    signal revealedData[94]; // mrz: 90 bytes | older_than: 2 bytes | ofac: 2 byte
     for (var i = 0; i < 90; i++) {
         revealedData[i] <== dg1[5+i] * selector_dg1[i];
     }
-    
+
     revealedData[90] <== older_than_verified[0] * selector_older_than;
     revealedData[91] <== older_than_verified[1] * selector_older_than;
 

--- a/circuits/tests/disclose/vc_and_disclose_id.test.ts
+++ b/circuits/tests/disclose/vc_and_disclose_id.test.ts
@@ -13,7 +13,6 @@ import crypto from 'crypto';
 import { SMT } from '@openpassport/zk-kit-smt';
 import nameAndDobjson from '@selfxyz/common/ofacdata/outputs/nameAndDobSMT_ID.json' with { type: 'json' };
 import nameAndYobjson from '@selfxyz/common/ofacdata/outputs/nameAndYobSMT_ID.json' with { type: 'json' };
-import passportNojson from '@selfxyz/common/ofacdata/outputs/passportNoAndNationalitySMT.json' with { type: 'json' };
 import {
   formatAndUnpackForbiddenCountriesList,
   formatAndUnpackReveal,
@@ -53,8 +52,6 @@ describe('Disclose', function () {
   const tree: any = new LeanIMT((a, b) => poseidon2([a, b]), []);
   tree.insert(BigInt(commitment));
 
-  const passportNo_smt = new SMT(poseidon2, true);
-  passportNo_smt.import(passportNojson);
 
   const nameAndDob_smt = new SMT(poseidon2, true);
   nameAndDob_smt.import(nameAndDobjson);
@@ -85,7 +82,7 @@ describe('Disclose', function () {
       selector_older_than,
       tree,
       majority,
-      passportNo_smt,
+      null,
       nameAndDob_smt,
       nameAndYob_smt,
       selector_ofac,
@@ -141,7 +138,7 @@ describe('Disclose', function () {
         const revealedData_packed = await circuit.getOutput(w, ['revealedData_packed[4]']);
         const reveal_unpacked = formatAndUnpackReveal(revealedData_packed, 'id');
 
-        for (let i = 0; i < 88; i++) {
+        for (let i = 0; i < 90; i++) {
           if (selector_dg1[i] == '1') {
             const char = String.fromCharCode(Number(inputs.dg1[i + 5]));
             assert(reveal_unpacked[i] == char, 'Should reveal the right character');
@@ -187,8 +184,8 @@ describe('Disclose', function () {
     const revealedData_packed = await circuit.getOutput(w, ['revealedData_packed[4]']);
 
     const reveal_unpacked = formatAndUnpackReveal(revealedData_packed, 'id');
-    expect(reveal_unpacked[88]).to.equal('\x00');
-    expect(reveal_unpacked[89]).to.equal('\x00');
+    expect(reveal_unpacked[90]).to.equal('\x00');
+    expect(reveal_unpacked[91]).to.equal('\x00');
   });
 
   describe('OFAC disclosure', function () {
@@ -269,7 +266,7 @@ describe('Disclose', function () {
           selector_older_than,
           tree,
           majority,
-          passportNo_smt,
+          null,
           nameAndDob_smt,
           nameAndYob_smt,
           '1', // selector_ofac

--- a/circuits/tests/disclose/vc_and_disclose_id.test.ts
+++ b/circuits/tests/disclose/vc_and_disclose_id.test.ts
@@ -52,7 +52,6 @@ describe('Disclose', function () {
   const tree: any = new LeanIMT((a, b) => poseidon2([a, b]), []);
   tree.insert(BigInt(commitment));
 
-
   const nameAndDob_smt = new SMT(poseidon2, true);
   nameAndDob_smt.import(nameAndDobjson);
 


### PR DESCRIPTION
- Comment on line 67 now correctly reads
   // mrz: 90 bytes | older_than: 2 bytes | ofac: 2 bytes.
- MRZ comparison loop now iterates over 90 bytes.
- checks moved from indices 88-89 ➜ 90-91.
- Removed unused passportNoAndNationalitySMT.json import; 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated comments to accurately describe data sizes and indexing in the passport disclosure logic.
- **Style**
  - Improved whitespace formatting for better readability.
- **Tests**
  - Adjusted test coverage to align with updated data sizes, ensuring accurate validation of selective disclosure and OFAC-related features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->