### PR TITLE
Extend platform build file tests

### DIFF
--- a/app/tests/src/androidBuildGradle.test.ts
+++ b/app/tests/src/androidBuildGradle.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+/**
+ * @jest-environment node
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Android build.gradle Configuration', () => {
+  const gradlePath = path.join(__dirname, '../../android/app/build.gradle');
+  const rootGradlePath = path.join(__dirname, '../../android/build.gradle');
+  let gradleContent: string;
+  let rootGradleContent: string;
+
+  beforeAll(() => {
+    gradleContent = fs.readFileSync(gradlePath, 'utf8');
+    rootGradleContent = fs.readFileSync(rootGradlePath, 'utf8');
+  });
+
+  it('uses the correct applicationId and version', () => {
+    expect(gradleContent).toMatch(/applicationId\s+"com\.proofofpassportapp"/);
+    expect(gradleContent).toMatch(/versionName\s+"2.6.1"/);
+    expect(gradleContent).toMatch(/versionCode\s+82/);
+  });
+
+  it('references SDK versions from the root project', () => {
+    expect(gradleContent).toMatch(
+      /minSdkVersion\s+rootProject\.ext\.minSdkVersion/,
+    );
+    expect(gradleContent).toMatch(
+      /targetSdkVersion\s+rootProject\.ext\.targetSdkVersion/,
+    );
+  });
+
+  it('sets the expected SDK version numbers', () => {
+    expect(rootGradleContent).toMatch(/minSdkVersion\s*=\s*23/);
+    expect(rootGradleContent).toMatch(/targetSdkVersion\s*=\s*35/);
+  });
+
+  it('includes Firebase messaging dependency', () => {
+    expect(gradleContent).toContain('com.google.firebase:firebase-messaging');
+  });
+});

--- a/app/tests/src/iosInfoPlist.test.ts
+++ b/app/tests/src/iosInfoPlist.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+/**
+ * @jest-environment node
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('iOS Info.plist Configuration', () => {
+  const plistPath = path.join(__dirname, '../../ios/OpenPassport/Info.plist');
+  let plistContent: string;
+
+  beforeAll(() => {
+    plistContent = fs.readFileSync(plistPath, 'utf8');
+  });
+
+  it('contains the proofofpassport URL scheme', () => {
+    const regex =
+      /<key>CFBundleURLSchemes<\/key>\s*<array>\s*<string>proofofpassport<\/string>/s;
+    expect(plistContent).toMatch(regex);
+  });
+
+  it('has NFC and camera usage descriptions', () => {
+    expect(plistContent).toContain('<key>NFCReaderUsageDescription</key>');
+    expect(plistContent).toContain('<key>NSCameraUsageDescription</key>');
+  });
+
+  it('lists required fonts', () => {
+    expect(plistContent).toContain('<string>Advercase-Regular.otf</string>');
+    expect(plistContent).toContain('<string>DINOT-Medium.otf</string>');
+  });
+});

--- a/app/tests/src/iosPbxproj.test.ts
+++ b/app/tests/src/iosPbxproj.test.ts
@@ -15,7 +15,13 @@ describe('iOS project.pbxproj Configuration', () => {
   let projectContent: string;
 
   beforeAll(() => {
-    projectContent = fs.readFileSync(projectPath, 'utf8');
+    try {
+      projectContent = fs.readFileSync(projectPath, 'utf8');
+    } catch (error) {
+      throw new Error(
+        `Failed to read iOS project file at ${projectPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   });
 
   it('uses the correct bundle identifier', () => {

--- a/app/tests/src/iosPbxproj.test.ts
+++ b/app/tests/src/iosPbxproj.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+/**
+ * @jest-environment node
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('iOS project.pbxproj Configuration', () => {
+  const projectPath = path.join(
+    __dirname,
+    '../../ios/Self.xcodeproj/project.pbxproj',
+  );
+  let projectContent: string;
+
+  beforeAll(() => {
+    projectContent = fs.readFileSync(projectPath, 'utf8');
+  });
+
+  it('uses the correct bundle identifier', () => {
+    expect(projectContent).toMatch(
+      /PRODUCT_BUNDLE_IDENTIFIER\s*=\s*com\.warroom\.proofofpassport;/,
+    );
+  });
+
+  it('has the expected development team set', () => {
+    expect(projectContent).toMatch(/DEVELOPMENT_TEAM\s*=\s*5B29R5LYHQ;/);
+  });
+
+  it('includes GoogleService-Info.plist in resources', () => {
+    expect(projectContent).toContain('GoogleService-Info.plist in Resources');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for iOS Info.plist, project.pbxproj and Android build.gradle
- ensure tests use license headers
- verify SDK versions are read from root Gradle file

## Testing
- `yarn fmt:fix`
- `yarn lint`
- `yarn workspace @selfxyz/mobile-app test`

------
https://chatgpt.com/codex/tasks/task_b_686b08533a34832d9ef4aabfebcf0217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new automated tests to verify Android Gradle build configuration, including application ID, versioning, SDK versions, and Firebase dependency.
  * Introduced tests to ensure iOS Info.plist includes required URL schemes, usage descriptions for NFC and camera, and necessary font files.
  * Added tests to validate iOS Xcode project configuration, checking bundle identifier, development team, and inclusion of GoogleService-Info.plist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->