### PR TITLE
SEL-487: Prompt user to backup recovery phrase before registering

### DIFF
--- a/app/jest.config.cjs
+++ b/app/jest.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'react-native',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|@react-native-community|@segment/analytics-react-native|@openpassport|react-native-keychain|react-native-check-version|react-native-nfc-manager|react-native-passport-reader|react-native-gesture-handler|uuid|@stablelib|@react-native-google-signin|react-native-cloud-storage|@react-native-clipboard|@react-native-firebase)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|@react-native-community|@segment/analytics-react-native|@openpassport|react-native-keychain|react-native-check-version|react-native-nfc-manager|react-native-passport-reader|react-native-gesture-handler|uuid|@stablelib|@react-native-google-signin|react-native-cloud-storage|@react-native-clipboard|@react-native-firebase|@sentry)/)',
   ],
   setupFiles: ['<rootDir>/jest.setup.js'],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$',

--- a/app/src/consts/analytics.ts
+++ b/app/src/consts/analytics.ts
@@ -60,6 +60,7 @@ export const ProofEvents = {
   PROOF_VERIFICATION_STARTED: 'Proof: Proof Verification Started',
   PROVING_PROCESS_ERROR: 'Proof: Proving Process Error',
   PROVING_STATE_CHANGE: 'Proof: Proving State Change',
+  PROVING_STORE_REINITIALIZED: 'Proof: Proving Store Re-initialized',
   REGISTER_COMPLETED: 'Proof: Register Completed',
   ALREADY_REGISTERED: 'Proof: Already Registered',
   QR_SCAN_CANCELLED: 'Proof: QR Scan Cancelled',

--- a/app/src/hooks/useRecoveryPrompts.ts
+++ b/app/src/hooks/useRecoveryPrompts.ts
@@ -49,7 +49,9 @@ export default function useRecoveryPrompts() {
         }
       }
     }
-    void maybePrompt();
+    maybePrompt().catch(() => {
+      // Silently fail to avoid breaking the hook
+    });
   }, [
     loginCount,
     cloudBackupEnabled,

--- a/app/src/screens/misc/LoadingScreen.tsx
+++ b/app/src/screens/misc/LoadingScreen.tsx
@@ -143,10 +143,19 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
 
     // Update UI if passport data is available
     if (passportData?.passportMetadata) {
-      // Update loading text based on current state
+      // Get the current circuit type from the proving store
+      const circuitType = useProvingStore.getState().circuitType;
+
+      // Determine the appropriate type for loading screen text
+      // 'disclose' circuit type should use 'register' timing, but 'dsc' should use 'dsc' timing
+      const loadingScreenType: 'dsc' | 'register' =
+        circuitType === 'dsc' ? 'dsc' : 'register';
+
+      // Update loading text based on current state and circuit type
       const { actionText, estimatedTime } = getLoadingScreenText(
         currentState as ProvingStateType,
         passportData?.passportMetadata,
+        loadingScreenType,
       );
       setLoadingText({ actionText, estimatedTime });
 

--- a/app/src/screens/prove/ConfirmBelongingScreen.tsx
+++ b/app/src/screens/prove/ConfirmBelongingScreen.tsx
@@ -12,6 +12,7 @@ import { Title } from '../../components/typography/Title';
 import { PassportEvents, ProofEvents } from '../../consts/analytics';
 import useHapticNavigation from '../../hooks/useHapticNavigation';
 import { ExpandableBottomLayout } from '../../layouts/ExpandableBottomLayout';
+import { captureException } from '../../Sentry';
 import analytics from '../../utils/analytics';
 import { black, white } from '../../utils/colors';
 import { notificationSuccess } from '../../utils/haptic';
@@ -61,10 +62,29 @@ const ConfirmBelongingScreen: React.FC<ConfirmBelongingScreenProps> = ({}) => {
 
       // Ensure proving store is initialized before navigation
       if (provingStore.circuitType !== 'dsc') {
-        console.log(
-          'Re-initializing proving store with DSC circuit type before navigation',
-        );
-        await provingStore.init('dsc', true);
+        try {
+          console.error(
+            'Re-initializing proving store with DSC circuit type before navigation',
+          );
+          trackEvent(ProofEvents.PROVING_STORE_REINITIALIZED, {
+            reason: 'circuit_type_mismatch',
+            expected_type: 'dsc',
+            current_type: provingStore.circuitType,
+          });
+          await provingStore.init('dsc', true);
+        } catch (error: any) {
+          console.error('Error during proving store re-initialization:', error);
+          captureException(error, {
+            context: 'proving_store_reinitialization',
+            circuit_type: 'dsc',
+            current_circuit_type: provingStore.circuitType,
+          });
+          trackEvent(ProofEvents.PROVING_PROCESS_ERROR, {
+            error: error?.message || 'Unknown re-initialization error',
+            context: 'proving_store_reinitialization',
+          });
+          throw error; // Re-throw to be handled by the outer try-catch
+        }
       }
 
       // Navigate to loading screen

--- a/app/src/screens/prove/ConfirmBelongingScreen.tsx
+++ b/app/src/screens/prove/ConfirmBelongingScreen.tsx
@@ -59,6 +59,14 @@ const ConfirmBelongingScreen: React.FC<ConfirmBelongingScreenProps> = ({}) => {
       // Mark as user confirmed - proving will start automatically when ready
       provingStore.setUserConfirmed();
 
+      // Ensure proving store is initialized before navigation
+      if (provingStore.circuitType !== 'dsc') {
+        console.log(
+          'Re-initializing proving store with DSC circuit type before navigation',
+        );
+        await provingStore.init('dsc', true);
+      }
+
       // Navigate to loading screen
       navigate();
     } catch (error: any) {

--- a/app/src/screens/recovery/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/recovery/RecoverWithPhraseScreen.tsx
@@ -16,8 +16,8 @@ import {
   loadPassportDataAndSecret,
   reStorePassportDataWithRightCSCA,
 } from '../../providers/passportDataProvider';
-import analytics from '../../utils/analytics';
 import { useSettingStore } from '../../stores/settingStore';
+import analytics from '../../utils/analytics';
 import {
   black,
   slate300,

--- a/app/src/screens/recovery/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/recovery/RecoverWithPhraseScreen.tsx
@@ -17,6 +17,7 @@ import {
   reStorePassportDataWithRightCSCA,
 } from '../../providers/passportDataProvider';
 import analytics from '../../utils/analytics';
+import { useSettingStore } from '../../stores/settingStore';
 import {
   black,
   slate300,
@@ -81,6 +82,7 @@ const RecoverWithPhraseScreen: React.FC<
 
     setRestoring(false);
     trackEvent(BackupEvents.ACCOUNT_RECOVERY_COMPLETED);
+    useSettingStore.getState().setHasViewedRecoveryPhrase(true);
     navigation.navigate('AccountVerifiedSuccess');
   }, [mnemonic, restoreAccountFromMnemonic]);
 

--- a/app/src/screens/recovery/SaveRecoveryPhraseScreen.tsx
+++ b/app/src/screens/recovery/SaveRecoveryPhraseScreen.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
-import React, { useCallback, useState } from 'react';
 import { StaticScreenProps } from '@react-navigation/native';
+import React, { useCallback, useState } from 'react';
 
 import { PrimaryButton } from '../../components/buttons/PrimaryButton';
 import { SecondaryButton } from '../../components/buttons/SecondaryButton';
@@ -11,11 +11,11 @@ import Description from '../../components/typography/Description';
 import { Title } from '../../components/typography/Title';
 import useHapticNavigation from '../../hooks/useHapticNavigation';
 import useMnemonic from '../../hooks/useMnemonic';
-import { RootStackParamList } from '../../navigation';
-import { useProvingStore } from '../../utils/proving/provingMachine';
 import { ExpandableBottomLayout } from '../../layouts/ExpandableBottomLayout';
+import { RootStackParamList } from '../../navigation';
 import { STORAGE_NAME } from '../../utils/cloudBackup';
 import { black, slate400, white } from '../../utils/colors';
+import { useProvingStore } from '../../utils/proving/provingMachine';
 
 type NextScreen = keyof RootStackParamList;
 interface SaveRecoveryPhraseScreenProps

--- a/app/src/screens/recovery/SaveRecoveryPhraseScreen.tsx
+++ b/app/src/screens/recovery/SaveRecoveryPhraseScreen.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import React, { useCallback, useState } from 'react';
+import { StaticScreenProps } from '@react-navigation/native';
 
 import { PrimaryButton } from '../../components/buttons/PrimaryButton';
 import { SecondaryButton } from '../../components/buttons/SecondaryButton';
@@ -10,15 +11,19 @@ import Description from '../../components/typography/Description';
 import { Title } from '../../components/typography/Title';
 import useHapticNavigation from '../../hooks/useHapticNavigation';
 import useMnemonic from '../../hooks/useMnemonic';
+import { RootStackParamList } from '../../navigation';
+import { useProvingStore } from '../../utils/proving/provingMachine';
 import { ExpandableBottomLayout } from '../../layouts/ExpandableBottomLayout';
 import { STORAGE_NAME } from '../../utils/cloudBackup';
 import { black, slate400, white } from '../../utils/colors';
 
-interface SaveRecoveryPhraseScreenProps {}
+type NextScreen = keyof RootStackParamList;
+interface SaveRecoveryPhraseScreenProps
+  extends StaticScreenProps<{ nextScreen?: NextScreen } | undefined> {}
 
-const SaveRecoveryPhraseScreen: React.FC<
-  SaveRecoveryPhraseScreenProps
-> = ({}) => {
+const SaveRecoveryPhraseScreen: React.FC<SaveRecoveryPhraseScreenProps> = ({
+  route,
+}) => {
   const [userHasSeenMnemonic, setUserHasSeenMnemonic] = useState(false);
   const { mnemonic, loadMnemonic } = useMnemonic();
 
@@ -27,12 +32,19 @@ const SaveRecoveryPhraseScreen: React.FC<
     setUserHasSeenMnemonic(true);
   }, []);
 
+  const nextScreen = route.params?.nextScreen ?? 'AccountVerifiedSuccess';
+
   const onCloudBackupPress = useHapticNavigation('CloudBackupSettings', {
     params: { nextScreen: 'SaveRecoveryPhrase' },
   });
-  const onSkipPress = useHapticNavigation('AccountVerifiedSuccess', {
-    action: 'confirm',
-  });
+
+  const navigateNext = useHapticNavigation(nextScreen, { action: 'confirm' });
+  const onSkipPress = useCallback(() => {
+    if (nextScreen === 'LoadingScreen') {
+      useProvingStore.getState().init('register', true);
+    }
+    navigateNext();
+  }, [navigateNext, nextScreen]);
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={black}>

--- a/app/tests/src/hooks/useRecoveryPrompts.test.ts
+++ b/app/tests/src/hooks/useRecoveryPrompts.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 
 import { useModal } from '../../../src/hooks/useModal';
 import useRecoveryPrompts from '../../../src/hooks/useRecoveryPrompts';
@@ -25,15 +25,19 @@ describe('useRecoveryPrompts', () => {
   beforeEach(() => {
     showModal.mockClear();
     getAllDocuments.mockResolvedValue({ doc1: {} as any });
-    useSettingStore.setState({
-      loginCount: 0,
-      cloudBackupEnabled: false,
-      hasViewedRecoveryPhrase: false,
+    act(() => {
+      useSettingStore.setState({
+        loginCount: 0,
+        cloudBackupEnabled: false,
+        hasViewedRecoveryPhrase: false,
+      });
     });
   });
 
   it('shows modal on first login', async () => {
-    useSettingStore.setState({ loginCount: 1 });
+    act(() => {
+      useSettingStore.setState({ loginCount: 1 });
+    });
     renderHook(() => useRecoveryPrompts());
     await waitFor(() => {
       expect(showModal).toHaveBeenCalled();
@@ -41,7 +45,9 @@ describe('useRecoveryPrompts', () => {
   });
 
   it('does not show modal when login count is 4', async () => {
-    useSettingStore.setState({ loginCount: 4 });
+    act(() => {
+      useSettingStore.setState({ loginCount: 4 });
+    });
     renderHook(() => useRecoveryPrompts());
     await waitFor(() => {
       expect(showModal).not.toHaveBeenCalled();
@@ -49,7 +55,9 @@ describe('useRecoveryPrompts', () => {
   });
 
   it('shows modal on eighth login', async () => {
-    useSettingStore.setState({ loginCount: 8 });
+    act(() => {
+      useSettingStore.setState({ loginCount: 8 });
+    });
     renderHook(() => useRecoveryPrompts());
     await waitFor(() => {
       expect(showModal).toHaveBeenCalled();
@@ -57,7 +65,9 @@ describe('useRecoveryPrompts', () => {
   });
 
   it('does not show modal if backup already enabled', async () => {
-    useSettingStore.setState({ loginCount: 1, cloudBackupEnabled: true });
+    act(() => {
+      useSettingStore.setState({ loginCount: 1, cloudBackupEnabled: true });
+    });
     renderHook(() => useRecoveryPrompts());
     await waitFor(() => {
       expect(showModal).not.toHaveBeenCalled();
@@ -67,7 +77,9 @@ describe('useRecoveryPrompts', () => {
   it('does not show modal when navigation is not ready', async () => {
     const navigationRef = require('../../../src/navigation').navigationRef;
     navigationRef.isReady.mockReturnValueOnce(false);
-    useSettingStore.setState({ loginCount: 1 });
+    act(() => {
+      useSettingStore.setState({ loginCount: 1 });
+    });
     renderHook(() => useRecoveryPrompts());
     await waitFor(() => {
       expect(showModal).not.toHaveBeenCalled();
@@ -75,7 +87,12 @@ describe('useRecoveryPrompts', () => {
   });
 
   it('does not show modal when recovery phrase has been viewed', async () => {
-    useSettingStore.setState({ loginCount: 1, hasViewedRecoveryPhrase: true });
+    act(() => {
+      useSettingStore.setState({
+        loginCount: 1,
+        hasViewedRecoveryPhrase: true,
+      });
+    });
     renderHook(() => useRecoveryPrompts());
     await waitFor(() => {
       expect(showModal).not.toHaveBeenCalled();
@@ -84,7 +101,9 @@ describe('useRecoveryPrompts', () => {
 
   it('does not show modal when no documents exist', async () => {
     getAllDocuments.mockResolvedValueOnce({});
-    useSettingStore.setState({ loginCount: 1 });
+    act(() => {
+      useSettingStore.setState({ loginCount: 1 });
+    });
     renderHook(() => useRecoveryPrompts());
     await waitFor(() => {
       expect(showModal).not.toHaveBeenCalled();
@@ -94,7 +113,9 @@ describe('useRecoveryPrompts', () => {
   it('shows modal for other valid login counts', async () => {
     for (const count of [2, 3, 13, 18]) {
       showModal.mockClear();
-      useSettingStore.setState({ loginCount: count });
+      act(() => {
+        useSettingStore.setState({ loginCount: count });
+      });
       renderHook(() => useRecoveryPrompts());
       await waitFor(() => {
         expect(showModal).toHaveBeenCalled();

--- a/app/tests/src/screens/misc/LoadingScreen.test.tsx
+++ b/app/tests/src/screens/misc/LoadingScreen.test.tsx
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import LoadingScreen from '../../../../src/screens/misc/LoadingScreen';
+import { useProvingStore } from '../../../../src/utils/proving/provingMachine';
+
+// Mock the proving store
+jest.mock('../../../../src/utils/proving/provingMachine');
+
+// Mock other dependencies
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: () => true,
+}));
+
+jest.mock('../../../../src/utils/proving/loadingScreenStateText', () => ({
+  getLoadingScreenText: jest.fn().mockReturnValue({
+    actionText: 'Test Action',
+    estimatedTime: 'Test Time',
+  }),
+}));
+
+jest.mock('../../../../src/providers/passportDataProvider', () => ({
+  loadPassportDataAndSecret: jest.fn().mockResolvedValue(
+    JSON.stringify({
+      passportData: {
+        passportMetadata: {
+          signatureAlgorithm: 'RSA',
+          curveOrExponent: '65537',
+        },
+      },
+    }),
+  ),
+}));
+
+jest.mock('../../../../src/utils/notifications/notificationService', () => ({
+  setupNotifications: jest.fn().mockReturnValue(() => {}),
+}));
+
+jest.mock('../../../../src/utils/proving/validateDocument', () => ({
+  checkPassportSupported: jest
+    .fn()
+    .mockResolvedValue({ status: 'passport_supported' }),
+}));
+
+const mockUseProvingStore = useProvingStore as unknown as jest.MockedFunction<
+  typeof useProvingStore
+>;
+
+describe('LoadingScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Circuit type handling', () => {
+    it('should handle DSC circuit type correctly', () => {
+      // Mock proving store state for DSC flow
+      mockUseProvingStore.mockImplementation(selector => {
+        if (typeof selector === 'function') {
+          return selector({
+            currentState: 'proving',
+            fcmToken: 'test-token',
+            circuitType: 'dsc',
+            // Add other required state properties
+          } as any);
+        }
+        return {
+          currentState: 'proving',
+          fcmToken: 'test-token',
+          circuitType: 'dsc',
+        } as any;
+      });
+
+      // Mock getState to return DSC circuit type
+      (mockUseProvingStore as any).getState = jest.fn().mockReturnValue({
+        circuitType: 'dsc',
+      });
+
+      const {
+        getLoadingScreenText,
+      } = require('../../../../src/utils/proving/loadingScreenStateText');
+
+      render(<LoadingScreen route={{} as any} />);
+
+      // Verify that getLoadingScreenText was called with 'dsc' type
+      expect(getLoadingScreenText).toHaveBeenCalledWith(
+        'proving',
+        expect.any(Object),
+        'dsc',
+      );
+    });
+
+    it('should handle register circuit type correctly', () => {
+      // Mock proving store state for register flow
+      mockUseProvingStore.mockImplementation(selector => {
+        if (typeof selector === 'function') {
+          return selector({
+            currentState: 'proving',
+            fcmToken: 'test-token',
+            circuitType: 'register',
+          } as any);
+        }
+        return {
+          currentState: 'proving',
+          fcmToken: 'test-token',
+          circuitType: 'register',
+        } as any;
+      });
+
+      // Mock getState to return register circuit type
+      (mockUseProvingStore as any).getState = jest.fn().mockReturnValue({
+        circuitType: 'register',
+      });
+
+      const {
+        getLoadingScreenText,
+      } = require('../../../../src/utils/proving/loadingScreenStateText');
+
+      render(<LoadingScreen route={{} as any} />);
+
+      // Verify that getLoadingScreenText was called with 'register' type
+      expect(getLoadingScreenText).toHaveBeenCalledWith(
+        'proving',
+        expect.any(Object),
+        'register',
+      );
+    });
+
+    it('should handle disclose circuit type correctly', () => {
+      // Mock proving store state for disclose flow
+      mockUseProvingStore.mockImplementation(selector => {
+        if (typeof selector === 'function') {
+          return selector({
+            currentState: 'proving',
+            fcmToken: 'test-token',
+            circuitType: 'disclose',
+          } as any);
+        }
+        return {
+          currentState: 'proving',
+          fcmToken: 'test-token',
+          circuitType: 'disclose',
+        } as any;
+      });
+
+      // Mock getState to return disclose circuit type
+      (mockUseProvingStore as any).getState = jest.fn().mockReturnValue({
+        circuitType: 'disclose',
+      });
+
+      const {
+        getLoadingScreenText,
+      } = require('../../../../src/utils/proving/loadingScreenStateText');
+
+      render(<LoadingScreen route={{} as any} />);
+
+      // Verify that getLoadingScreenText was called with 'register' type (disclose uses register timing)
+      expect(getLoadingScreenText).toHaveBeenCalledWith(
+        'proving',
+        expect.any(Object),
+        'register',
+      );
+    });
+
+    it('should default to register type when circuit type is null', () => {
+      // Mock proving store state with null circuit type
+      mockUseProvingStore.mockImplementation(selector => {
+        if (typeof selector === 'function') {
+          return selector({
+            currentState: 'proving',
+            fcmToken: 'test-token',
+            circuitType: null,
+          } as any);
+        }
+        return {
+          currentState: 'proving',
+          fcmToken: 'test-token',
+          circuitType: null,
+        } as any;
+      });
+
+      // Mock getState to return null circuit type
+      (mockUseProvingStore as any).getState = jest.fn().mockReturnValue({
+        circuitType: null,
+      });
+
+      const {
+        getLoadingScreenText,
+      } = require('../../../../src/utils/proving/loadingScreenStateText');
+
+      render(<LoadingScreen route={{} as any} />);
+
+      // Verify that getLoadingScreenText was called with 'register' type as default
+      expect(getLoadingScreenText).toHaveBeenCalledWith(
+        'proving',
+        expect.any(Object),
+        'register',
+      );
+    });
+  });
+});

--- a/app/tests/src/screens/misc/LoadingScreen.test.tsx
+++ b/app/tests/src/screens/misc/LoadingScreen.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
 import LoadingScreen from '../../../../src/screens/misc/LoadingScreen';
@@ -12,7 +12,60 @@ jest.mock('../../../../src/utils/proving/provingMachine');
 // Mock other dependencies
 jest.mock('@react-navigation/native', () => ({
   useIsFocused: () => true,
+  createNavigationContainerRef: jest.fn(() => ({
+    isReady: jest.fn(() => true),
+    navigate: jest.fn(),
+    getCurrentRoute: jest.fn(() => ({ name: 'TestScreen' })),
+  })),
+  createStaticNavigation: jest.fn(() => jest.fn()),
 }));
+
+jest.mock('@react-navigation/native-stack', () => ({
+  createNativeStackNavigator: jest.fn(() => ({})),
+}));
+
+jest.mock('react-native-gesture-handler', () => ({
+  GestureHandlerRootView: ({ children }: any) => children,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  }),
+}));
+
+jest.mock('lottie-react-native', () => ({
+  __esModule: true,
+  default: ({ children }: any) => children,
+}));
+
+jest.mock('tamagui', () => ({
+  YStack: ({ children }: any) => children,
+  Text: ({ children }: any) => children,
+  styled: jest.fn(
+    () =>
+      ({ children }: any) =>
+        children,
+  ),
+}));
+
+jest.mock('../../../../src/hooks/useHapticNavigation', () => ({
+  __esModule: true,
+  default: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../../../src/utils/haptic', () => ({
+  loadingScreenProgress: jest.fn(),
+}));
+
+// Mock SVG imports
+jest.mock(
+  '../../../../src/images/icons/close-warning.svg',
+  () => 'CloseWarningIcon',
+);
 
 jest.mock('../../../../src/utils/proving/loadingScreenStateText', () => ({
   getLoadingScreenText: jest.fn().mockReturnValue({
@@ -32,6 +85,7 @@ jest.mock('../../../../src/providers/passportDataProvider', () => ({
       },
     }),
   ),
+  clearPassportData: jest.fn(),
 }));
 
 jest.mock('../../../../src/utils/notifications/notificationService', () => ({
@@ -54,7 +108,7 @@ describe('LoadingScreen', () => {
   });
 
   describe('Circuit type handling', () => {
-    it('should handle DSC circuit type correctly', () => {
+    it('should handle DSC circuit type correctly', async () => {
       // Mock proving store state for DSC flow
       mockUseProvingStore.mockImplementation(selector => {
         if (typeof selector === 'function') {
@@ -84,14 +138,16 @@ describe('LoadingScreen', () => {
       render(<LoadingScreen route={{} as any} />);
 
       // Verify that getLoadingScreenText was called with 'dsc' type
-      expect(getLoadingScreenText).toHaveBeenCalledWith(
-        'proving',
-        expect.any(Object),
-        'dsc',
-      );
+      await waitFor(() => {
+        expect(getLoadingScreenText).toHaveBeenCalledWith(
+          'proving',
+          expect.any(Object),
+          'dsc',
+        );
+      });
     });
 
-    it('should handle register circuit type correctly', () => {
+    it('should handle register circuit type correctly', async () => {
       // Mock proving store state for register flow
       mockUseProvingStore.mockImplementation(selector => {
         if (typeof selector === 'function') {
@@ -120,14 +176,16 @@ describe('LoadingScreen', () => {
       render(<LoadingScreen route={{} as any} />);
 
       // Verify that getLoadingScreenText was called with 'register' type
-      expect(getLoadingScreenText).toHaveBeenCalledWith(
-        'proving',
-        expect.any(Object),
-        'register',
-      );
+      await waitFor(() => {
+        expect(getLoadingScreenText).toHaveBeenCalledWith(
+          'proving',
+          expect.any(Object),
+          'register',
+        );
+      });
     });
 
-    it('should handle disclose circuit type correctly', () => {
+    it('should handle disclose circuit type correctly', async () => {
       // Mock proving store state for disclose flow
       mockUseProvingStore.mockImplementation(selector => {
         if (typeof selector === 'function') {
@@ -156,14 +214,16 @@ describe('LoadingScreen', () => {
       render(<LoadingScreen route={{} as any} />);
 
       // Verify that getLoadingScreenText was called with 'register' type (disclose uses register timing)
-      expect(getLoadingScreenText).toHaveBeenCalledWith(
-        'proving',
-        expect.any(Object),
-        'register',
-      );
+      await waitFor(() => {
+        expect(getLoadingScreenText).toHaveBeenCalledWith(
+          'proving',
+          expect.any(Object),
+          'register',
+        );
+      });
     });
 
-    it('should default to register type when circuit type is null', () => {
+    it('should default to register type when circuit type is null', async () => {
       // Mock proving store state with null circuit type
       mockUseProvingStore.mockImplementation(selector => {
         if (typeof selector === 'function') {
@@ -192,11 +252,13 @@ describe('LoadingScreen', () => {
       render(<LoadingScreen route={{} as any} />);
 
       // Verify that getLoadingScreenText was called with 'register' type as default
-      expect(getLoadingScreenText).toHaveBeenCalledWith(
-        'proving',
-        expect.any(Object),
-        'register',
-      );
+      await waitFor(() => {
+        expect(getLoadingScreenText).toHaveBeenCalledWith(
+          'proving',
+          expect.any(Object),
+          'register',
+        );
+      });
     });
   });
 });

--- a/app/tests/src/stores/settingStore.test.ts
+++ b/app/tests/src/stores/settingStore.test.ts
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
+import { act } from '@testing-library/react-native';
+
 import { useSettingStore } from '../../../src/stores/settingStore';
 
 describe('settingStore', () => {
   beforeEach(() => {
-    useSettingStore.setState({
-      loginCount: 0,
-      cloudBackupEnabled: false,
-      hasViewedRecoveryPhrase: false,
+    act(() => {
+      useSettingStore.setState({
+        loginCount: 0,
+        cloudBackupEnabled: false,
+        hasViewedRecoveryPhrase: false,
+      });
     });
   });
 
@@ -24,34 +28,47 @@ describe('settingStore', () => {
   });
 
   it('increments login count from non-zero initial value', () => {
-    useSettingStore.setState({ loginCount: 5 });
+    act(() => {
+      useSettingStore.setState({ loginCount: 5 });
+    });
     useSettingStore.getState().incrementLoginCount();
     expect(useSettingStore.getState().loginCount).toBe(6);
   });
 
   it('resets login count when recovery phrase viewed', () => {
-    useSettingStore.setState({ loginCount: 2 });
+    act(() => {
+      useSettingStore.setState({ loginCount: 2 });
+    });
     useSettingStore.getState().setHasViewedRecoveryPhrase(true);
     expect(useSettingStore.getState().hasViewedRecoveryPhrase).toBe(true);
     expect(useSettingStore.getState().loginCount).toBe(0);
   });
 
   it('does not reset login count when setting recovery phrase viewed to false', () => {
-    useSettingStore.setState({ loginCount: 3, hasViewedRecoveryPhrase: true });
+    act(() => {
+      useSettingStore.setState({
+        loginCount: 3,
+        hasViewedRecoveryPhrase: true,
+      });
+    });
     useSettingStore.getState().setHasViewedRecoveryPhrase(false);
     expect(useSettingStore.getState().hasViewedRecoveryPhrase).toBe(false);
     expect(useSettingStore.getState().loginCount).toBe(3);
   });
 
   it('resets login count when enabling cloud backup', () => {
-    useSettingStore.setState({ loginCount: 3, cloudBackupEnabled: false });
+    act(() => {
+      useSettingStore.setState({ loginCount: 3, cloudBackupEnabled: false });
+    });
     useSettingStore.getState().toggleCloudBackupEnabled();
     expect(useSettingStore.getState().cloudBackupEnabled).toBe(true);
     expect(useSettingStore.getState().loginCount).toBe(0);
   });
 
   it('does not reset login count when disabling cloud backup', () => {
-    useSettingStore.setState({ loginCount: 4, cloudBackupEnabled: true });
+    act(() => {
+      useSettingStore.setState({ loginCount: 4, cloudBackupEnabled: true });
+    });
     useSettingStore.getState().toggleCloudBackupEnabled();
     expect(useSettingStore.getState().cloudBackupEnabled).toBe(false);
     expect(useSettingStore.getState().loginCount).toBe(4);
@@ -79,7 +96,12 @@ describe('settingStore', () => {
   });
 
   it('does not reset login count when setting recovery phrase viewed to true when already true', () => {
-    useSettingStore.setState({ loginCount: 5, hasViewedRecoveryPhrase: true });
+    act(() => {
+      useSettingStore.setState({
+        loginCount: 5,
+        hasViewedRecoveryPhrase: true,
+      });
+    });
     useSettingStore.getState().setHasViewedRecoveryPhrase(true);
     expect(useSettingStore.getState().hasViewedRecoveryPhrase).toBe(true);
     expect(useSettingStore.getState().loginCount).toBe(5);
@@ -93,13 +115,17 @@ describe('settingStore', () => {
     expect(useSettingStore.getState().loginCount).toBe(3);
 
     // Disable cloud backup (should not reset)
-    useSettingStore.setState({ cloudBackupEnabled: true });
+    act(() => {
+      useSettingStore.setState({ cloudBackupEnabled: true });
+    });
     useSettingStore.getState().toggleCloudBackupEnabled();
     expect(useSettingStore.getState().cloudBackupEnabled).toBe(false);
     expect(useSettingStore.getState().loginCount).toBe(3);
 
     // Set recovery phrase viewed to false (should not reset)
-    useSettingStore.setState({ hasViewedRecoveryPhrase: true });
+    act(() => {
+      useSettingStore.setState({ hasViewedRecoveryPhrase: true });
+    });
     useSettingStore.getState().setHasViewedRecoveryPhrase(false);
     expect(useSettingStore.getState().hasViewedRecoveryPhrase).toBe(false);
     expect(useSettingStore.getState().loginCount).toBe(3);
@@ -112,7 +138,9 @@ describe('settingStore', () => {
 
   it('maintains login count when toggling cloud backup from true to false then back to true', () => {
     // Start with cloud backup enabled and some login count
-    useSettingStore.setState({ loginCount: 2, cloudBackupEnabled: true });
+    act(() => {
+      useSettingStore.setState({ loginCount: 2, cloudBackupEnabled: true });
+    });
 
     // Toggle to disable (should not reset)
     useSettingStore.getState().toggleCloudBackupEnabled();

--- a/app/tests/utils/proving/getPostVerificationRoute.test.ts
+++ b/app/tests/utils/proving/getPostVerificationRoute.test.ts
@@ -5,16 +5,27 @@ import { getPostVerificationRoute } from '../../../src/utils/proving/provingMach
 
 describe('getPostVerificationRoute', () => {
   afterEach(() => {
-    useSettingStore.setState({ cloudBackupEnabled: false });
+    useSettingStore.setState({
+      cloudBackupEnabled: false,
+      hasViewedRecoveryPhrase: false,
+    });
   });
 
-  it('returns SaveRecoveryPhrase when cloud backup disabled', () => {
-    useSettingStore.setState({ cloudBackupEnabled: false });
+  it('returns SaveRecoveryPhrase when no backup and phrase not viewed', () => {
+    useSettingStore.setState({
+      cloudBackupEnabled: false,
+      hasViewedRecoveryPhrase: false,
+    });
     expect(getPostVerificationRoute()).toBe('SaveRecoveryPhrase');
   });
 
   it('returns AccountVerifiedSuccess when cloud backup enabled', () => {
     useSettingStore.setState({ cloudBackupEnabled: true });
+    expect(getPostVerificationRoute()).toBe('AccountVerifiedSuccess');
+  });
+
+  it('returns AccountVerifiedSuccess when phrase already viewed', () => {
+    useSettingStore.setState({ hasViewedRecoveryPhrase: true });
     expect(getPostVerificationRoute()).toBe('AccountVerifiedSuccess');
   });
 });

--- a/app/tests/utils/proving/getPostVerificationRoute.test.ts
+++ b/app/tests/utils/proving/getPostVerificationRoute.test.ts
@@ -1,31 +1,41 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
+import { act } from '@testing-library/react-native';
+
 import { useSettingStore } from '../../../src/stores/settingStore';
 import { getPostVerificationRoute } from '../../../src/utils/proving/provingMachine';
 
 describe('getPostVerificationRoute', () => {
   afterEach(() => {
-    useSettingStore.setState({
-      cloudBackupEnabled: false,
-      hasViewedRecoveryPhrase: false,
+    act(() => {
+      useSettingStore.setState({
+        cloudBackupEnabled: false,
+        hasViewedRecoveryPhrase: false,
+      });
     });
   });
 
   it('returns SaveRecoveryPhrase when no backup and phrase not viewed', () => {
-    useSettingStore.setState({
-      cloudBackupEnabled: false,
-      hasViewedRecoveryPhrase: false,
+    act(() => {
+      useSettingStore.setState({
+        cloudBackupEnabled: false,
+        hasViewedRecoveryPhrase: false,
+      });
     });
     expect(getPostVerificationRoute()).toBe('SaveRecoveryPhrase');
   });
 
   it('returns AccountVerifiedSuccess when cloud backup enabled', () => {
-    useSettingStore.setState({ cloudBackupEnabled: true });
+    act(() => {
+      useSettingStore.setState({ cloudBackupEnabled: true });
+    });
     expect(getPostVerificationRoute()).toBe('AccountVerifiedSuccess');
   });
 
   it('returns AccountVerifiedSuccess when phrase already viewed', () => {
-    useSettingStore.setState({ hasViewedRecoveryPhrase: true });
+    act(() => {
+      useSettingStore.setState({ hasViewedRecoveryPhrase: true });
+    });
     expect(getPostVerificationRoute()).toBe('AccountVerifiedSuccess');
   });
 });

--- a/app/tests/utils/proving/loadingScreenStateText.test.ts
+++ b/app/tests/utils/proving/loadingScreenStateText.test.ts
@@ -95,6 +95,63 @@ describe('stateLoadingScreenText', () => {
       // Should use RSA (4 SECONDS)
       expect(result.estimatedTime).toBe('4 SECONDS');
     });
+
+    it('should use DSC timing when type is specified as dsc', () => {
+      const result = getLoadingScreenText('proving', rsaMetadata, 'dsc');
+
+      // Should use RSA DSC (2 SECONDS) instead of register (4 SECONDS)
+      expect(result.estimatedTime).toBe('2 SECONDS');
+    });
+
+    it('should use register timing when type is specified as register', () => {
+      const result = getLoadingScreenText('proving', rsaMetadata, 'register');
+
+      // Should use RSA register (4 SECONDS)
+      expect(result.estimatedTime).toBe('4 SECONDS');
+    });
+
+    it('should default to register timing when no type is specified', () => {
+      const result = getLoadingScreenText('proving', rsaMetadata);
+
+      // Should default to register timing (4 SECONDS)
+      expect(result.estimatedTime).toBe('4 SECONDS');
+    });
+  });
+
+  describe('Circuit type specific timing estimates', () => {
+    const ecdsaMetadata: PassportMetadata = {
+      signatureAlgorithm: 'ECDSA',
+      curveOrExponent: 'secp256r1',
+    };
+
+    it('should provide correct DSC timing for ECDSA', () => {
+      const result = getLoadingScreenText('proving', ecdsaMetadata, 'dsc');
+      expect(result.estimatedTime).toBe('25 SECONDS');
+    });
+
+    it('should provide correct register timing for ECDSA', () => {
+      const result = getLoadingScreenText('proving', ecdsaMetadata, 'register');
+      expect(result.estimatedTime).toBe('50 SECONDS');
+    });
+
+    const rsaPssMetadata: PassportMetadata = {
+      signatureAlgorithm: 'RSAPSS',
+      curveOrExponent: '65537',
+    };
+
+    it('should provide correct DSC timing for RSA-PSS', () => {
+      const result = getLoadingScreenText('proving', rsaPssMetadata, 'dsc');
+      expect(result.estimatedTime).toBe('3 SECONDS');
+    });
+
+    it('should provide correct register timing for RSA-PSS', () => {
+      const result = getLoadingScreenText(
+        'proving',
+        rsaPssMetadata,
+        'register',
+      );
+      expect(result.estimatedTime).toBe('6 SECONDS');
+    });
   });
 
   describe('getProvingTimeEstimate', () => {


### PR DESCRIPTION
## Summary
- trigger backup prompt before registering on-chain for new users
- allow specifying a next screen from SaveRecoveryPhraseScreen
- mark recovery phrase as viewed when recovering account
- update `getPostVerificationRoute` logic
- adjust unit tests

## Testing
- `cd app && yarn test`

------
https://chatgpt.com/codex/tasks/task_b_686310fe83a8832dbf98fe523c4afb71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation after saving or skipping the recovery phrase is now dynamic, allowing for flexible next steps based on user actions.
  * Users are prompted to view their recovery phrase before proceeding in certain account verification flows, enhancing security.
  * Loading screen text now adapts based on the current proving circuit type, providing more accurate status information.

* **Bug Fixes**
  * Improved handling of navigation and state updates to ensure users are directed to the correct screens based on their actions.
  * Added error handling to prevent unhandled promise rejections during recovery prompt checks.
  * Enhanced error tracking and handling during proving store re-initialization to improve reliability.

* **Tests**
  * Expanded test coverage for navigation logic related to viewing the recovery phrase.
  * Added tests verifying loading screen behavior across different proving circuit types.
  * Extended timing estimate tests to cover proof type and signature algorithm variations.
  * Improved test reliability by ensuring state updates are properly flushed in recovery prompts and settings store tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->