### PR TITLE
Auto-start NFC scan

### DIFF
--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -87,6 +87,7 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
   const [isNfcEnabled, setIsNfcEnabled] = useState(true);
   const [isNfcSheetOpen, setIsNfcSheetOpen] = useState(false);
   const [dialogMessage, setDialogMessage] = useState('');
+  const [hasStarted, setHasStarted] = useState(false);
 
   const animationRef = useRef<LottieView>(null);
 
@@ -302,6 +303,11 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
     useCallback(() => {
       checkNfcSupport();
 
+      if (!hasStarted && isNfcEnabled) {
+        setHasStarted(true);
+        onVerifyPress();
+      }
+
       if (Platform.OS === 'android' && emitter) {
         const subscription = emitter.addListener(
           'NativeEvent',
@@ -316,7 +322,7 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
           subscription.remove();
         };
       }
-    }, [checkNfcSupport]),
+    }, [checkNfcSupport, hasStarted, isNfcEnabled, onVerifyPress]),
   );
 
   return (


### PR DESCRIPTION
## Summary
- trigger passport scan when the NFC scan screen gains focus

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account config)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: unsupported signature algorithm)*
- `yarn workspace @selfxyz/mobile-app test`

------
https://chatgpt.com/codex/tasks/task_b_68796e6517d0832db2bacdae9f543516