### PR TITLE
Clean stale ios refs and type config

### DIFF
--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -41,6 +41,12 @@ module.exports = {
 
     // Override any ESLint rules that conflict with the TypeScript union type formatting
     '@typescript-eslint/indent': 'off',
+
+    // Enable key linting rules with warnings so violations surface without
+    // blocking development
+    'no-console': 'warn',
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
   },
   overrides: [
     {

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -19,9 +19,6 @@
 		1686F0DC2C500F3800841CDE /* QRScannerBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0DB2C500F3800841CDE /* QRScannerBridge.swift */; };
 		1686F0DE2C500F4F00841CDE /* QRScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0DD2C500F4F00841CDE /* QRScannerViewController.swift */; };
 		1686F0E02C500FBD00841CDE /* QRScannerBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0DF2C500FBD00841CDE /* QRScannerBridge.m */; };
-		1686F0E42C500FBD00841CDE /* DocumentScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0E12C500FBD00841CDE /* DocumentScanner.swift */; };
-		1686F0E52C500FBD00841CDE /* DocumentScannerBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0E22C500FBD00841CDE /* DocumentScannerBridge.m */; };
-		1686F0E62C500FBD00841CDE /* DocumentScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0E32C500FBD00841CDE /* DocumentScannerViewController.swift */; };
 		16E6646E2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E6646D2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift */; };
 		16E884A52C5BD764003B7125 /* passport.json in Resources */ = {isa = PBXBuildFile; fileRef = 16E884A42C5BD764003B7125 /* passport.json */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
@@ -55,9 +52,6 @@
 		1686F0DB2C500F3800841CDE /* QRScannerBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerBridge.swift; sourceTree = "<group>"; };
 		1686F0DD2C500F4F00841CDE /* QRScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerViewController.swift; sourceTree = "<group>"; };
 		1686F0DF2C500FBD00841CDE /* QRScannerBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QRScannerBridge.m; sourceTree = "<group>"; };
-		1686F0E12C500FBD00841CDE /* DocumentScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentScanner.swift; sourceTree = "<group>"; };
-		1686F0E22C500FBD00841CDE /* DocumentScannerBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DocumentScannerBridge.m; sourceTree = "<group>"; };
-		1686F0E32C500FBD00841CDE /* DocumentScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentScannerViewController.swift; sourceTree = "<group>"; };
 		169349842CC694DA00166F21 /* OpenPassportDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = OpenPassportDebug.entitlements; path = OpenPassport/OpenPassportDebug.entitlements; sourceTree = "<group>"; };
 		16E6646D2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QKMRZScannerViewRepresentable.swift; sourceTree = "<group>"; };
 		16E884A42C5BD764003B7125 /* passport.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = passport.json; sourceTree = "<group>"; };
@@ -123,9 +117,6 @@
 				1648EB772CC9564D003BEA7D /* LottieView.swift */,
 				164FD9662D569A640067E63B /* QRCodeScannerViewManager.swift */,
 				164FD9682D569C1F0067E63B /* QRCodeScannerViewManager.m */,
-				1686F0E12C500FBD00841CDE /* DocumentScanner.swift */,
-				1686F0E22C500FBD00841CDE /* DocumentScannerBridge.m */,
-				1686F0E32C500FBD00841CDE /* DocumentScannerViewController.swift */,
 			);
 			name = OpenPassport;
 			sourceTree = "<group>";
@@ -393,9 +384,6 @@
 				165E76BD2B8DC4A00000FA90 /* MRZScannerModule.swift in Sources */,
 				BF1044812DD53540009B3688 /* LiveMRZScannerView.swift in Sources */,
 				164FD9692D569C1F0067E63B /* QRCodeScannerViewManager.m in Sources */,
-				1686F0E42C500FBD00841CDE /* DocumentScanner.swift in Sources */,
-				1686F0E52C500FBD00841CDE /* DocumentScannerBridge.m in Sources */,
-				1686F0E62C500FBD00841CDE /* DocumentScannerViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/app/src/components/buttons/AbstractButton.tsx
+++ b/app/src/components/buttons/AbstractButton.tsx
@@ -19,7 +19,7 @@ interface AbstractButtonProps extends ButtonProps {
   bgColor: string;
   borderColor?: string;
   color: string;
-  onPress?: ((e: any) => void) | null | undefined;
+  onPress?: (e: any) => void;
 }
 
 const { trackEvent: analyticsTrackEvent } = analytics();

--- a/app/src/components/native/RCTFragment.tsx
+++ b/app/src/components/native/RCTFragment.tsx
@@ -33,7 +33,7 @@ function dispatchCommand(
   try {
     UIManager.dispatchViewManagerCommand(
       viewId,
-      UIManager.getViewManagerConfig(fragmentComponentName).Commands[
+      (UIManager.getViewManagerConfig(fragmentComponentName) as any).Commands[
         command
       ].toString(),
       [viewId],

--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -284,9 +284,8 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
       checkNfcSupport();
 
       if (Platform.OS === 'android' && emitter) {
-        const subscription = emitter.addListener(
-          'NativeEvent',
-          (event: string) => console.info(event),
+        const subscription = emitter.addListener('NativeEvent', (event: any) =>
+          console.info(event),
         );
 
         return () => {

--- a/app/src/screens/prove/ProveScreen.tsx
+++ b/app/src/screens/prove/ProveScreen.tsx
@@ -49,7 +49,7 @@ const ProveScreen: React.FC = () => {
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [scrollViewContentHeight, setScrollViewContentHeight] = useState(0);
   const [scrollViewHeight, setScrollViewHeight] = useState(0);
-  const scrollViewRef = useRef<ScrollView>(null);
+  const scrollViewRef = useRef<any>(null);
 
   const isContentShorterThanScrollView = useMemo(
     () => scrollViewContentHeight <= scrollViewHeight,

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -5,7 +5,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "customConditions": ["react-native-strict-api"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "allowJs": false
   },
   "exclude": [
     "node_modules",

--- a/common/package.json
+++ b/common/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@types/js-sha1": "^0.6.3",
+    "@types/node": "^20.11.19",
     "@types/node-forge": "^1.3.10",
     "mocha": "^10.7.3",
     "prettier": "^3.3.3",

--- a/sdk/core/tsconfig.json
+++ b/sdk/core/tsconfig.json
@@ -13,7 +13,13 @@
     "moduleResolution": "node16",
     "baseUrl": "."
   },
-  "include": ["index.ts", "src/**/*", "circuits/**/*", "circuits/**/*.json", "utils/utils.ts"],
+  "include": [
+    "index.ts",
+    "src/**/*",
+    "circuits/**/*",
+    "circuits/**/*.json",
+    "src/utils/utils.ts"
+  ],
   "exclude": [
     "node_modules",
     "**/__tests__/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4002,6 +4002,7 @@ __metadata:
     "@openpassport/zk-kit-lean-imt": "npm:^0.0.6"
     "@openpassport/zk-kit-smt": "npm:^0.0.1"
     "@types/js-sha1": "npm:^0.6.3"
+    "@types/node": "npm:^20.11.19"
     "@types/node-forge": "npm:^1.3.10"
     asn1.js: "npm:^5.4.1"
     asn1js: "npm:^3.0.5"


### PR DESCRIPTION
## Summary
- remove DocumentScanner source references from iOS project
- add `@types/node` to common package dev deps
- fix utils path in core tsconfig
- disable allowJs for mobile tsconfig and fix resulting type errors
- enable warnings for console, explicit any, and unused vars in ESLint

## Testing
- `pod install` *(fails: command not found)*
- `yarn workspace @selfxyz/common run types`
- `yarn workspace @selfxyz/core run types`
- `yarn types`


------
https://chatgpt.com/codex/tasks/task_b_6867ee657d18832d8b9815ec4e72fe43