### PR TITLE
SEL-548: Add localhost validation to QR Code SDK

### DIFF
--- a/common/src/utils/appType.ts
+++ b/common/src/utils/appType.ts
@@ -78,6 +78,13 @@ export class SelfAppBuilder {
     if (config.endpointType === 'celo' && !config.endpoint.startsWith('0x')) {
       throw new Error('endpoint must be a valid address');
     }
+    // Validate that localhost endpoints are not allowed
+    if (
+      config.endpoint &&
+      (config.endpoint.includes('localhost') || config.endpoint.includes('127.0.0.1'))
+    ) {
+      throw new Error('localhost endpoints are not allowed');
+    }
     if (config.userIdType === 'hex') {
       if (!config.userId.startsWith('0x')) {
         throw new Error('userId as hex must start with 0x');

--- a/sdk/qrcode/utils/websocket.ts
+++ b/sdk/qrcode/utils/websocket.ts
@@ -11,6 +11,15 @@ export interface WebAppInfo {
 // Log once when this module loads
 console.log('[WebSocket] Initializing websocket module.');
 
+const validateWebSocketUrl = (websocketUrl: string) => {
+  if (
+    websocketUrl.includes('localhost') ||
+    websocketUrl.includes('127.0.0.1')
+  ) {
+    throw new Error('localhost websocket URLs are not allowed');
+  }
+};
+
 const newSocket = (websocketUrl: string, sessionId: string) => {
   const fullUrl = `${websocketUrl}/websocket`;
   console.log(
@@ -88,6 +97,7 @@ export function initWebSocket(
   onSuccess: () => void,
   onError: (data: { error_code?: string; reason?: string }) => void,
 ) {
+  validateWebSocketUrl(websocketUrl);
   const sessionId = selfApp.sessionId;
   console.log(
     `[WebSocket] Initializing WebSocket connection for sessionId: ${sessionId}`,


### PR DESCRIPTION
## Summary
- Added validation to prevent localhost URLs in QR Code SDK endpoints
- Throws descriptive error when localhost or 127.0.0.1 is detected in endpoint URLs  
- Added validation for both SelfApp endpoints and websocket URLs

## Test plan
- [x] Verified SelfAppBuilder rejects localhost endpoints with proper error message
- [x] Verified websocket initialization rejects localhost URLs with proper error message  
- [x] Confirmed valid non-localhost endpoints continue to work
- [x] Ran linting and type checking
- [x] Applied code formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent the use of "localhost" or "127.0.0.1" in endpoints and WebSocket URLs. Attempting to use such addresses will now result in an error message indicating that local endpoints are not allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->