### PR TITLE
Improve NFC unsupported message

### DIFF
--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -113,6 +113,9 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
       setDialogMessage(
         "Sorry, your device doesn't seem to have an NFC reader.",
       );
+      // Set isNfcEnabled to false so the message is shown on the screen
+      // near the disabled button when NFC isn't supported
+      setIsNfcEnabled(false);
       setIsNfcSupported(false);
     }
   }, []);


### PR DESCRIPTION
## Summary
- show dialog text explaining NFC is unsupported

## Testing
- `cd app && yarn test`

------
https://chatgpt.com/codex/tasks/task_b_6861b3955c00832d957831abd1b3d858