### PR TITLE
SEL-425: Add document management analytics events

### DIFF
--- a/app/src/consts/analytics.ts
+++ b/app/src/consts/analytics.ts
@@ -105,3 +105,15 @@ export const MockDataEvents = {
   SELECT_COUNTRY: 'Mock Data: Select Country',
   TOGGLE_OFAC_LIST: 'Mock Data: Toggle OFAC List',
 };
+
+export const DocumentEvents = {
+  MANAGE_SCREEN_OPENED: 'Document: Manage Documents Screen Opened',
+  DOCUMENTS_FETCHED: 'Document: Documents Fetched',
+  NO_DOCUMENTS_FOUND: 'Document: No Documents Found',
+  DOCUMENT_SELECTED: 'Document: Document Selected',
+  DOCUMENT_DELETED: 'Document: Document Deleted',
+  ADD_NEW_SCAN_SELECTED: 'Document: Add New Document via Scan',
+  ADD_NEW_MOCK_SELECTED: 'Document: Add New Document via Mock',
+  PASSPORT_INFO_OPENED: 'Document: Passport Info Screen Opened',
+  PASSPORT_METADATA_LOADED: 'Document: Passport Metadata Loaded',
+};

--- a/app/src/screens/settings/ManageDocumentsScreen.tsx
+++ b/app/src/screens/settings/ManageDocumentsScreen.tsx
@@ -10,10 +10,14 @@ import { Button, ScrollView, Spinner, Text, XStack, YStack } from 'tamagui';
 import { PrimaryButton } from '../../components/buttons/PrimaryButton';
 import { SecondaryButton } from '../../components/buttons/SecondaryButton';
 import ButtonsContainer from '../../components/ButtonsContainer';
+import { DocumentEvents } from '../../consts/analytics';
 import { usePassport } from '../../providers/passportDataProvider';
+import analytics from '../../utils/analytics';
 import { borderColor, textBlack, white } from '../../utils/colors';
 import { extraYPadding } from '../../utils/constants';
 import { impactLight } from '../../utils/haptic';
+
+const { trackEvent } = analytics();
 
 interface ManageDocumentsScreenProps {}
 
@@ -40,6 +44,12 @@ const PassportDataSelector = () => {
     const docs = await getAllDocuments();
     setDocumentCatalog(catalog);
     setAllDocuments(docs);
+    trackEvent(DocumentEvents.DOCUMENTS_FETCHED, {
+      count: catalog.documents.length,
+    });
+    if (catalog.documents.length === 0) {
+      trackEvent(DocumentEvents.NO_DOCUMENTS_FOUND);
+    }
     setLoading(false);
   };
 
@@ -50,11 +60,13 @@ const PassportDataSelector = () => {
     const docs = await getAllDocuments();
     setDocumentCatalog(catalog);
     setAllDocuments(docs);
+    trackEvent(DocumentEvents.DOCUMENT_SELECTED, { document_id: documentId });
   };
 
   const handleDeleteSpecific = async (documentId: string) => {
     setLoading(true);
     await deleteDocument(documentId);
+    trackEvent(DocumentEvents.DOCUMENT_DELETED, { document_id: documentId });
     await loadPassportDataInfo();
   };
 
@@ -240,13 +252,19 @@ const ManageDocumentsScreen: React.FC<ManageDocumentsScreenProps> = ({}) => {
   const navigation = useNavigation();
   const { bottom } = useSafeAreaInsets();
 
+  useEffect(() => {
+    trackEvent(DocumentEvents.MANAGE_SCREEN_OPENED);
+  }, []);
+
   const handleScanDocument = () => {
     impactLight();
+    trackEvent(DocumentEvents.ADD_NEW_SCAN_SELECTED);
     navigation.navigate('PassportOnboarding' as any);
   };
 
   const handleGenerateMock = () => {
     impactLight();
+    trackEvent(DocumentEvents.ADD_NEW_MOCK_SELECTED);
     navigation.navigate('CreateMock' as any);
   };
 

--- a/app/src/screens/settings/ManageDocumentsScreen.tsx
+++ b/app/src/screens/settings/ManageDocumentsScreen.tsx
@@ -60,13 +60,13 @@ const PassportDataSelector = () => {
     const docs = await getAllDocuments();
     setDocumentCatalog(catalog);
     setAllDocuments(docs);
-    trackEvent(DocumentEvents.DOCUMENT_SELECTED, { document_id: documentId });
+    trackEvent(DocumentEvents.DOCUMENT_SELECTED);
   };
 
   const handleDeleteSpecific = async (documentId: string) => {
     setLoading(true);
     await deleteDocument(documentId);
-    trackEvent(DocumentEvents.DOCUMENT_DELETED, { document_id: documentId });
+    trackEvent(DocumentEvents.DOCUMENT_DELETED);
     await loadPassportDataInfo();
   };
 

--- a/app/src/screens/settings/PassportDataInfoScreen.tsx
+++ b/app/src/screens/settings/PassportDataInfoScreen.tsx
@@ -7,9 +7,13 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, Separator, XStack, YStack } from 'tamagui';
 
 import { Caption } from '../../components/typography/Caption';
+import { DocumentEvents } from '../../consts/analytics';
 import { usePassport } from '../../providers/passportDataProvider';
+import analytics from '../../utils/analytics';
 import { black, slate200, white } from '../../utils/colors';
 import { extraYPadding } from '../../utils/constants';
+
+const { trackEvent } = analytics();
 
 // TODO clarify if we need more/less keys to be displayed
 const dataKeysToLabels: Record<
@@ -74,9 +78,11 @@ const PassportDataInfoScreen: React.FC<PassportDataInfoScreenProps> = ({}) => {
     }
 
     setMetadata(result.data.passportMetadata!);
+    trackEvent(DocumentEvents.PASSPORT_METADATA_LOADED);
   }, [metadata, getData]);
 
   useFocusEffect(() => {
+    trackEvent(DocumentEvents.PASSPORT_INFO_OPENED);
     loadData();
   });
 

--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -14,7 +14,6 @@ import { Button, ScrollView, View, XStack, YStack } from 'tamagui';
 import { version } from '../../../package.json';
 import { pressedStyle } from '../../components/buttons/pressedStyle';
 import { BodyText } from '../../components/typography/BodyText';
-import { DocumentEvents } from '../../consts/analytics';
 import {
   appStoreUrl,
   gitHubUrl,
@@ -33,7 +32,6 @@ import Telegram from '../../images/icons/telegram.svg';
 import Web from '../../images/icons/webpage.svg';
 import { RootStackParamList } from '../../navigation';
 import { useSettingStore } from '../../stores/settingStore';
-import analytics from '../../utils/analytics';
 import {
   amber500,
   black,
@@ -43,8 +41,6 @@ import {
 } from '../../utils/colors';
 import { extraYPadding } from '../../utils/constants';
 import { impactLight } from '../../utils/haptic';
-
-const { trackEvent } = analytics();
 
 interface SettingsScreenProps {}
 interface MenuButtonProps extends PropsWithChildren {
@@ -190,7 +186,6 @@ ${deviceInfo.map(([k, v]) => `${k}=${v}`).join('; ')}
             break;
 
           case 'ManageDocuments':
-            trackEvent(DocumentEvents.MANAGE_SCREEN_OPENED);
             navigation.navigate('ManageDocuments' as any);
             break;
 

--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -14,6 +14,7 @@ import { Button, ScrollView, View, XStack, YStack } from 'tamagui';
 import { version } from '../../../package.json';
 import { pressedStyle } from '../../components/buttons/pressedStyle';
 import { BodyText } from '../../components/typography/BodyText';
+import { DocumentEvents } from '../../consts/analytics';
 import {
   appStoreUrl,
   gitHubUrl,
@@ -32,6 +33,7 @@ import Telegram from '../../images/icons/telegram.svg';
 import Web from '../../images/icons/webpage.svg';
 import { RootStackParamList } from '../../navigation';
 import { useSettingStore } from '../../stores/settingStore';
+import analytics from '../../utils/analytics';
 import {
   amber500,
   black,
@@ -41,6 +43,8 @@ import {
 } from '../../utils/colors';
 import { extraYPadding } from '../../utils/constants';
 import { impactLight } from '../../utils/haptic';
+
+const { trackEvent } = analytics();
 
 interface SettingsScreenProps {}
 interface MenuButtonProps extends PropsWithChildren {
@@ -186,6 +190,7 @@ ${deviceInfo.map(([k, v]) => `${k}=${v}`).join('; ')}
             break;
 
           case 'ManageDocuments':
+            trackEvent(DocumentEvents.MANAGE_SCREEN_OPENED);
             navigation.navigate('ManageDocuments' as any);
             break;
 


### PR DESCRIPTION
## Summary
- extend analytics constants with `DocumentEvents`
- track document-related events in **ManageDocumentsScreen**
- log when viewing passport data info
- log navigation to Manage Documents from Settings

## Testing
- `yarn lint`
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_6861b1032ecc832daf1e2a3827efda1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for key actions in document management screens, including opening screens, fetching documents, selecting or deleting documents, adding new documents, and viewing passport information or metadata.
  
* **Chores**
  * Introduced new analytics event definitions for improved monitoring of document-related user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->