### PR TITLE
Update fastlane and tests for mobile deployment

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -8,7 +8,7 @@ gem "cocoapods", ">= 1.13", "!= 1.15.0", "!= 1.15.1"
 gem "activesupport", ">= 6.1.7.5", "!= 7.1.0"
 
 # Add fastlane for CI/CD
-gem "fastlane", "~> 2.227.0"
+gem "fastlane", "~> 2.228.0"
 
 group :development do
   gem "dotenv"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.227.1)
+    fastlane (2.228.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -305,7 +305,7 @@ DEPENDENCIES
   activesupport (>= 6.1.7.5, != 7.1.0)
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
   dotenv
-  fastlane (~> 2.227.0)
+  fastlane (~> 2.228.0)
   fastlane-plugin-increment_version_code
   fastlane-plugin-versioning_android
   nokogiri (~> 1.18)

--- a/app/fastlane/helpers/android.rb
+++ b/app/fastlane/helpers/android.rb
@@ -3,21 +3,25 @@ module Fastlane
     module Android
       @@android_has_permissions = false
 
+      def self.set_permissions(value)
+        @@android_has_permissions = value
+      end
+
       # Decode keystore from ENV for local development
       def android_create_keystore(path)
-        if ENV["ANDROID_KEYSTORE"]
-          FileUtils.mkdir_p(File.dirname(path))
-          File.write(path, Base64.decode64(ENV["ANDROID_KEYSTORE"]))
-        end
+        return nil unless ENV["ANDROID_KEYSTORE"]
+
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, Base64.decode64(ENV["ANDROID_KEYSTORE"]))
         File.realpath(path)
       end
 
       # Decode Play Store JSON key from ENV
       def android_create_play_store_key(path)
-        if ENV["ANDROID_PLAY_STORE_JSON_KEY_BASE64"]
-          FileUtils.mkdir_p(File.dirname(path))
-          File.write(path, Base64.decode64(ENV["ANDROID_PLAY_STORE_JSON_KEY_BASE64"]))
-        end
+        return nil unless ENV["ANDROID_PLAY_STORE_JSON_KEY_BASE64"]
+
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, Base64.decode64(ENV["ANDROID_PLAY_STORE_JSON_KEY_BASE64"]))
         File.realpath(path)
       end
 
@@ -45,7 +49,7 @@ module Fastlane
 
       # Increment version code locally (Play Store fetch disabled)
       def android_increment_version_code(gradle_file)
-        full = File.expand_path(gradle_file, File.dirname(__FILE__))
+        full = File.expand_path(gradle_file)
         raise "Could not find build.gradle" unless File.exist?(full)
         content = File.read(full)
         match = content.match(/versionCode\s+(\d+)/)

--- a/app/fastlane/helpers/ios.rb
+++ b/app/fastlane/helpers/ios.rb
@@ -3,12 +3,7 @@ module Fastlane
     module IOS
       # Verify the build number is higher than TestFlight
       def ios_verify_app_store_build_number(xcodeproj)
-        api_key = Fastlane::Actions::AppStoreConnectApiKeyAction.run(
-          key_id: ENV["IOS_CONNECT_KEY_ID"],
-          issuer_id: ENV["IOS_CONNECT_ISSUER_ID"],
-          key_filepath: ENV["IOS_CONNECT_API_KEY_PATH"],
-          in_house: false
-        )
+        api_key = ios_connect_api_key
 
         latest = Fastlane::Actions::LatestTestflightBuildNumberAction.run(
           api_key: api_key,
@@ -18,7 +13,13 @@ module Fastlane
 
         project = Xcodeproj::Project.open(xcodeproj)
         target = project.targets.first
-        current = target.build_configurations.first.build_settings["CURRENT_PROJECT_VERSION"]
+        report_error("No targets found in Xcode project") unless target
+
+        config = target.build_configurations.first
+        report_error("No build configurations found for target") unless config
+
+        current = config.build_settings["CURRENT_PROJECT_VERSION"]
+        report_error("CURRENT_PROJECT_VERSION not set in build settings") unless current
 
         if current.to_i <= latest.to_i
           report_error(
@@ -46,15 +47,19 @@ module Fastlane
         report_success("Enabled Apple Generic Versioning in Xcode project")
       end
 
-      # Increment the build number based on latest TestFlight build
-      def ios_increment_build_number(xcodeproj)
-        ios_ensure_generic_versioning(xcodeproj)
-        api_key = Fastlane::Actions::AppStoreConnectApiKeyAction.run(
+      def ios_connect_api_key
+        Fastlane::Actions::AppStoreConnectApiKeyAction.run(
           key_id: ENV["IOS_CONNECT_KEY_ID"],
           issuer_id: ENV["IOS_CONNECT_ISSUER_ID"],
           key_filepath: ENV["IOS_CONNECT_API_KEY_PATH"],
-          in_house: false
+          in_house: false,
         )
+      end
+
+      # Increment the build number based on latest TestFlight build
+      def ios_increment_build_number(xcodeproj)
+        ios_ensure_generic_versioning(xcodeproj)
+        api_key = ios_connect_api_key
 
         latest = Fastlane::Actions::LatestTestflightBuildNumberAction.run(
           api_key: api_key,
@@ -74,13 +79,15 @@ module Fastlane
       # Decode certificate from ENV and import into keychain
       def ios_dev_setup_certificate
         data = ENV["IOS_DIST_CERT_BASE64"]
-        pass = ENV["IOS_P12_PASSWORD"] || ""
+        pass = ENV["IOS_P12_PASSWORD"]
+        report_error("Missing IOS_P12_PASSWORD") unless pass
         report_error("Missing IOS_DIST_CERT_BASE64") unless data
         tmp = Tempfile.new(["fastlane_local_cert", ".p12"])
         tmp.binmode
         tmp.write(Base64.decode64(data))
         tmp.close
-        system("security import #{Shellwords.escape(tmp.path)} -P #{Shellwords.escape(pass)} -T /usr/bin/codesign")
+        success = system("security import #{Shellwords.escape(tmp.path)} -P #{Shellwords.escape(pass)} -T /usr/bin/codesign")
+        report_error("Failed to import certificate into keychain") unless success
         report_success("Certificate imported successfully into default keychain")
       ensure
         tmp&.unlink
@@ -93,6 +100,7 @@ module Fastlane
         if ENV["IOS_CONNECT_API_KEY_BASE64"]
           FileUtils.mkdir_p(File.dirname(full))
           File.write(full, Base64.decode64(ENV["IOS_CONNECT_API_KEY_BASE64"]))
+          File.chmod(0600, full)
           report_success("Connect API Key written to: #{full}")
         end
         File.realpath(full)
@@ -109,8 +117,10 @@ module Fastlane
         tmp_profile.close
 
         tmp_plist = Tempfile.new(["fastlane_temp_plist", ".plist"])
-        system("security cms -D -i #{Shellwords.escape(tmp_profile.path)} -o #{Shellwords.escape(tmp_plist.path)}")
-        uuid = `/usr/libexec/PlistBuddy -c "Print :UUID" #{Shellwords.escape(tmp_plist.path)}`.strip
+        success = system("security cms -D -i #{Shellwords.escape(tmp_profile.path)} -o #{Shellwords.escape(tmp_plist.path)}")
+        report_error("Failed to decode provisioning profile") unless success
+        uuid = `/usr/libexec/PlistBuddy -c "Print :UUID" #{Shellwords.escape(tmp_plist.path)} 2>/dev/null`.strip
+        report_error("Failed to extract UUID from provisioning profile") if uuid.empty?
 
         target_dir = File.expand_path(dir)
         FileUtils.mkdir_p(target_dir)

--- a/app/fastlane/test/helpers_test.rb
+++ b/app/fastlane/test/helpers_test.rb
@@ -6,7 +6,7 @@ class HelpersTest < Minitest::Test
     @gradle = Tempfile.new(['build', '.gradle'])
     @gradle.write("versionCode 5\n")
     @gradle.close
-    Fastlane::Helpers::Android.class_variable_set(:@@android_has_permissions, true)
+    Fastlane::Helpers::Android.set_permissions(true)
   end
 
   def teardown
@@ -20,6 +20,7 @@ class HelpersTest < Minitest::Test
   end
 
   def test_should_upload_app
+    assert_respond_to Fastlane::Helpers, :should_upload_app
     ENV.delete('CI')
     ENV.delete('FORCE_UPLOAD_LOCAL_DEV')
     ENV.delete('ACT')
@@ -29,5 +30,27 @@ class HelpersTest < Minitest::Test
     assert_equal true, Fastlane::Helpers.should_upload_app('ios')
   ensure
     ENV.delete('FORCE_UPLOAD_LOCAL_DEV')
+  end
+
+  def test_should_upload_app_with_ci
+    ENV['CI'] = 'true'
+    %w[FORCE_UPLOAD_LOCAL_DEV ACT IS_PR].each { |v| ENV.delete(v) }
+    assert_equal true, Fastlane::Helpers.should_upload_app('ios')
+  ensure
+    ENV.delete('CI')
+  end
+
+  def test_should_upload_app_with_act_or_is_pr
+    %w[ACT IS_PR].each do |flag|
+      ENV[flag] = 'true'
+      %w[CI FORCE_UPLOAD_LOCAL_DEV].each { |v| ENV.delete(v) }
+      assert_equal false, Fastlane::Helpers.should_upload_app('ios'), "#{flag} should block upload"
+      ENV.delete(flag)
+    end
+  end
+
+  def test_should_upload_app_with_invalid_platform
+    %w[CI ACT IS_PR FORCE_UPLOAD_LOCAL_DEV].each { |v| ENV.delete(v) }
+    assert_equal false, Fastlane::Helpers.should_upload_app(nil)
   end
 end


### PR DESCRIPTION
## Summary
- update fastlane to 2.228.0
- add method for setting Android fastlane permissions
- improve Android keystore helpers
- update iOS helpers for better error handling and API key security
- expand helper test coverage

## Testing
- `yarn test` *(fails: script not found)*
- `RBENV_VERSION=3.2.3 bundle exec ruby fastlane/test/helpers_test.rb` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_b_6866db2c14f4832d8e18ea07ab9f7527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting for iOS build and provisioning tasks, including better detection of missing environment variables and file operation failures.
  * Enhanced Android helper methods to handle missing environment variables more explicitly.

* **Refactor**
  * Increased code modularity and reuse in iOS helpers by introducing a dedicated method for API key creation.
  * Simplified file path resolution in Android version code increment logic.

* **Tests**
  * Expanded test coverage for environment-dependent logic, especially for app upload conditions.

* **Chores**
  * Updated the Fastlane dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->