### PR TITLE
Update README: replace outdated /registry link with Self Protocol docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Not all signature algorithms are currently supported. To help us add support for
 
 #### Where can I find the countries' public keys ?
 
-You can download the full list of public keys on the [ICAO website](https://download.pkd.icao.int/). Our parsed list is at [`/registry`](https://github.com/zk-passport/openpassport/tree/main/registry).
+You can download the full list of public keys on the [ICAO website](https://download.pkd.icao.int/). Our parsed list is now available in the [Self Protocol documentation](https://docs.self.xyz/).
 
 #### What's the ICAO ?
 


### PR DESCRIPTION
Replaced the outdated link to /registry (previously at zk-passport/openpassport) with the current Self Protocol documentation link (https://docs.self.xyz/) for accessing the parsed list of public keys. This ensures users have access to up-to-date resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reference the Self Protocol documentation website for the list of countries' public keys instead of the GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->