### PR TITLE
SEL-447: Improve proof failure feedback

### DIFF
--- a/app/src/screens/home/ProofHistoryScreen.tsx
+++ b/app/src/screens/home/ProofHistoryScreen.tsx
@@ -22,12 +22,12 @@ import {
   black,
   blue100,
   blue600,
+  red500,
   slate50,
   slate200,
   slate300,
   slate500,
   white,
-  red500,
 } from '../../utils/colors';
 import { extraYPadding } from '../../utils/constants';
 import { dinot } from '../../utils/fonts';

--- a/app/src/screens/home/ProofHistoryScreen.tsx
+++ b/app/src/screens/home/ProofHistoryScreen.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { useNavigation } from '@react-navigation/native';
-import { CheckSquare2, Wallet } from '@tamagui/lucide-icons';
+import { CheckSquare2, Wallet, XCircle } from '@tamagui/lucide-icons';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
@@ -15,6 +15,7 @@ import { Card, Image, Text, View, XStack, YStack } from 'tamagui';
 import { BodyText } from '../../components/typography/BodyText';
 import {
   ProofHistory,
+  ProofStatus,
   useProofHistoryStore,
 } from '../../stores/proofHistoryStore';
 import {
@@ -26,6 +27,7 @@ import {
   slate300,
   slate500,
   white,
+  red500,
 } from '../../utils/colors';
 import { extraYPadding } from '../../utils/constants';
 import { dinot } from '../../utils/fonts';
@@ -270,6 +272,25 @@ const ProofHistoryScreen: React.FC = () => {
                     </Text>
                     <CheckSquare2 color={blue600} height={14} width={14} />
                   </XStack>
+                  {item.status === ProofStatus.FAILURE && (
+                    <XStack
+                      paddingVertical={2}
+                      paddingHorizontal={8}
+                      borderRadius={4}
+                      alignItems="center"
+                      marginLeft={4}
+                    >
+                      <Text
+                        color={red500}
+                        fontSize={14}
+                        fontWeight="600"
+                        marginRight={4}
+                      >
+                        FAIL
+                      </Text>
+                      <XCircle color={red500} height={14} width={14} />
+                    </XStack>
+                  )}
                 </XStack>
               </Card>
             </YStack>

--- a/app/src/stores/proofHistoryStore.ts
+++ b/app/src/stores/proofHistoryStore.ts
@@ -62,6 +62,16 @@ export const useProofHistoryStore = create<ProofHistoryState>()((set, get) => {
         name: DB_NAME,
         location: 'default',
       });
+
+      const tenMinutesAgo = Date.now() - 10 * 60 * 1000;
+      const [stalePending] = await db.executeSql(
+        `SELECT sessionId FROM ${TABLE_NAME} WHERE status = ? AND timestamp <= ?`,
+        [ProofStatus.PENDING, tenMinutesAgo],
+      );
+      for (let i = 0; i < stalePending.rows.length; i++) {
+        const { sessionId } = stalePending.rows.item(i);
+        await get().updateProofStatus(sessionId, ProofStatus.FAILURE);
+      }
       const [pendingProofs] = await db.executeSql(`
         SELECT * FROM ${TABLE_NAME} WHERE status = '${ProofStatus.PENDING}'
       `);

--- a/app/src/stores/proofHistoryStore.ts
+++ b/app/src/stores/proofHistoryStore.ts
@@ -53,6 +53,7 @@ interface ProofHistoryState {
 const PAGE_SIZE = 20;
 const DB_NAME = Platform.OS === 'ios' ? 'proof_history.db' : 'proof_history.db';
 const TABLE_NAME = 'proof_history';
+const STALE_PROOF_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
 export const useProofHistoryStore = create<ProofHistoryState>()((set, get) => {
   const syncProofHistoryStatus = async () => {
@@ -63,7 +64,7 @@ export const useProofHistoryStore = create<ProofHistoryState>()((set, get) => {
         location: 'default',
       });
 
-      const tenMinutesAgo = Date.now() - 10 * 60 * 1000;
+      const tenMinutesAgo = Date.now() - STALE_PROOF_TIMEOUT_MS;
       const [stalePending] = await db.executeSql(
         `SELECT sessionId FROM ${TABLE_NAME} WHERE status = ? AND timestamp <= ?`,
         [ProofStatus.PENDING, tenMinutesAgo],


### PR DESCRIPTION
## Summary
- mark old pending proofs (>10m) as failed when syncing history
- show "FAIL" badge with an X icon for failed proofs in the history list

## Testing
- `CI=true yarn workspace @selfxyz/mobile-app test --runInBand --ci`

------
https://chatgpt.com/codex/tasks/task_b_6861b26bc410832da0073de9432bdb89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visual indicator for failed proof history items, displaying a red "FAIL" badge and icon.
* **Bug Fixes**
  * Automatically marks pending proofs as failed if they remain unconfirmed for more than ten minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->