### PR TITLE
Add auto scan on focus

### DIFF
--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -288,6 +288,15 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
     isPacePolling,
   ]);
 
+  useFocusEffect(
+    useCallback(() => {
+      const timer = setTimeout(() => {
+        onVerifyPress();
+      }, 150); // short delay to ensure window focus
+      return () => clearTimeout(timer);
+    }, [onVerifyPress]),
+  );
+
   const onCancelPress = useHapticNavigation('Launch', {
     action: 'cancel',
   });


### PR DESCRIPTION
## Summary
- trigger a scan automatically when the NFC scan screen gains focus

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_687d6174fa54832d93a4abec51e0564d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NFC verification now starts automatically shortly after the Passport NFC Scan screen becomes active, removing the need for manual initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->