### PR TITLE
Update settings exit flow to LaunchScreen

### DIFF
--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -32,6 +32,7 @@ import Telegram from '../../images/icons/telegram.svg';
 import Web from '../../images/icons/webpage.svg';
 import { RootStackParamList } from '../../navigation';
 import { useSettingStore } from '../../stores/settingStore';
+import { usePassport } from '../../providers/passportDataProvider';
 import {
   amber500,
   black,
@@ -133,6 +134,21 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({}) => {
   const { isDevMode, setDevModeOn } = useSettingStore();
   useSettingStore();
   const navigation = useNavigation();
+  const { getAllDocuments } = usePassport();
+
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', async () => {
+      try {
+        const docs = await getAllDocuments();
+        if (Object.keys(docs).length === 0) {
+          navigation.reset({ index: 0, routes: [{ name: 'Launch' as any }] });
+        }
+      } catch {
+        // silently fail
+      }
+    });
+    return unsubscribe;
+  }, [getAllDocuments, navigation]);
 
   const screenRoutes = useMemo(() => {
     return isDevMode ? [...routes, ...DEBUG_MENU] : routes;

--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -31,8 +31,8 @@ import Star from '../../images/icons/star.svg';
 import Telegram from '../../images/icons/telegram.svg';
 import Web from '../../images/icons/webpage.svg';
 import { RootStackParamList } from '../../navigation';
-import { useSettingStore } from '../../stores/settingStore';
 import { usePassport } from '../../providers/passportDataProvider';
+import { useSettingStore } from '../../stores/settingStore';
 import {
   amber500,
   black,

--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -32,6 +32,7 @@ import Telegram from '../../images/icons/telegram.svg';
 import Web from '../../images/icons/webpage.svg';
 import { RootStackParamList } from '../../navigation';
 import { usePassport } from '../../providers/passportDataProvider';
+import { captureException } from '../../Sentry';
 import { useSettingStore } from '../../stores/settingStore';
 import {
   amber500,
@@ -137,17 +138,50 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({}) => {
   const { getAllDocuments } = usePassport();
 
   React.useEffect(() => {
+    let isActive = true; // Flag to prevent race conditions
+
     const unsubscribe = navigation.addListener('beforeRemove', async () => {
+      if (!isActive) return; // Early return if component is unmounted
+
       try {
         const docs = await getAllDocuments();
+
+        // Double-check the component is still active after async operation
+        if (!isActive) return;
+
         if (Object.keys(docs).length === 0) {
-          navigation.reset({ index: 0, routes: [{ name: 'Launch' as any }] });
+          navigation.reset({
+            index: 0,
+            routes: [{ name: 'Launch' }], // Removed 'as any' - Launch is a valid route name
+          });
         }
-      } catch {
-        // silently fail
+      } catch (error: any) {
+        console.error(
+          'Error checking documents before navigation removal:',
+          error,
+        );
+
+        // Log error with context for debugging
+        captureException(error, {
+          context: 'settings_screen_before_remove',
+          action: 'getAllDocuments',
+        });
+
+        // Optionally, you could still navigate to Launch if there's an error
+        // This depends on your app's requirements
+        if (isActive && error?.message?.includes('no documents')) {
+          navigation.reset({
+            index: 0,
+            routes: [{ name: 'Launch' }],
+          });
+        }
       }
     });
-    return unsubscribe;
+
+    return () => {
+      isActive = false; // Mark as inactive to prevent race conditions
+      unsubscribe();
+    };
   }, [getAllDocuments, navigation]);
 
   const screenRoutes = useMemo(() => {

--- a/app/tests/src/screens/settings/SettingsScreen.test.tsx
+++ b/app/tests/src/screens/settings/SettingsScreen.test.tsx
@@ -1,0 +1,66 @@
+import { render, act, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import SettingsScreen from '../../../../src/screens/settings/SettingsScreen';
+import { usePassport } from '../../../../src/providers/passportDataProvider';
+import { useNavigation } from '@react-navigation/native';
+
+jest.mock('../../../../src/providers/passportDataProvider');
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  }),
+}));
+
+jest.mock('tamagui', () => ({
+  Button: ({ children }: any) => <>{children}</>,
+  ScrollView: ({ children }: any) => <>{children}</>,
+  View: ({ children }: any) => <>{children}</>,
+  XStack: ({ children }: any) => <>{children}</>,
+  YStack: ({ children }: any) => <>{children}</>,
+  styled: jest.fn(() => ({ children }: any) => <>{children}</>),
+}));
+
+jest.mock('@tamagui/lucide-icons', () => new Proxy({}, {
+  get: () => () => null,
+}));
+
+jest.mock('../../../../src/images/icons/github.svg', () => 'Github');
+jest.mock('../../../../src/images/icons/settings_cloud_backup.svg', () => 'Cloud');
+jest.mock('../../../../src/images/icons/settings_data.svg', () => 'Data');
+jest.mock('../../../../src/images/icons/settings_feedback.svg', () => 'Feedback');
+jest.mock('../../../../src/images/icons/settings_lock.svg', () => 'Lock');
+jest.mock('../../../../src/images/icons/share.svg', () => 'ShareIcon');
+jest.mock('../../../../src/images/icons/star.svg', () => 'Star');
+jest.mock('../../../../src/images/icons/telegram.svg', () => 'Telegram');
+jest.mock('../../../../src/images/icons/webpage.svg', () => 'Web');
+
+const mockReset = jest.fn();
+const mockAddListener = jest.fn();
+
+(useNavigation as jest.Mock).mockReturnValue({
+  reset: mockReset,
+  addListener: mockAddListener,
+});
+
+const mockGetAllDocuments = jest.fn();
+(usePassport as jest.Mock).mockReturnValue({ getAllDocuments: mockGetAllDocuments });
+
+it('redirects to Launch when leaving settings with no documents', async () => {
+  mockAddListener.mockImplementation((_evt, cb) => cb);
+  mockGetAllDocuments.mockResolvedValue({});
+  render(<SettingsScreen />);
+  const handler = mockAddListener.mock.calls[0][1];
+  await act(async () => {
+    await handler();
+  });
+  await waitFor(() => {
+    expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: 'Launch' }] });
+  });
+});

--- a/app/tests/src/screens/settings/SettingsScreen.test.tsx
+++ b/app/tests/src/screens/settings/SettingsScreen.test.tsx
@@ -1,8 +1,11 @@
-import { render, act, waitFor } from '@testing-library/react-native';
-import React from 'react';
-import SettingsScreen from '../../../../src/screens/settings/SettingsScreen';
-import { usePassport } from '../../../../src/providers/passportDataProvider';
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
 import { useNavigation } from '@react-navigation/native';
+import { act, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import { usePassport } from '../../../../src/providers/passportDataProvider';
+import SettingsScreen from '../../../../src/screens/settings/SettingsScreen';
 
 jest.mock('../../../../src/providers/passportDataProvider');
 jest.mock('@react-navigation/native', () => ({
@@ -27,14 +30,27 @@ jest.mock('tamagui', () => ({
   styled: jest.fn(() => ({ children }: any) => <>{children}</>),
 }));
 
-jest.mock('@tamagui/lucide-icons', () => new Proxy({}, {
-  get: () => () => null,
-}));
+jest.mock(
+  '@tamagui/lucide-icons',
+  () =>
+    new Proxy(
+      {},
+      {
+        get: () => () => null,
+      },
+    ),
+);
 
 jest.mock('../../../../src/images/icons/github.svg', () => 'Github');
-jest.mock('../../../../src/images/icons/settings_cloud_backup.svg', () => 'Cloud');
+jest.mock(
+  '../../../../src/images/icons/settings_cloud_backup.svg',
+  () => 'Cloud',
+);
 jest.mock('../../../../src/images/icons/settings_data.svg', () => 'Data');
-jest.mock('../../../../src/images/icons/settings_feedback.svg', () => 'Feedback');
+jest.mock(
+  '../../../../src/images/icons/settings_feedback.svg',
+  () => 'Feedback',
+);
 jest.mock('../../../../src/images/icons/settings_lock.svg', () => 'Lock');
 jest.mock('../../../../src/images/icons/share.svg', () => 'ShareIcon');
 jest.mock('../../../../src/images/icons/star.svg', () => 'Star');
@@ -50,7 +66,9 @@ const mockAddListener = jest.fn();
 });
 
 const mockGetAllDocuments = jest.fn();
-(usePassport as jest.Mock).mockReturnValue({ getAllDocuments: mockGetAllDocuments });
+(usePassport as jest.Mock).mockReturnValue({
+  getAllDocuments: mockGetAllDocuments,
+});
 
 it('redirects to Launch when leaving settings with no documents', async () => {
   mockAddListener.mockImplementation((_evt, cb) => cb);
@@ -61,6 +79,9 @@ it('redirects to Launch when leaving settings with no documents', async () => {
     await handler();
   });
   await waitFor(() => {
-    expect(mockReset).toHaveBeenCalledWith({ index: 0, routes: [{ name: 'Launch' }] });
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'Launch' }],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- ensure when all ID documents are deleted leaving Settings directs users to Launch screen
- add regression test for redirect behavior

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68634b850734832db1fdb3927b72cb17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now automatically redirects users away from the settings screen to the launch screen if no documents are present.

* **Tests**
  * Added tests to verify that users are redirected to the launch screen when there are no documents in the settings screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->