### PR TITLE
SEL-330: Add backup check after verification

### DIFF
--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -24,6 +24,7 @@ import {
 } from '../../providers/passportDataProvider';
 import { useProtocolStore } from '../../stores/protocolStore';
 import { useSelfAppStore } from '../../stores/selfAppStore';
+import { useSettingStore } from '../../stores/settingStore';
 import analytics from '../analytics';
 import { getPublicKey, verifyAttestation } from './attest';
 import {
@@ -48,6 +49,11 @@ import {
 } from './validateDocument';
 
 const { trackEvent } = analytics();
+
+export const getPostVerificationRoute = () => {
+  const { cloudBackupEnabled } = useSettingStore.getState();
+  return cloudBackupEnabled ? 'AccountVerifiedSuccess' : 'SaveRecoveryPhrase';
+};
 
 const provingMachine = createMachine({
   id: 'proving',
@@ -227,7 +233,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       if (state.value === 'completed') {
         if (get().circuitType !== 'disclose' && navigationRef.isReady()) {
           setTimeout(() => {
-            navigationRef.navigate('AccountVerifiedSuccess');
+            navigationRef.navigate(getPostVerificationRoute());
           }, 3000);
         }
         if (get().circuitType === 'disclose') {

--- a/app/tests/utils/proving/getPostVerificationRoute.test.ts
+++ b/app/tests/utils/proving/getPostVerificationRoute.test.ts
@@ -1,5 +1,6 @@
-import { getPostVerificationRoute } from '../../../src/utils/proving/provingMachine';
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 import { useSettingStore } from '../../../src/stores/settingStore';
+import { getPostVerificationRoute } from '../../../src/utils/proving/provingMachine';
 
 describe('getPostVerificationRoute', () => {
   afterEach(() => {

--- a/app/tests/utils/proving/getPostVerificationRoute.test.ts
+++ b/app/tests/utils/proving/getPostVerificationRoute.test.ts
@@ -1,0 +1,18 @@
+import { getPostVerificationRoute } from '../../../src/utils/proving/provingMachine';
+import { useSettingStore } from '../../../src/stores/settingStore';
+
+describe('getPostVerificationRoute', () => {
+  afterEach(() => {
+    useSettingStore.setState({ cloudBackupEnabled: false });
+  });
+
+  it('returns SaveRecoveryPhrase when cloud backup disabled', () => {
+    useSettingStore.setState({ cloudBackupEnabled: false });
+    expect(getPostVerificationRoute()).toBe('SaveRecoveryPhrase');
+  });
+
+  it('returns AccountVerifiedSuccess when cloud backup enabled', () => {
+    useSettingStore.setState({ cloudBackupEnabled: true });
+    expect(getPostVerificationRoute()).toBe('AccountVerifiedSuccess');
+  });
+});


### PR DESCRIPTION
## Summary
- navigate to SaveRecoveryPhrase when cloud backup is off
- expose helper to get next route after verification
- test getPostVerificationRoute helper

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_6861bafe6118832da0fd0cd5426012da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post-verification navigation now adapts based on whether cloud backup is enabled, directing users to either the success screen or the recovery phrase screen accordingly.

* **Tests**
  * Added tests to ensure correct navigation after verification depending on the cloud backup setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->