### PR TITLE
Implement recovery backup prompts

### DIFF
--- a/app/src/components/Mnemonic.tsx
+++ b/app/src/components/Mnemonic.tsx
@@ -14,6 +14,7 @@ import {
   white,
 } from '../utils/colors';
 import { confirmTap } from '../utils/haptic';
+import { useSettingStore } from '../stores/settingStore';
 
 interface MnemonicProps {
   words?: string[];
@@ -50,11 +51,13 @@ const REDACTED = new Array(24)
 const Mnemonic = ({ words = REDACTED, onRevealWords }: MnemonicProps) => {
   const [revealWords, setRevealWords] = useState(false);
   const [copied, setCopied] = useState(false);
+  const { setHasViewedRecoveryPhrase } = useSettingStore();
   const copyToClipboardOrReveal = useCallback(async () => {
     confirmTap();
     if (!revealWords) {
       // TODO: container jumps when words are revealed on android
       await onRevealWords?.();
+      setHasViewedRecoveryPhrase(true);
       return setRevealWords(previous => !previous);
     }
     Clipboard.setString(words.join(' '));

--- a/app/src/hooks/useRecoveryPrompts.ts
+++ b/app/src/hooks/useRecoveryPrompts.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { navigationRef } from '../navigation';
+import { useModal } from './useModal';
+import { useSettingStore } from '../stores/settingStore';
+
+const modalParams = {
+  titleText: 'Protect your account',
+  bodyText:
+    'Enable cloud backup or save your recovery phrase so you can recover your account.',
+  buttonText: 'Back up now',
+  onButtonPress: async () => {
+    if (navigationRef.isReady()) {
+      navigationRef.navigate('CloudBackupSettings', {
+        nextScreen: 'SaveRecoveryPhrase',
+      });
+    }
+  },
+  onModalDismiss: () => {},
+} as const;
+
+export default function useRecoveryPrompts() {
+  const { loginCount, cloudBackupEnabled, hasViewedRecoveryPhrase } =
+    useSettingStore();
+  const { showModal, visible } = useModal(modalParams);
+
+  useEffect(() => {
+    if (!navigationRef.isReady()) {
+      return;
+    }
+    if (!cloudBackupEnabled && !hasViewedRecoveryPhrase) {
+      const shouldPrompt =
+        loginCount > 0 && (loginCount <= 3 || (loginCount - 3) % 5 === 0);
+      if (shouldPrompt && !visible) {
+        showModal();
+      }
+    }
+  }, [loginCount, cloudBackupEnabled, hasViewedRecoveryPhrase, visible, showModal]);
+
+  return { visible };
+}

--- a/app/src/providers/authProvider.tsx
+++ b/app/src/providers/authProvider.tsx
@@ -15,6 +15,7 @@ import Keychain from 'react-native-keychain';
 import { AuthEvents } from '../consts/analytics';
 import { Mnemonic } from '../types/mnemonic';
 import analytics from '../utils/analytics';
+import { useSettingStore } from '../stores/settingStore';
 
 const { trackEvent } = analytics();
 
@@ -208,6 +209,7 @@ export const AuthProvider = ({
 
     setIsAuthenticatingPromise(null);
     setIsAuthenticated(true);
+    useSettingStore.getState().incrementLoginCount();
     trackEvent(AuthEvents.BIOMETRIC_LOGIN_SUCCESS);
     setAuthenticatedTimeout(previousTimeout => {
       if (previousTimeout) {

--- a/app/src/screens/home/HomeScreen.tsx
+++ b/app/src/screens/home/HomeScreen.tsx
@@ -10,6 +10,7 @@ import { BodyText } from '../../components/typography/BodyText';
 import { Caption } from '../../components/typography/Caption';
 import { useAppUpdates } from '../../hooks/useAppUpdates';
 import useConnectionModal from '../../hooks/useConnectionModal';
+import useRecoveryPrompts from '../../hooks/useRecoveryPrompts';
 import useHapticNavigation from '../../hooks/useHapticNavigation';
 import SelfCard from '../../images/card-style-1.svg';
 import ScanIcon from '../../images/icons/qr_scan.svg';
@@ -36,6 +37,7 @@ const ScanButton = styled(Button, {
 
 const HomeScreen: React.FC = () => {
   useConnectionModal();
+  useRecoveryPrompts();
   const [isNewVersionAvailable, showAppUpdateModal, isModalDismissed] =
     useAppUpdates();
 

--- a/app/src/stores/settingStore.ts
+++ b/app/src/stores/settingStore.ts
@@ -11,6 +11,10 @@ interface PersistedSettingsState {
   setBiometricsAvailable: (biometricsAvailable: boolean) => void;
   cloudBackupEnabled: boolean;
   toggleCloudBackupEnabled: () => void;
+  loginCount: number;
+  incrementLoginCount: () => void;
+  hasViewedRecoveryPhrase: boolean;
+  setHasViewedRecoveryPhrase: (viewed: boolean) => void;
   isDevMode: boolean;
   setDevModeOn: () => void;
   setDevModeOff: () => void;
@@ -43,6 +47,19 @@ export const useSettingStore = create<SettingsState>()(
       toggleCloudBackupEnabled: () =>
         set(oldState => ({
           cloudBackupEnabled: !oldState.cloudBackupEnabled,
+          loginCount: oldState.cloudBackupEnabled
+            ? oldState.loginCount
+            : 0,
+        })),
+
+      loginCount: 0,
+      incrementLoginCount: () =>
+        set(oldState => ({ loginCount: oldState.loginCount + 1 })),
+      hasViewedRecoveryPhrase: false,
+      setHasViewedRecoveryPhrase: viewed =>
+        set(oldState => ({
+          hasViewedRecoveryPhrase: viewed,
+          loginCount: viewed ? 0 : oldState.loginCount,
         })),
 
       isDevMode: false,


### PR DESCRIPTION
## Summary
- track biometric login count and recovery phrase view in `settingStore`
- increment login counter after successful biometric login
- record when the mnemonic is revealed
- display backup prompts on Home screen via new `useRecoveryPrompts` hook

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_6861bbdb234c832d82dfed9d20d32d32