### PR TITLE
Improve NFC focus handling

### DIFF
--- a/NFC_SCANNING_BUG_ANALYSIS.md
+++ b/NFC_SCANNING_BUG_ANALYSIS.md
@@ -178,6 +178,8 @@ adb logcat -s MAIN_ACTIVITY:D -s RNPassportReaderModule:D -s libnfc_nci:D
 
 3. **AndroidManifest Configuration:** The `DEFAULT` category is required for NFC intent filters, not just the action.
 
+4. **Focus-driven Lifecycle:** `MainActivity.onWindowFocusChanged()` now forwards focus events to `RNPassportReaderModule` so NFC enabling happens immediately when focus is gained.
+
 4. **Background/Foreground Cycles are Harmful:** They disrupt the user experience and create race conditions.
 
 ### **User Preferences:**

--- a/app/android/app/src/main/java/com/proofofpassportapp/MainActivity.kt
+++ b/app/android/app/src/main/java/com/proofofpassportapp/MainActivity.kt
@@ -64,6 +64,18 @@ class MainActivity : ReactActivity() {
     Log.e("MAIN_ACTIVITY", "🔄 onResume: Window focus: ${hasWindowFocus()}")
   }
 
+  override fun onWindowFocusChanged(hasFocus: Boolean) {
+    super.onWindowFocusChanged(hasFocus)
+    Log.e("MAIN_ACTIVITY", "🏙️ onWindowFocusChanged: hasFocus=$hasFocus")
+    if (hasFocus) {
+      try {
+        RNPassportReaderModule.getInstance().onWindowFocusChanged(true)
+      } catch (e: Exception) {
+        Log.e("MAIN_ACTIVITY", "❌ Error notifying RNPassportReaderModule: ${e.message}", e)
+      }
+    }
+  }
+
   override fun onPause() {
     super.onPause()
     Log.e("MAIN_ACTIVITY", "⏸️ MainActivity onPause called")

--- a/app/android/react-native-passport-reader/android/src/main/java/io/tradle/nfc/RNPassportReaderModule.kt
+++ b/app/android/react-native-passport-reader/android/src/main/java/io/tradle/nfc/RNPassportReaderModule.kt
@@ -213,10 +213,19 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
         this.scanPromise = promise
         Log.d("RNPassportReaderModule", "opts set to: " + opts.toString())
 
-        // Step 2: Enable NFC with focus check - this replaces the disruptive background/foreground cycle
-        Log.e("RNPassportReaderModule", "🚀 SCAN: About to call enableNfcWithFocusCheck()")
-        eventMessageEmitter("🚀 SCAN: Starting NFC with focus check")
-        enableNfcWithFocusCheck()
+        // Step 2: Enable NFC once the activity has focus
+        val hasFocus = currentActivity?.hasWindowFocus() ?: false
+        Log.e("RNPassportReaderModule", "🚀 SCAN: Activity has focus=$hasFocus")
+        eventMessageEmitter("🚀 SCAN: Activity focus=$hasFocus")
+        onWindowFocusChanged(hasFocus)
+        if (!hasFocus) {
+            Handler(Looper.getMainLooper()).postDelayed({
+                if (scanPromise != null && !isNfcEnabled) {
+                    Log.e("RNPassportReaderModule", "⏰ SCAN FOCUS TIMEOUT: Falling back to enableNfcWithFocusCheck")
+                    enableNfcWithFocusCheck()
+                }
+            }, 3000)
+        }
     }
 
 
@@ -393,11 +402,19 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
         // If a scan is in progress (scanPromise exists), we need to ensure NFC is enabled.
         // This handles resumes after screen lock/unlock.
         if (scanPromise != null) {
-            Log.e("RNPassportReaderModule", "🏠 HOST RESUMED: Scan in progress, enabling NFC with focus check.")
-            eventMessageEmitter("🏠 HOST RESUMED: Scan in progress, enabling NFC.")
+            Log.e("RNPassportReaderModule", "🏠 HOST RESUMED: Scan in progress, checking window focus.")
+            eventMessageEmitter("🏠 HOST RESUMED: Scan in progress, checking focus.")
 
-            // Use the new focus-aware method instead of a simple delay
-            enableNfcWithFocusCheck()
+            val hasFocus = currentActivity?.hasWindowFocus() ?: false
+            onWindowFocusChanged(hasFocus)
+            if (!hasFocus) {
+                Handler(Looper.getMainLooper()).postDelayed({
+                    if (scanPromise != null && !isNfcEnabled) {
+                        Log.e("RNPassportReaderModule", "⏰ RESUME FOCUS TIMEOUT: Falling back to enableNfcWithFocusCheck")
+                        enableNfcWithFocusCheck()
+                    }
+                }, 3000)
+            }
         } else {
             Log.e("RNPassportReaderModule", "🏠 HOST RESUMED: No active scan, no action needed.")
         }
@@ -415,6 +432,15 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
         } else {
             Log.e("RNPassportReaderModule", "⏸️ HOST PAUSED: NFC not enabled, no action needed")
             eventMessageEmitter("⏸️ HOST PAUSED: NFC not enabled, no action needed")
+        }
+    }
+
+    fun onWindowFocusChanged(hasFocus: Boolean) {
+        Log.e("RNPassportReaderModule", "🏙️ WINDOW FOCUS: hasFocus=$hasFocus, scanPromise=${scanPromise != null}, nfcEnabled=$isNfcEnabled")
+        eventMessageEmitter("🏙️ WINDOW FOCUS: hasFocus=$hasFocus")
+        if (hasFocus && scanPromise != null && !isNfcEnabled) {
+            Log.e("RNPassportReaderModule", "🏙️ WINDOW FOCUS: Enabling NFC after focus gained")
+            enableNfcForScanning()
         }
     }
 


### PR DESCRIPTION
## Summary
- notify `RNPassportReaderModule` when `MainActivity` gains focus
- enable foreground dispatch in the module when focus is gained
- fallback to a delayed check if focus is not available
- document the new focus-driven lifecycle

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account config)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm)*
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_687d807b2200832d90f615981c734904