### PR TITLE
Abstract iOS cloud backup logic

### DIFF
--- a/app/src/utils/cloudBackup/helpers.ts
+++ b/app/src/utils/cloudBackup/helpers.ts
@@ -63,13 +63,14 @@ export async function withRetries<T>(
     try {
       return await promiseBuilder();
     } catch (e) {
-      retries++;
       latestError = e as Error;
-      if (retries < i - 1) {
+      if (i < retries - 1) {
         console.info('retry #', i);
         await new Promise(resolve => setTimeout(resolve, 200 * i));
       }
     }
   }
-  throw new Error(`retry count exhausted (${retries}), original error ${latestError!}`);
+  throw new Error(
+    `retry count exhausted (${retries}), original error ${latestError!}`,
+  );
 }

--- a/app/src/utils/cloudBackup/helpers.ts
+++ b/app/src/utils/cloudBackup/helpers.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+import { ethers } from 'ethers';
+import { Platform } from 'react-native';
+import { CloudStorage, CloudStorageScope } from 'react-native-cloud-storage';
+
+import { name } from '../../../package.json';
+import { Mnemonic } from '../../types/mnemonic';
+
+export const FOLDER = `/${name}`;
+export const ENCRYPTED_FILE_PATH = `/${FOLDER}/encrypted-private-key`;
+export const FILE_NAME = 'encrypted-private-key';
+
+if (Platform.OS === 'ios') {
+  CloudStorage.setProviderOptions({ scope: CloudStorageScope.AppData });
+}
+
+export function isMnemonic(obj: unknown): obj is Mnemonic {
+  if (!obj || typeof obj !== 'object') {
+    return false;
+  }
+
+  const candidate = obj as Record<string, unknown>;
+
+  return !!(
+    typeof candidate.phrase === 'string' &&
+    typeof candidate.password === 'string' &&
+    typeof candidate.entropy === 'string' &&
+    candidate.wordlist &&
+    typeof candidate.wordlist === 'object' &&
+    typeof (candidate.wordlist as Record<string, unknown>).locale === 'string'
+  );
+}
+
+export function parseMnemonic(mnemonicString: string): Mnemonic {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(mnemonicString);
+  } catch (e) {
+    throw new Error('Invalid JSON format in mnemonic backup');
+  }
+
+  if (!isMnemonic(parsed)) {
+    throw new Error(
+      'Invalid mnemonic structure: missing required properties (phrase, password, wordlist, entropy)',
+    );
+  }
+
+  if (!parsed.phrase || !ethers.Mnemonic.isValidMnemonic(parsed.phrase)) {
+    throw new Error('Invalid mnemonic phrase: not a valid BIP39 mnemonic');
+  }
+
+  return parsed;
+}
+
+export async function withRetries<T>(
+  promiseBuilder: () => Promise<T>,
+  retries = 10,
+): Promise<T> {
+  let latestError: Error;
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await promiseBuilder();
+    } catch (e) {
+      retries++;
+      latestError = e as Error;
+      if (retries < i - 1) {
+        console.info('retry #', i);
+        await new Promise(resolve => setTimeout(resolve, 200 * i));
+      }
+    }
+  }
+  throw new Error(`retry count exhausted (${retries}), original error ${latestError!}`);
+}

--- a/app/src/utils/cloudBackup/index.ts
+++ b/app/src/utils/cloudBackup/index.ts
@@ -4,98 +4,15 @@ import {
   APP_DATA_FOLDER_ID,
   MIME_TYPES,
 } from '@robinbobin/react-native-google-drive-api-wrapper';
-import { ethers } from 'ethers';
 import { useMemo } from 'react';
 import { Platform } from 'react-native';
-import { CloudStorage, CloudStorageScope } from 'react-native-cloud-storage';
 
-import { name } from '../../../package.json';
 import { Mnemonic } from '../../types/mnemonic';
 import { createGDrive } from './google';
-
-const FOLDER = `/${name}`;
-const ENCRYPTED_FILE_PATH = `/${FOLDER}/encrypted-private-key`;
-if (Platform.OS === 'ios') {
-  CloudStorage.setProviderOptions({ scope: CloudStorageScope.AppData });
-}
-
-const FILE_NAME = 'encrypted-private-key';
+import * as ios from './ios';
+import { FILE_NAME, parseMnemonic, withRetries } from './helpers';
 
 export const STORAGE_NAME = Platform.OS === 'ios' ? 'iCloud' : 'Google Drive';
-
-/**
- * Type guard function to validate that an object conforms to the Mnemonic interface
- */
-function isMnemonic(obj: unknown): obj is Mnemonic {
-  if (!obj || typeof obj !== 'object') {
-    return false;
-  }
-
-  const candidate = obj as Record<string, unknown>;
-
-  return !!(
-    typeof candidate.phrase === 'string' &&
-    typeof candidate.password === 'string' &&
-    typeof candidate.entropy === 'string' &&
-    candidate.wordlist &&
-    typeof candidate.wordlist === 'object' &&
-    typeof (candidate.wordlist as Record<string, unknown>).locale === 'string'
-  );
-}
-
-/**
- * Safely parses and validates a mnemonic string
- */
-function parseMnemonic(mnemonicString: string): Mnemonic {
-  let parsed: unknown;
-
-  try {
-    parsed = JSON.parse(mnemonicString);
-  } catch (e) {
-    throw new Error('Invalid JSON format in mnemonic backup');
-  }
-
-  if (!isMnemonic(parsed)) {
-    throw new Error(
-      'Invalid mnemonic structure: missing required properties (phrase, password, wordlist, entropy)',
-    );
-  }
-
-  if (!parsed.phrase || !ethers.Mnemonic.isValidMnemonic(parsed.phrase)) {
-    throw new Error('Invalid mnemonic phrase: not a valid BIP39 mnemonic');
-  }
-
-  return parsed;
-}
-
-/**
- * For some reason google drive api can be very ... brittle and abort randomly (network conditions)
- * so retry a couple times for good measure.
- *
- * Filter the error message by checking if `abort` is included didnt help as the error can be `path not found`
- * maybe some race conditions on the drive side
- */
-async function withRetries<T>(
-  promiseBuilder: () => Promise<T>,
-  retries = 10,
-): Promise<T> {
-  let latestError: Error;
-  for (let i = 0; i < retries; i++) {
-    try {
-      return await promiseBuilder();
-    } catch (e) {
-      retries++;
-      latestError = e as Error;
-      if (retries < i - 1) {
-        console.info('retry #', i);
-        await new Promise(resolve => setTimeout(resolve, 200 * i));
-      }
-    }
-  }
-  throw new Error(
-    `retry count exhausted (${retries}), original error ${latestError!}`,
-  );
-}
 
 export function useBackupMnemonic() {
   return useMemo(
@@ -115,17 +32,7 @@ export async function upload(mnemonic: Mnemonic) {
     );
   }
   if (Platform.OS === 'ios') {
-    try {
-      await CloudStorage.mkdir(FOLDER);
-    } catch (e) {
-      console.error(e);
-      if (!(e as Error).message.includes('already')) {
-        throw e;
-      }
-    }
-    await withRetries(() =>
-      CloudStorage.writeFile(ENCRYPTED_FILE_PATH, JSON.stringify(mnemonic)),
-    );
+    await ios.upload(mnemonic);
   } else {
     const gdrive = await createGDrive();
     if (!gdrive) {
@@ -144,23 +51,7 @@ export async function upload(mnemonic: Mnemonic) {
 
 export async function download() {
   if (Platform.OS === 'ios') {
-    if (await CloudStorage.exists(ENCRYPTED_FILE_PATH)) {
-      const mnemonicString = await withRetries(() =>
-        CloudStorage.readFile(ENCRYPTED_FILE_PATH),
-      );
-
-      try {
-        const mnemonic = parseMnemonic(mnemonicString);
-        return mnemonic;
-      } catch (e) {
-        throw new Error(
-          `Failed to parse mnemonic backup: ${(e as Error).message}`,
-        );
-      }
-    }
-    throw new Error(
-      'Couldnt find the encrypted backup, did you back it up previously?',
-    );
+    return ios.download();
   }
 
   const gdrive = await createGDrive();
@@ -189,7 +80,7 @@ export async function download() {
 
 export async function disableBackup() {
   if (Platform.OS === 'ios') {
-    await withRetries(() => CloudStorage.rmdir(FOLDER, { recursive: true }));
+    await ios.disableBackup();
     return;
   }
   const gdrive = await createGDrive();

--- a/app/src/utils/cloudBackup/index.ts
+++ b/app/src/utils/cloudBackup/index.ts
@@ -9,8 +9,8 @@ import { Platform } from 'react-native';
 
 import { Mnemonic } from '../../types/mnemonic';
 import { createGDrive } from './google';
-import * as ios from './ios';
 import { FILE_NAME, parseMnemonic, withRetries } from './helpers';
+import * as ios from './ios';
 
 export const STORAGE_NAME = Platform.OS === 'ios' ? 'iCloud' : 'Google Drive';
 
@@ -62,14 +62,18 @@ export async function download() {
     spaces: APP_DATA_FOLDER_ID,
     q: `name = '${FILE_NAME}'`,
   });
-  if (!files.length || !files[0].id) {
+  if (!files.length) {
     throw new Error(
       'Couldnt find the encrypted backup, did you back it up previously?',
     );
   }
-  const mnemonicString = await withRetries(() =>
-    gdrive.files.getText(files[0].id as string),
-  );
+  const fileId = (files[0] as any).id as string;
+  if (!fileId) {
+    throw new Error(
+      'Couldnt find the encrypted backup, did you back it up previously?',
+    );
+  }
+  const mnemonicString = await withRetries(() => gdrive.files.getText(fileId));
   try {
     const mnemonic = parseMnemonic(mnemonicString);
     return mnemonic;
@@ -93,6 +97,9 @@ export async function disableBackup() {
     q: `name = '${FILE_NAME}'`,
   });
   await Promise.all(
-    files.filter(f => f.id).map(f => gdrive.files.delete(f.id as string)),
+    files.map((f: any) => {
+      const id = f.id as string;
+      return id ? gdrive.files.delete(id) : Promise.resolve();
+    }),
   );
 }

--- a/app/src/utils/cloudBackup/ios.ts
+++ b/app/src/utils/cloudBackup/ios.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+import { CloudStorage } from 'react-native-cloud-storage';
+
+import { ENCRYPTED_FILE_PATH, FOLDER, parseMnemonic, withRetries } from './helpers';
+import { Mnemonic } from '../../types/mnemonic';
+
+export async function upload(mnemonic: Mnemonic) {
+  try {
+    await CloudStorage.mkdir(FOLDER);
+  } catch (e) {
+    console.error(e);
+    if (!(e as Error).message.includes('already')) {
+      throw e;
+    }
+  }
+  await withRetries(() =>
+    CloudStorage.writeFile(ENCRYPTED_FILE_PATH, JSON.stringify(mnemonic)),
+  );
+}
+
+export async function download() {
+  if (await CloudStorage.exists(ENCRYPTED_FILE_PATH)) {
+    const mnemonicString = await withRetries(() =>
+      CloudStorage.readFile(ENCRYPTED_FILE_PATH),
+    );
+    try {
+      return parseMnemonic(mnemonicString);
+    } catch (e) {
+      throw new Error(
+        `Failed to parse mnemonic backup: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  throw new Error(
+    'Couldnt find the encrypted backup, did you back it up previously?',
+  );
+}
+
+export async function disableBackup() {
+  await withRetries(() => CloudStorage.rmdir(FOLDER, { recursive: true }));
+}

--- a/app/src/utils/cloudBackup/ios.ts
+++ b/app/src/utils/cloudBackup/ios.ts
@@ -2,8 +2,13 @@
 
 import { CloudStorage } from 'react-native-cloud-storage';
 
-import { ENCRYPTED_FILE_PATH, FOLDER, parseMnemonic, withRetries } from './helpers';
 import { Mnemonic } from '../../types/mnemonic';
+import {
+  ENCRYPTED_FILE_PATH,
+  FOLDER,
+  parseMnemonic,
+  withRetries,
+} from './helpers';
 
 export async function upload(mnemonic: Mnemonic) {
   try {

--- a/app/tests/utils/cloudBackup.test.ts
+++ b/app/tests/utils/cloudBackup.test.ts
@@ -399,4 +399,51 @@ describe('cloudBackup', () => {
       );
     });
   });
+
+  describe('disableBackup function - iOS', () => {
+    beforeEach(() => {
+      Platform.OS = 'ios';
+    });
+
+    it('should remove backup folder from iCloud', async () => {
+      (CloudStorage.rmdir as jest.Mock).mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.disableBackup()).resolves.toBeUndefined();
+      expect(CloudStorage.rmdir).toHaveBeenCalledWith('/@selfxyz/mobile-app', { recursive: true });
+    });
+  });
+
+  describe('disableBackup function - Android', () => {
+    beforeEach(() => {
+      Platform.OS = 'android';
+    });
+
+    it('should delete backup files from Google Drive', async () => {
+      (createGDrive as jest.Mock).mockResolvedValue(mockGDriveInstance);
+      mockGDriveInstance.files.list.mockResolvedValue({
+        files: [{ id: 'file-id' }, { id: 'file-id2' }],
+      });
+      mockGDriveInstance.files.delete.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.disableBackup()).resolves.toBeUndefined();
+      expect(mockGDriveInstance.files.list).toHaveBeenCalledWith({
+        spaces: 'mock-app-data-folder',
+        q: "name = 'encrypted-private-key'",
+      });
+      expect(mockGDriveInstance.files.delete).toHaveBeenNthCalledWith(1, 'file-id');
+      expect(mockGDriveInstance.files.delete).toHaveBeenNthCalledWith(2, 'file-id2');
+    });
+
+    it('should resolve when user cancels Google sign-in', async () => {
+      (createGDrive as jest.Mock).mockResolvedValue(null);
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.disableBackup()).resolves.toBeUndefined();
+    });
+  });
 });

--- a/app/tests/utils/cloudBackup.test.ts
+++ b/app/tests/utils/cloudBackup.test.ts
@@ -411,7 +411,9 @@ describe('cloudBackup', () => {
       const { result } = renderHook(() => useBackupMnemonic());
 
       await expect(result.current.disableBackup()).resolves.toBeUndefined();
-      expect(CloudStorage.rmdir).toHaveBeenCalledWith('/@selfxyz/mobile-app', { recursive: true });
+      expect(CloudStorage.rmdir).toHaveBeenCalledWith('/@selfxyz/mobile-app', {
+        recursive: true,
+      });
     });
   });
 
@@ -434,8 +436,14 @@ describe('cloudBackup', () => {
         spaces: 'mock-app-data-folder',
         q: "name = 'encrypted-private-key'",
       });
-      expect(mockGDriveInstance.files.delete).toHaveBeenNthCalledWith(1, 'file-id');
-      expect(mockGDriveInstance.files.delete).toHaveBeenNthCalledWith(2, 'file-id2');
+      expect(mockGDriveInstance.files.delete).toHaveBeenNthCalledWith(
+        1,
+        'file-id',
+      );
+      expect(mockGDriveInstance.files.delete).toHaveBeenNthCalledWith(
+        2,
+        'file-id2',
+      );
     });
 
     it('should resolve when user cancels Google sign-in', async () => {


### PR DESCRIPTION
## Summary
- move reusable cloudBackup helpers into `helpers.ts`
- split iOS implementation into `ios.ts` and use it from the main index
- extend unit tests to cover iOS/Android parity and disableBackup logic

## Testing
- `yarn workspace @selfxyz/mobile-app test`

------
https://chatgpt.com/codex/tasks/task_b_686161c1a198832da57ddea17f59d484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced iOS-specific cloud backup utilities for uploading, downloading, and disabling encrypted mnemonic backups.
  * Added helper functions for validating and parsing mnemonics, as well as generic retry logic for asynchronous operations.

* **Refactor**
  * Modularized cloud backup code by separating platform-specific logic and shared utilities, resulting in a cleaner and more maintainable structure.

* **Tests**
  * Expanded test coverage for backup disabling functionality on both iOS and Android platforms, ensuring correct behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->