### PR TITLE
SEL-488: Fix unsupported passport logic

### DIFF
--- a/app/src/screens/misc/LoadingScreen.tsx
+++ b/app/src/screens/misc/LoadingScreen.tsx
@@ -28,7 +28,6 @@ import {
   ProvingStateType,
   useProvingStore,
 } from '../../utils/proving/provingMachine';
-import { checkPassportSupported } from '../../utils/proving/validateDocument';
 
 const { trackEvent } = analytics();
 
@@ -74,10 +73,10 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
   const canCloseApp = safeToCloseStates.includes(currentState);
 
   const handleUnsupportedPassport = async (_passportData: PassportData) => {
-    const isSupported = await checkPassportSupported(_passportData);
+    const { error_code, reason } = useProvingStore.getState();
     trackEvent(PassportEvents.UNSUPPORTED_PASSPORT, {
-      reason: isSupported.status,
-      details: isSupported.details,
+      reason: error_code,
+      details: reason,
     });
     console.log('Passport not supported');
     clearPassportData();

--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -581,6 +581,10 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             isSupported.status,
             isSupported.details,
           );
+          set({
+            error_code: isSupported.status,
+            reason: isSupported.details,
+          });
           await clearPassportData();
           actor!.send({ type: 'PASSPORT_NOT_SUPPORTED' });
           return;

--- a/app/src/utils/proving/validateDocument.ts
+++ b/app/src/utils/proving/validateDocument.ts
@@ -24,6 +24,7 @@ export type PassportSupportStatus =
   | 'csca_not_found'
   | 'registration_circuit_not_supported'
   | 'dsc_circuit_not_supported'
+  | 'protocol_data_missing'
   | 'passport_supported';
 export async function checkPassportSupported(
   passportData: PassportData,
@@ -46,9 +47,15 @@ export async function checkPassportSupported(
     'register',
   );
   const deployedCircuits =
-    useProtocolStore.getState()[document].deployed_circuits; // change this to the document type
+    useProtocolStore.getState()[document].deployed_circuits;
+  if (!deployedCircuits) {
+    console.warn('Protocol data missing: deployed circuits not loaded');
+    return { status: 'protocol_data_missing', details: 'deployed_circuits' };
+  }
   if (
     !circuitNameRegister ||
+    !deployedCircuits.REGISTER ||
+    !deployedCircuits.REGISTER_ID ||
     !(
       deployedCircuits.REGISTER.includes(circuitNameRegister) ||
       deployedCircuits.REGISTER_ID.includes(circuitNameRegister)
@@ -62,6 +69,8 @@ export async function checkPassportSupported(
   const circuitNameDsc = getCircuitNameFromPassportData(passportData, 'dsc');
   if (
     !circuitNameDsc ||
+    !deployedCircuits.DSC ||
+    !deployedCircuits.DSC_ID ||
     !(
       deployedCircuits.DSC.includes(circuitNameDsc) ||
       deployedCircuits.DSC_ID.includes(circuitNameDsc)

--- a/app/tests/src/screens/misc/LoadingScreen.test.tsx
+++ b/app/tests/src/screens/misc/LoadingScreen.test.tsx
@@ -6,6 +6,15 @@ import React from 'react';
 import LoadingScreen from '../../../../src/screens/misc/LoadingScreen';
 import { useProvingStore } from '../../../../src/utils/proving/provingMachine';
 
+jest.mock('../../../../src/utils/analytics', () => {
+  const trackEventMock = jest.fn();
+  return {
+    __esModule: true,
+    default: () => ({ trackEvent: trackEventMock }),
+    trackEventMock,
+  };
+});
+
 // Mock the proving store
 jest.mock('../../../../src/utils/proving/provingMachine');
 
@@ -259,6 +268,50 @@ describe('LoadingScreen', () => {
           'register',
         );
       });
+    });
+  });
+
+  describe('Unsupported passport handling', () => {
+    it('tracks reason from proving store', async () => {
+      const { PassportEvents } = require('../../../../src/consts/analytics');
+      const { checkPassportSupported } = require('../../../../src/utils/proving/validateDocument');
+
+      mockUseProvingStore.mockImplementation(selector => {
+        if (typeof selector === 'function') {
+          return selector({
+            currentState: 'passport_not_supported',
+            fcmToken: 'test-token',
+            circuitType: 'register',
+            error_code: 'csca_not_found',
+            reason: 'missing csca',
+          } as any);
+        }
+        return {
+          currentState: 'passport_not_supported',
+          fcmToken: 'test-token',
+          circuitType: 'register',
+          error_code: 'csca_not_found',
+          reason: 'missing csca',
+        } as any;
+      });
+
+      (mockUseProvingStore as any).getState = jest.fn().mockReturnValue({
+        circuitType: 'register',
+        error_code: 'csca_not_found',
+        reason: 'missing csca',
+      });
+
+      render(<LoadingScreen route={{} as any} />);
+
+      const { trackEventMock } = require('../../../../src/utils/analytics');
+      await waitFor(() => {
+        expect(trackEventMock).toHaveBeenCalledWith(
+          PassportEvents.UNSUPPORTED_PASSPORT,
+          { reason: 'csca_not_found', details: 'missing csca' },
+        );
+      });
+
+      expect(checkPassportSupported).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/tests/src/screens/misc/LoadingScreen.test.tsx
+++ b/app/tests/src/screens/misc/LoadingScreen.test.tsx
@@ -274,7 +274,9 @@ describe('LoadingScreen', () => {
   describe('Unsupported passport handling', () => {
     it('tracks reason from proving store', async () => {
       const { PassportEvents } = require('../../../../src/consts/analytics');
-      const { checkPassportSupported } = require('../../../../src/utils/proving/validateDocument');
+      const {
+        checkPassportSupported,
+      } = require('../../../../src/utils/proving/validateDocument');
 
       mockUseProvingStore.mockImplementation(selector => {
         if (typeof selector === 'function') {

--- a/app/tests/utils/proving/validateDocument.test.ts
+++ b/app/tests/utils/proving/validateDocument.test.ts
@@ -1,0 +1,58 @@
+import { checkPassportSupported } from '../../../src/utils/proving/validateDocument';
+import { useProtocolStore } from '../../../src/stores/protocolStore';
+import { PassportData } from '@selfxyz/common';
+
+jest.mock('@selfxyz/common', () => {
+  const actual = jest.requireActual('@selfxyz/common');
+  return {
+    ...actual,
+    getCircuitNameFromPassportData: (_pd: any, type: string) =>
+      type === 'register' ? 'register_rsa' : 'dsc_rsa',
+  };
+});
+
+describe('checkPassportSupported', () => {
+  const basePassportData: PassportData = {
+    mrz: 'mrz',
+    dsc: 'dsc',
+    eContent: [],
+    signedAttr: [],
+    encryptedDigest: [],
+    passportMetadata: { cscaFound: true, signatureAlgorithm: 'RSA', curveOrExponent: '' } as any,
+    documentType: 'passport',
+    documentCategory: 'passport',
+    mock: false,
+  };
+
+  afterEach(() => {
+    useProtocolStore.setState(state => ({
+      passport: { ...state.passport, deployed_circuits: null },
+    }));
+  });
+
+  it('returns protocol_data_missing when protocol data is absent', async () => {
+    useProtocolStore.setState(state => ({
+      passport: { ...state.passport, deployed_circuits: null },
+    }));
+
+    const result = await checkPassportSupported(basePassportData);
+    expect(result.status).toBe('protocol_data_missing');
+  });
+
+  it('returns passport_supported when circuits are available', async () => {
+    useProtocolStore.setState(state => ({
+      passport: {
+        ...state.passport,
+        deployed_circuits: {
+          REGISTER: ['register_rsa'],
+          REGISTER_ID: ['register_rsa'],
+          DSC: ['dsc_rsa'],
+          DSC_ID: ['dsc_rsa'],
+        },
+      },
+    }));
+
+    const result = await checkPassportSupported(basePassportData);
+    expect(result.status).toBe('passport_supported');
+  });
+});

--- a/app/tests/utils/proving/validateDocument.test.ts
+++ b/app/tests/utils/proving/validateDocument.test.ts
@@ -1,6 +1,9 @@
-import { checkPassportSupported } from '../../../src/utils/proving/validateDocument';
-import { useProtocolStore } from '../../../src/stores/protocolStore';
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
 import { PassportData } from '@selfxyz/common';
+
+import { useProtocolStore } from '../../../src/stores/protocolStore';
+import { checkPassportSupported } from '../../../src/utils/proving/validateDocument';
 
 jest.mock('@selfxyz/common', () => {
   const actual = jest.requireActual('@selfxyz/common');
@@ -18,7 +21,11 @@ describe('checkPassportSupported', () => {
     eContent: [],
     signedAttr: [],
     encryptedDigest: [],
-    passportMetadata: { cscaFound: true, signatureAlgorithm: 'RSA', curveOrExponent: '' } as any,
+    passportMetadata: {
+      cscaFound: true,
+      signatureAlgorithm: 'RSA',
+      curveOrExponent: '',
+    } as any,
     documentType: 'passport',
     documentCategory: 'passport',
     mock: false,


### PR DESCRIPTION
## Summary
- store unsupported reason in proving store to avoid recomputing support checks
- use stored error information in LoadingScreen when logging analytics
- handle missing protocol data when validating passports
- add unit tests for new behaviour

## Testing
- `yarn workspace @selfxyz/mobile-app test`

------
https://chatgpt.com/codex/tasks/task_b_686405ba4084832d9e3ffbfb8461857c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling and messaging for unsupported passports, including explicit error codes and reasons for unsupported cases.
  * Enhanced validation for missing protocol data when checking passport support.

* **Bug Fixes**
  * More robust detection and reporting when required protocol data is absent.

* **Tests**
  * Added new tests for unsupported passport scenarios and protocol data validation to ensure accurate analytics tracking and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->