### PR TITLE
Fix web app screen loading

### DIFF
--- a/app/src/navigation/aesop.ts
+++ b/app/src/navigation/aesop.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { lazy } from 'react';
 
 import { ProgressNavBar } from '../components/NavBar';
 import { shouldShowAesopRedesign } from '../hooks/useAesopRedesign';
+import { lazyScreen } from './lazyScreen';
 
-const PassportOnboardingScreen = lazy(
+const PassportOnboardingScreen = lazyScreen(
   () => import('../screens/aesop/PassportOnboardingScreen'),
 );
 import { white } from '../utils/colors';

--- a/app/src/navigation/dev.ts
+++ b/app/src/navigation/dev.ts
@@ -1,19 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { lazy } from 'react';
 
-const DevFeatureFlagsScreen = lazy(
+import { lazyScreen } from './lazyScreen';
+
+const DevFeatureFlagsScreen = lazyScreen(
   () => import('../screens/dev/DevFeatureFlagsScreen'),
 );
-const DevHapticFeedbackScreen = lazy(
+const DevHapticFeedbackScreen = lazyScreen(
   () => import('../screens/dev/DevHapticFeedback'),
 );
-const DevSettingsScreen = lazy(
+const DevSettingsScreen = lazyScreen(
   () => import('../screens/dev/DevSettingsScreen'),
 );
-const MockDataScreen = lazy(() => import('../screens/dev/MockDataScreen'));
-const MockDataScreenDeepLink = lazy(
+const MockDataScreen = lazyScreen(
+  () => import('../screens/dev/MockDataScreen'),
+);
+const MockDataScreenDeepLink = lazyScreen(
   () => import('../screens/dev/MockDataScreenDeepLink'),
 );
 import { white } from '../utils/colors';

--- a/app/src/navigation/lazyScreen.tsx
+++ b/app/src/navigation/lazyScreen.tsx
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+import React, { Suspense } from 'react';
+import { View } from 'react-native';
+
+export function lazyScreen<T extends object>(
+  importer: () => Promise<{ default: React.ComponentType<T> }>,
+): React.ComponentType<T> {
+  const LazyComp = React.lazy(importer) as unknown as React.ComponentType<T>;
+  const LazyScreenWrapper = (props: T) => (
+    <Suspense fallback={<View />}>
+      <LazyComp {...(props as T)} />
+    </Suspense>
+  );
+  return LazyScreenWrapper as React.ComponentType<T>;
+}

--- a/app/src/navigation/passport.ts
+++ b/app/src/navigation/passport.ts
@@ -1,27 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { lazy } from 'react';
 
-const PassportCameraScreen = lazy(
+import { lazyScreen } from './lazyScreen';
+
+const PassportCameraScreen = lazyScreen(
   () => import('../screens/passport/PassportCameraScreen'),
 );
-const PassportCameraTrouble = lazy(
+const PassportCameraTrouble = lazyScreen(
   () => import('../screens/passport/PassportCameraTroubleScreen'),
 );
-const PassportNFCScanScreen = lazy(
+const PassportNFCScanScreen = lazyScreen(
   () => import('../screens/passport/PassportNFCScanScreen'),
 );
-const PassportNFCTrouble = lazy(
+const PassportNFCTrouble = lazyScreen(
   () => import('../screens/passport/PassportNFCTroubleScreen'),
 );
-const PassportOnboardingScreen = lazy(
+const PassportOnboardingScreen = lazyScreen(
   () => import('../screens/passport/PassportOnboardingScreen'),
 );
-const UnsupportedPassportScreen = lazy(
+const UnsupportedPassportScreen = lazyScreen(
   () => import('../screens/passport/UnsupportedPassportScreen'),
 );
-const NFCMethodSelectionScreen = lazy(
+const NFCMethodSelectionScreen = lazyScreen(
   () => import('../screens/passport/NFCMethodSelectionScreen'),
 );
 

--- a/app/src/navigation/prove.ts
+++ b/app/src/navigation/prove.ts
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { lazy } from 'react';
 
-const ConfirmBelongingScreen = lazy(
+import { lazyScreen } from './lazyScreen';
+
+const ConfirmBelongingScreen = lazyScreen(
   () => import('../screens/prove/ConfirmBelongingScreen'),
 );
-const ProofRequestStatusScreen = lazy(
+const ProofRequestStatusScreen = lazyScreen(
   () => import('../screens/prove/ProofRequestStatusScreen'),
 );
-const ProveScreen = lazy(() => import('../screens/prove/ProveScreen'));
-const QRCodeTroubleScreen = lazy(
+const ProveScreen = lazyScreen(() => import('../screens/prove/ProveScreen'));
+const QRCodeTroubleScreen = lazyScreen(
   () => import('../screens/prove/QRCodeTroubleScreen'),
 );
-const QRCodeViewFinderScreen = lazy(
+const QRCodeViewFinderScreen = lazyScreen(
   () => import('../screens/prove/ViewFinderScreen'),
 );
 import { black, white } from '../utils/colors';

--- a/app/src/navigation/recovery.ts
+++ b/app/src/navigation/recovery.ts
@@ -1,24 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { lazy } from 'react';
 
-const AccountRecoveryChoiceScreen = lazy(
+import { lazyScreen } from './lazyScreen';
+
+const AccountRecoveryChoiceScreen = lazyScreen(
   () => import('../screens/recovery/AccountRecoveryChoiceScreen'),
 );
-const AccountRecoveryScreen = lazy(
+const AccountRecoveryScreen = lazyScreen(
   () => import('../screens/recovery/AccountRecoveryScreen'),
 );
-const AccountVerifiedSuccessScreen = lazy(
+const AccountVerifiedSuccessScreen = lazyScreen(
   () => import('../screens/recovery/AccountVerifiedSuccessScreen'),
 );
-const PassportDataNotFound = lazy(
+const PassportDataNotFound = lazyScreen(
   () => import('../screens/recovery/PassportDataNotFoundScreen'),
 );
-const RecoverWithPhraseScreen = lazy(
+const RecoverWithPhraseScreen = lazyScreen(
   () => import('../screens/recovery/RecoverWithPhraseScreen'),
 );
-const SaveRecoveryPhraseScreen = lazy(
+const SaveRecoveryPhraseScreen = lazyScreen(
   () => import('../screens/recovery/SaveRecoveryPhraseScreen'),
 );
 import { black, slate300 } from '../utils/colors';

--- a/app/src/navigation/settings.ts
+++ b/app/src/navigation/settings.ts
@@ -1,19 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { lazy } from 'react';
 
-const CloudBackupScreen = lazy(
+import { lazyScreen } from './lazyScreen';
+
+const CloudBackupScreen = lazyScreen(
   () => import('../screens/settings/CloudBackupScreen'),
 );
-const ManageDocumentsScreen = lazy(
+const ManageDocumentsScreen = lazyScreen(
   () => import('../screens/settings/ManageDocumentsScreen'),
 );
-const PassportDataInfoScreen = lazy(
+const PassportDataInfoScreen = lazyScreen(
   () => import('../screens/settings/PassportDataInfoScreen'),
 );
-const SettingsScreen = lazy(() => import('../screens/settings/SettingsScreen'));
-const ShowRecoveryPhraseScreen = lazy(
+const SettingsScreen = lazyScreen(
+  () => import('../screens/settings/SettingsScreen'),
+);
+const ShowRecoveryPhraseScreen = lazyScreen(
   () => import('../screens/settings/ShowRecoveryPhraseScreen'),
 );
 import { black, slate300, white } from '../utils/colors';


### PR DESCRIPTION
## Summary
- add a `lazyScreen` helper component to wrap dynamic imports in `<Suspense>`
- use `lazyScreen` instead of `React.lazy` across navigation modules

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account for hardhat)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm)*
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/mobile-app web` *(no "Objects are not valid as a React child" error)*

------
https://chatgpt.com/codex/tasks/task_b_688a6860bf88832da3f866cdd8ed7854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved screen loading experience by introducing a custom lazy loading utility for all navigation screens.

* **Refactor**
  * Updated all navigation modules to use the new lazy loading utility for screen components, replacing the previous approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->