### PR TITLE
Fix backup button label

### DIFF
--- a/app/src/screens/recovery/SaveRecoveryPhraseScreen.tsx
+++ b/app/src/screens/recovery/SaveRecoveryPhraseScreen.tsx
@@ -13,6 +13,7 @@ import useHapticNavigation from '../../hooks/useHapticNavigation';
 import useMnemonic from '../../hooks/useMnemonic';
 import { ExpandableBottomLayout } from '../../layouts/ExpandableBottomLayout';
 import { RootStackParamList } from '../../navigation';
+import { useSettingStore } from '../../stores/settingStore';
 import { STORAGE_NAME } from '../../utils/cloudBackup';
 import { black, slate400, white } from '../../utils/colors';
 import { useProvingStore } from '../../utils/proving/provingMachine';
@@ -26,6 +27,7 @@ const SaveRecoveryPhraseScreen: React.FC<SaveRecoveryPhraseScreenProps> = ({
 }) => {
   const [userHasSeenMnemonic, setUserHasSeenMnemonic] = useState(false);
   const { mnemonic, loadMnemonic } = useMnemonic();
+  const { cloudBackupEnabled } = useSettingStore();
 
   const onRevealWords = useCallback(async () => {
     await loadMnemonic();
@@ -75,7 +77,9 @@ const SaveRecoveryPhraseScreen: React.FC<SaveRecoveryPhraseScreenProps> = ({
           Manage {STORAGE_NAME} backups
         </PrimaryButton>
         <SecondaryButton onPress={onSkipPress}>
-          {userHasSeenMnemonic ? 'Continue' : 'Skip making a backup'}
+          {userHasSeenMnemonic || cloudBackupEnabled
+            ? 'Continue'
+            : 'Skip making a backup'}
         </SecondaryButton>
       </ExpandableBottomLayout.BottomSection>
     </ExpandableBottomLayout.Layout>


### PR DESCRIPTION
## Summary
- show `Continue` after a user enables cloud backups during registration

## Testing
- `yarn lint`
- `yarn types`


------
https://chatgpt.com/codex/tasks/task_b_6864332b61a4832d95bad673151c02fe