### PR TITLE
Fix settings icon tap

### DIFF
--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -47,10 +47,6 @@ interface MenuButtonProps extends PropsWithChildren {
   Icon: React.FC<SvgProps>;
   onPress: () => void;
 }
-interface MenuButtonProps {
-  Icon: React.FC<SvgProps>;
-  onPress: () => void;
-}
 interface SocialButtonProps {
   Icon: React.FC<SvgProps>;
   href: string;
@@ -107,7 +103,7 @@ const MenuButton: React.FC<MenuButtonProps> = ({ children, Icon, onPress }) => (
     borderBottomWidth={1}
     hitSlop={4}
   >
-    <Icon height={24} width={21} color={white} />
+    <Icon height={24} width={21} color={white} onPress={onPress} />
     <BodyText color={white} fontSize={18} lineHeight={23}>
       {children}
     </BodyText>


### PR DESCRIPTION
## Summary
- remove duplicated `MenuButtonProps` interface
- attach the row's onPress to its icon

## Testing
- `yarn lint`
- `yarn test` *(fails: Couldn't find a script named "test")*

------
https://chatgpt.com/codex/tasks/task_b_6861b3fd0978832da6bbb93db3f6758f