### PR TITLE
SEL-413: Improve ConfirmBelonging copy

### DIFF
--- a/app/src/screens/prove/ConfirmBelongingScreen.tsx
+++ b/app/src/screens/prove/ConfirmBelongingScreen.tsx
@@ -95,7 +95,9 @@ const ConfirmBelongingScreen: React.FC<ConfirmBelongingScreenProps> = ({}) => {
           <Title textAlign="center">Confirm your identity</Title>
           <Description textAlign="center" paddingBottom={20}>
             By continuing, you certify that this passport belongs to you and is
-            not stolen or forged.
+            not stolen or forged. Once registered with Self, this document will
+            be permanently linked to your identity and can't be linked to
+            another one.
           </Description>
           <PrimaryButton
             trackEvent={PassportEvents.OWNERSHIP_CONFIRMED}


### PR DESCRIPTION
## Summary
- clarify that once a passport is registered with Self it cannot be registered by another identity

## Testing
- `yarn workspace @selfxyz/mobile-app test`

------
https://chatgpt.com/codex/tasks/task_b_6861b1665950832db20c1e2c27e5a042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description text on the Confirm Belonging screen to clarify that once a passport is registered, it is permanently linked to the user's identity and cannot be linked to another identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->