### PR TITLE
Fix socket.io import alias

### DIFF
--- a/app/src/stores/selfAppStore.tsx
+++ b/app/src/stores/selfAppStore.tsx
@@ -2,7 +2,7 @@
 
 import type { SelfApp } from '@selfxyz/common';
 import { WS_DB_RELAYER } from '@selfxyz/common';
-import io, { Socket } from 'socket.io-client';
+import socketIo, { Socket } from 'socket.io-client';
 import { create } from 'zustand';
 
 interface SelfAppState {
@@ -32,7 +32,7 @@ export const useSelfAppStore = create<SelfAppState>((set, get) => ({
     const socketUrl = `${connectionUrl}/websocket`;
 
     // Create a new socket connection using the updated URL.
-    const socket = io(socketUrl, {
+    const socket = socketIo(socketUrl, {
       path: '/',
       transports: ['websocket'],
       forceNew: true, // Ensure a new connection is established


### PR DESCRIPTION
## Summary
- alias socket.io-client import to `socketIo`

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account HH8)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Cannot read properties of undefined)*
- `yarn workspace @selfxyz/mobile-app test`

------
https://chatgpt.com/codex/tasks/task_b_68807435a3cc832d954096eaf59c909d