### PR TITLE
SEL-473: Add lint rule for BUSL headers

### DIFF
--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:jest/recommended',
   ],
-  plugins: ['simple-import-sort', 'prettier', 'jest', 'header'],
+  plugins: ['header', 'jest', 'prettier', 'simple-import-sort'],
   ignorePatterns: ['ios/', 'android/', 'deployments/', 'node_modules/'],
   rules: {
     // Import sorting rules

--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -5,12 +5,17 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:jest/recommended',
   ],
-  plugins: ['simple-import-sort', 'prettier', 'jest'],
+  plugins: ['simple-import-sort', 'prettier', 'jest', 'header'],
   ignorePatterns: ['ios/', 'android/', 'deployments/', 'node_modules/'],
   rules: {
     // Import sorting rules
     'simple-import-sort/imports': 'warn',
     'simple-import-sort/exports': 'warn',
+    'header/header': [
+      2,
+      'line',
+      ' SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11',
+    ],
 
     // Add prettier rule to show prettier errors as ESLint errors
     'prettier/prettier': [

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1811,9 +1811,9 @@ PODS:
   - segment-analytics-react-native (2.21.1):
     - React-Core
     - sovran-react-native
-  - Sentry (8.52.1):
-    - Sentry/Core (= 8.52.1)
-  - Sentry/Core (8.52.1)
+  - Sentry (8.53.1):
+    - Sentry/Core (= 8.53.1)
+  - Sentry/Core (8.53.1)
   - Sentry/HybridSDK (8.48.0)
   - SentryPrivate (8.21.0)
   - SocketRocket (0.7.0)

--- a/app/package.json
+++ b/app/package.json
@@ -139,6 +139,7 @@
     "@types/react-test-renderer": "^18",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^10.1.2",
+    "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-jest": "^28.11.1",
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/sdk/core/src/SelfBackendVerifier.ts
+++ b/sdk/core/src/SelfBackendVerifier.ts
@@ -148,7 +148,7 @@ export class SelfBackendVerifier {
     if (!configId) {
       issues.push({
         type: ConfigMismatch.ConfigNotFound,
-        message: "Config Id not found",
+        message: 'Config Id not found',
       });
     }
 

--- a/sdk/core/src/utils/id.ts
+++ b/sdk/core/src/utils/id.ts
@@ -59,11 +59,10 @@ export const formatRevealedDataPacked = (
     )
     .toString('utf-8');
   const olderThan = Buffer.from(
-    revealedDataPackedString
-      .subarray(
-        revealedDataIndices[attestationId].olderThanStart,
-        revealedDataIndices[attestationId].olderThanEnd + 1
-      )
+    revealedDataPackedString.subarray(
+      revealedDataIndices[attestationId].olderThanStart,
+      revealedDataIndices[attestationId].olderThanEnd + 1
+    )
   ).toString('utf-8');
   const ofac = Array.from(
     revealedDataPackedString.subarray(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4505,6 +4505,7 @@ __metadata:
     elliptic: "npm:^6.6.1"
     eslint: "npm:^8.19.0"
     eslint-config-prettier: "npm:^10.1.2"
+    eslint-plugin-header: "npm:^3.1.1"
     eslint-plugin-jest: "npm:^28.11.1"
     eslint-plugin-prettier: "npm:^5.2.6"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
@@ -12893,6 +12894,15 @@ __metadata:
     "@babel/eslint-parser": ^7.12.0
     eslint: ^8.1.0
   checksum: 10c0/171f6862f7be3c66a415c2ebf14a6e29ade78b661a16f344b78fbefeaeed97fc7f2c710c0d3a2c2df2bbb614b282eaef830993c2aac83b13324cd8c2f9497ea6
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-header@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "eslint-plugin-header@npm:3.1.1"
+  peerDependencies:
+    eslint: ">=7.7.0"
+  checksum: 10c0/2eb70acd8efe2b72a7bff3e3958a637871c6d0ed4166effea8b68e79b9ba291b6a33182e7f0e31ca7de717fc5b2cf2e42dcc0a07db1a37ae6941bbb6a8eda731
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- enforce BUSL license banner with `eslint-plugin-header`
- install the plugin in the mobile app package

## Testing
- `yarn workspace @selfxyz/mobile-app lint`
- `yarn workspace @selfxyz/mobile-app test`

------
https://chatgpt.com/codex/tasks/task_b_6860d36b57dc832d801353774474d64f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to include a plugin for enforcing license headers in source files.
  * Enhanced code quality checks by requiring standardized license headers in all files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->