### PR TITLE
Trigger NFC scan on screen focus

### DIFF
--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -300,7 +300,11 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
 
   useFocusEffect(
     useCallback(() => {
-      checkNfcSupport();
+      checkNfcSupport().then(() => {
+        setTimeout(() => {
+          onVerifyPress();
+        }, 100);
+      });
 
       if (Platform.OS === 'android' && emitter) {
         const subscription = emitter.addListener(
@@ -316,7 +320,7 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
           subscription.remove();
         };
       }
-    }, [checkNfcSupport]),
+    }, [checkNfcSupport, onVerifyPress]),
   );
 
   return (


### PR DESCRIPTION
## Summary
- automatically start NFC scan when `PassportNFCScanScreen` is focused

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Hardhat config error)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm)*
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_687975c26e14832d870e668440580997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the NFC support check and automatic verification process when the screen gains focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->