### PR TITLE
Fix safe area padding

### DIFF
--- a/app/src/layouts/ExpandableBottomLayout.tsx
+++ b/app/src/layouts/ExpandableBottomLayout.tsx
@@ -12,6 +12,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { View, ViewProps } from 'tamagui';
 
 import { black, white } from '../utils/colors';
+import { extraYPadding } from '../utils/constants';
 
 // Get the current font scale factor
 const fontScale = PixelRatio.getFontScale();
@@ -102,7 +103,7 @@ const BottomSection: React.FC<BottomSectionProps> = ({
 }) => {
   const { bottom: safeAreaBottom } = useSafeAreaInsets();
   const incomingBottom = props.paddingBottom ?? props.pb ?? 0;
-  const minBottom = Math.max(safeAreaBottom, 10);
+  const minBottom = safeAreaBottom + extraYPadding;
   const totalBottom =
     typeof incomingBottom === 'number' ? minBottom + incomingBottom : minBottom;
 

--- a/app/src/screens/dev/MockDataScreen.tsx
+++ b/app/src/screens/dev/MockDataScreen.tsx
@@ -40,6 +40,7 @@ import {
   white,
 } from '../../utils/colors';
 import { buttonTap, selectionChange } from '../../utils/haptic';
+import { extraYPadding } from '../../utils/constants';
 
 const { trackEvent } = analytics();
 
@@ -272,7 +273,7 @@ const MockDataScreen: React.FC<MockDataScreenProps> = ({}) => {
 
   const { top, bottom } = useSafeAreaInsets();
   return (
-    <YStack f={1} bg={white} pt={top} pb={bottom}>
+    <YStack f={1} bg={white} pt={top} pb={bottom + extraYPadding}>
       <ScrollView showsVerticalScrollIndicator={false}>
         <YStack px="$4" pb="$4" gap="$5">
           <GestureDetector gesture={devModeTap}>

--- a/app/src/screens/dev/MockDataScreenDeepLink.tsx
+++ b/app/src/screens/dev/MockDataScreenDeepLink.tsx
@@ -19,6 +19,7 @@ import { MockDataEvents } from '../../consts/analytics';
 import { storePassportData } from '../../providers/passportDataProvider';
 import useUserStore from '../../stores/userStore';
 import { black, borderColor, white } from '../../utils/colors';
+import { extraYPadding } from '../../utils/constants';
 
 const MockDataScreenDeepLink: React.FC = () => {
   const navigation = useNavigation();
@@ -72,7 +73,7 @@ const MockDataScreenDeepLink: React.FC = () => {
 
   const { top, bottom } = useSafeAreaInsets();
   return (
-    <YStack f={1} bg={white} pt={top} pb={bottom}>
+    <YStack f={1} bg={white} pt={top} pb={bottom + extraYPadding}>
       <ScrollView showsVerticalScrollIndicator={false}>
         <YStack px="$4" pb="$4" gap="$5">
           <YStack ai="center" mb={'$5'} mt={'$14'}>

--- a/app/src/screens/misc/LaunchScreen.tsx
+++ b/app/src/screens/misc/LaunchScreen.tsx
@@ -19,6 +19,7 @@ import useConnectionModal from '../../hooks/useConnectionModal';
 import useHapticNavigation from '../../hooks/useHapticNavigation';
 import Logo from '../../images/logo.svg';
 import { black, slate400, white, zinc800, zinc900 } from '../../utils/colors';
+import { extraYPadding } from '../../utils/constants';
 import { advercase, dinot } from '../../utils/fonts';
 
 const LaunchScreen: React.FC = () => {
@@ -40,7 +41,7 @@ const LaunchScreen: React.FC = () => {
       justifyContent="space-between"
       alignItems="center"
       paddingHorizontal={20}
-      paddingBottom={bottom}
+      paddingBottom={bottom + extraYPadding}
     >
       <View style={styles.container}>
         <View style={styles.card}>

--- a/app/src/screens/misc/LoadingScreen.tsx
+++ b/app/src/screens/misc/LoadingScreen.tsx
@@ -22,6 +22,7 @@ import analytics from '../../utils/analytics';
 import { black, slate400, white, zinc500, zinc900 } from '../../utils/colors';
 import { advercase, dinot } from '../../utils/fonts';
 import { loadingScreenProgress } from '../../utils/haptic';
+import { extraYPadding } from '../../utils/constants';
 import { setupNotifications } from '../../utils/notifications/notificationService';
 import { getLoadingScreenText } from '../../utils/proving/loadingScreenStateText';
 import {
@@ -205,7 +206,7 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
       jc="space-between"
       flex={1}
       paddingHorizontal={20}
-      paddingBottom={bottom}
+      paddingBottom={bottom + extraYPadding}
     >
       <View style={styles.container}>
         <View style={styles.card}>


### PR DESCRIPTION
## Summary
- bump up bottom padding using extraYPadding in `ExpandableBottomLayout`
- use `extraYPadding` on misc screens and dev tools

## Testing
- `yarn workspace @selfxyz/mobile-app test`
- `yarn gitleaks` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68649c7a5410832db22a1a774c136f82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the bottom padding across several screens to provide additional spacing beyond the device's safe area inset. This change affects the layout of the bottom area in various screens, offering a more consistent and visually appealing spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->