### PR TITLE
Improve mobile deployment tooling

### DIFF
--- a/app/fastlane/DEV.md
+++ b/app/fastlane/DEV.md
@@ -116,6 +116,12 @@ yarn mobile-local-deploy:android  # Deploy Android to Google Play Internal Testi
 
 **Why internal testing?** This provides the same safety as GitHub runner deployments while allowing you to use your local machine for building.
 
+After running a local iOS deploy, reset the Xcode project to avoid committing build artifacts:
+
+```bash
+./scripts/cleanup-ios-build.sh
+```
+
 ### Direct Fastlane Commands (Not Recommended)
 
 ⚠️ **Use the confirmation script above instead of these direct commands.**
@@ -218,7 +224,7 @@ Fastlane requires various secrets to interact with the app stores and sign appli
 | `IOS_P12_PASSWORD` | Password for the p12 certificate file |
 | `IOS_TEAM_ID` | Apple Developer Team ID |
 | `IOS_TEAM_NAME` | Apple Developer Team name |
-| `IOS_TESTFLIGHT_GROUPS` | Comma-separated list of TestFlight groups to distribute the app to |
+| `IOS_TESTFLIGHT_GROUPS` | Comma-separated list of **external** TestFlight groups to distribute the app to |
 
 #### Slack Integration Secrets 📱
 

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -22,6 +22,11 @@ android_has_permissions = false
 
 # Project configuration
 PROJECT_NAME = ENV["IOS_PROJECT_NAME"]
+APP_NAME = ENV["IOS_PROJECT_NAME"] || begin
+  JSON.parse(File.read("../app.json"))["displayName"]
+rescue
+  nil
+end || "MobileApp"
 PROJECT_SCHEME = ENV["IOS_PROJECT_SCHEME"]
 SIGNING_CERTIFICATE = ENV["IOS_SIGNING_CERTIFICATE"]
 
@@ -54,7 +59,7 @@ platform :ios do
     upload_to_testflight(
       api_key: result[:api_key],
       distribute_external: true,
-      # TODO: fix error about the groups not being set correctly, fwiw groups are set in the app store connect
+      # Only external TestFlight groups are valid here
       groups: ENV["IOS_TESTFLIGHT_GROUPS"].split(","),
       changelog: "",
       skip_waiting_for_build_processing: false,
@@ -66,7 +71,7 @@ platform :ios do
         file_path: result[:ipa_path],
         channel_id: ENV["SLACK_CHANNEL_ID"],
         initial_comment: "🍎 iOS v#{package_version} (Build #{result[:build_number]}) deployed to TestFlight",
-        title: "#{PROJECT_NAME}-#{package_version}-#{result[:build_number]}.ipa",
+        title: "#{APP_NAME}-#{package_version}-#{result[:build_number]}.ipa",
       )
     else
       UI.important("Skipping Slack notification: SLACK_CHANNEL_ID not set.")
@@ -266,7 +271,7 @@ platform :android do
         file_path: android_aab_path,
         channel_id: ENV["SLACK_CHANNEL_ID"],
         initial_comment: "🤖 Android v#{package_version} (Build #{version_code}) deployed to #{target_platform}",
-        title: "#{PROJECT_NAME}-#{package_version}-#{version_code}.aab",
+        title: "#{APP_NAME}-#{package_version}-#{version_code}.aab",
       )
     else
       UI.important("Skipping Slack notification: SLACK_CHANNEL_ID not set.")

--- a/app/fastlane/helpers/slack.rb
+++ b/app/fastlane/helpers/slack.rb
@@ -5,6 +5,7 @@ module Fastlane
       def upload_file_to_slack(file_path:, channel_id:, initial_comment: nil, thread_ts: nil, title: nil)
         slack_token = ENV["SLACK_API_TOKEN"]
         report_error("Missing SLACK_API_TOKEN environment variable.", nil, "Slack Upload Failed") if slack_token.to_s.strip.empty?
+        report_error("Missing SLACK_CHANNEL_ID environment variable.", nil, "Slack Upload Failed") if channel_id.to_s.strip.empty?
         report_error("File not found at path: #{file_path}", nil, "Slack Upload Failed") unless File.exist?(file_path)
 
         file_name = File.basename(file_path)

--- a/app/fastlane/test/helpers_test.rb
+++ b/app/fastlane/test/helpers_test.rb
@@ -328,6 +328,20 @@ class HelpersTest < Minitest::Test
     assert_equal ["MISSING_VAR1", "EMPTY_VAR", "WHITESPACE_VAR"], missing
   end
 
+  def test_upload_file_to_slack_missing_channel
+    ENV["SLACK_API_TOKEN"] = "token"
+    file = Tempfile.new(["artifact", ".txt"])
+    file.write("data")
+    file.close
+
+    assert_raises(FastlaneCore::Interface::FastlaneCommonException) do
+      Fastlane::Helpers.upload_file_to_slack(file_path: file.path, channel_id: "")
+    end
+  ensure
+    file.unlink
+    ENV.delete("SLACK_API_TOKEN")
+  end
+
   private
 
   def clear_test_env_vars

--- a/app/scripts/cleanup-ios-build.sh
+++ b/app/scripts/cleanup-ios-build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Reset Xcode project after local fastlane builds
+set -euo pipefail
+
+PROJECT_NAME="${IOS_PROJECT_NAME:-Self}"
+PBXPROJ="ios/${PROJECT_NAME}.xcodeproj/project.pbxproj"
+
+if [ ! -f "$PBXPROJ" ]; then
+  echo "Project file not found: $PBXPROJ" >&2
+  exit 1
+fi
+
+MARKETING_VERSION=$(grep -m1 "MARKETING_VERSION =" "$PBXPROJ" | awk '{print $3}' | tr -d ';')
+CURRENT_VERSION=$(grep -m1 "CURRENT_PROJECT_VERSION =" "$PBXPROJ" | awk '{print $3}' | tr -d ';')
+
+git checkout -- "$PBXPROJ"
+
+if sed --version >/dev/null 2>&1; then
+  sed -i -e "s/\(MARKETING_VERSION = \).*/\1$MARKETING_VERSION;/" -e "s/\(CURRENT_PROJECT_VERSION = \).*/\1$CURRENT_VERSION;/" "$PBXPROJ"
+else
+  sed -i '' -e "s/\(MARKETING_VERSION = \).*/\1$MARKETING_VERSION;/" -e "s/\(CURRENT_PROJECT_VERSION = \).*/\1$CURRENT_VERSION;/" "$PBXPROJ"
+fi
+
+echo "Reset $PBXPROJ"

--- a/app/scripts/tests/cleanup-ios-build.test.cjs
+++ b/app/scripts/tests/cleanup-ios-build.test.cjs
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const SCRIPT = path.join(__dirname, '../cleanup-ios-build.sh');
+
+describe('cleanup-ios-build.sh', () => {
+  it('resets pbxproj and reapplies versions', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-test-'));
+    const projectName = 'MyApp';
+    const iosDir = path.join(tmp, 'ios', `${projectName}.xcodeproj`);
+    fs.mkdirSync(iosDir, { recursive: true });
+    const pbxPath = path.join(iosDir, 'project.pbxproj');
+    fs.writeFileSync(
+      pbxPath,
+      'CURRENT_PROJECT_VERSION = 1;\nMARKETING_VERSION = 1.0.0;\n',
+    );
+
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    execSync('git init -q');
+    execSync('git config user.email "test@example.com"');
+    execSync('git config user.name "Test"');
+    execSync(`git add ${pbxPath}`);
+    execSync('git commit -m init -q');
+
+    fs.writeFileSync(
+      pbxPath,
+      'CURRENT_PROJECT_VERSION = 2;\nMARKETING_VERSION = 2.0.0;\nSomeArtifact = 123;\n',
+    );
+
+    execSync(`IOS_PROJECT_NAME=${projectName} bash ${SCRIPT}`);
+    process.chdir(cwd);
+
+    const result = fs.readFileSync(pbxPath, 'utf8');
+    assert(result.includes('CURRENT_PROJECT_VERSION = 2;'));
+    assert(result.includes('MARKETING_VERSION = 2.0.0;'));
+    assert(!result.includes('SomeArtifact'));
+  });
+});


### PR DESCRIPTION
## Summary
- add `APP_NAME` constant and use for Slack artifact titles
- note only external TestFlight groups are allowed
- validate Slack channel ID before uploading
- add cleanup script for local iOS builds
- document cleanup step and TestFlight group requirement
- test Slack validation and cleanup script

## Testing
- `node --test scripts/tests/cleanup-ios-build.test.cjs`
- `RBENV_VERSION=3.2.3 bundle exec ruby -Itest fastlane/test/helpers_test.rb`

------
https://chatgpt.com/codex/tasks/task_b_686b04f3a6a4832d900d3fbf37d81004