### PR TITLE
fix: navigate home

### DIFF
--- a/app/src/providers/passportDataProvider.tsx
+++ b/app/src/providers/passportDataProvider.tsx
@@ -65,6 +65,7 @@ interface DocumentMetadata {
   documentCategory: DocumentCategory; // passport, id_card, aadhaar
   data: string; // DG1/MRZ data for passports/IDs, relevant data for aadhaar
   mock: boolean; // whether this is a mock document
+  isRegistered?: boolean; // whether the document is registered onChain
 }
 
 interface DocumentCatalog {
@@ -185,6 +186,7 @@ export async function storeDocumentWithDeduplication(
       inferDocumentCategory(passportData.documentType),
     data: passportData.mrz || '', // Store MRZ for passports/IDs, relevant data for aadhaar
     mock: passportData.mock || false,
+    isRegistered: false,
   };
 
   catalog.documents.push(metadata);
@@ -522,6 +524,12 @@ interface IPassportContext {
   migrateFromLegacyStorage: () => Promise<void>;
   getCurrentDocumentType: () => Promise<string | null>;
   clearDocumentCatalogForMigrationTesting: () => Promise<void>;
+  markCurrentDocumentAsRegistered: () => Promise<void>;
+  updateDocumentRegistrationState: (
+    documentId: string,
+    isRegistered: boolean,
+  ) => Promise<void>;
+  checkIfAnyDocumentsNeedMigration: () => Promise<boolean>;
 }
 
 export const PassportContext = createContext<IPassportContext>({
@@ -542,6 +550,9 @@ export const PassportContext = createContext<IPassportContext>({
   getCurrentDocumentType: getCurrentDocumentType,
   clearDocumentCatalogForMigrationTesting:
     clearDocumentCatalogForMigrationTesting,
+  markCurrentDocumentAsRegistered: markCurrentDocumentAsRegistered,
+  updateDocumentRegistrationState: updateDocumentRegistrationState,
+  checkIfAnyDocumentsNeedMigration: checkIfAnyDocumentsNeedMigration,
 });
 
 export const PassportProvider = ({ children }: PassportProviderProps) => {
@@ -598,6 +609,9 @@ export const PassportProvider = ({ children }: PassportProviderProps) => {
       getCurrentDocumentType: getCurrentDocumentType,
       clearDocumentCatalogForMigrationTesting:
         clearDocumentCatalogForMigrationTesting,
+      markCurrentDocumentAsRegistered: markCurrentDocumentAsRegistered,
+      updateDocumentRegistrationState: updateDocumentRegistrationState,
+      checkIfAnyDocumentsNeedMigration: checkIfAnyDocumentsNeedMigration,
     }),
     [
       getData,
@@ -673,4 +687,36 @@ export async function getCurrentDocumentType(): Promise<string | null> {
     d => d.id === catalog.selectedDocumentId,
   );
   return metadata?.documentType || null;
+}
+
+export async function updateDocumentRegistrationState(
+  documentId: string,
+  isRegistered: boolean,
+): Promise<void> {
+  const catalog = await loadDocumentCatalog();
+  const documentIndex = catalog.documents.findIndex(d => d.id === documentId);
+
+  if (documentIndex !== -1) {
+    catalog.documents[documentIndex].isRegistered = isRegistered;
+    await saveDocumentCatalog(catalog);
+    console.log(
+      `Updated registration state for document ${documentId}: ${isRegistered}`,
+    );
+  } else {
+    console.warn(`Document ${documentId} not found in catalog`);
+  }
+}
+
+export async function markCurrentDocumentAsRegistered(): Promise<void> {
+  const catalog = await loadDocumentCatalog();
+  if (catalog.selectedDocumentId) {
+    await updateDocumentRegistrationState(catalog.selectedDocumentId, true);
+  } else {
+    console.warn('No selected document to mark as registered');
+  }
+}
+
+export async function checkIfAnyDocumentsNeedMigration(): Promise<boolean> {
+  const catalog = await loadDocumentCatalog();
+  return catalog.documents.some(doc => doc.isRegistered === undefined);
 }

--- a/app/src/screens/aesop/PassportOnboardingScreen.tsx
+++ b/app/src/screens/aesop/PassportOnboardingScreen.tsx
@@ -17,6 +17,7 @@ import useHapticNavigation from '../../hooks/useHapticNavigation';
 import Scan from '../../images/icons/passport_camera_scan.svg';
 import { ExpandableBottomLayout } from '../../layouts/ExpandableBottomLayout';
 import { black, slate100, white } from '../../utils/colors';
+import { hasAnyValidRegisteredDocument } from '../../utils/proving/validateDocument';
 
 interface PassportOnboardingScreenProps {}
 
@@ -24,7 +25,20 @@ const PassportOnboardingScreen: React.FC<
   PassportOnboardingScreenProps
 > = ({}) => {
   const handleCameraPress = useHapticNavigation('PassportCamera');
-  const onCancelPress = useHapticNavigation('Launch', { action: 'cancel' });
+  const navigateToLaunch = useHapticNavigation('Launch', {
+    action: 'cancel',
+  });
+  const navigateToHome = useHapticNavigation('Home', {
+    action: 'cancel',
+  });
+  const onCancelPress = async () => {
+    const hasValidDocument = await hasAnyValidRegisteredDocument();
+    if (hasValidDocument) {
+      navigateToHome();
+    } else {
+      navigateToLaunch();
+    }
+  };
   const animationRef = useRef<LottieView>(null);
 
   useEffect(() => {

--- a/app/src/screens/passport/PassportCameraScreen.tsx
+++ b/app/src/screens/passport/PassportCameraScreen.tsx
@@ -23,6 +23,7 @@ import useUserStore from '../../stores/userStore';
 import analytics from '../../utils/analytics';
 import { black, slate400, slate800, white } from '../../utils/colors';
 import { dinot } from '../../utils/fonts';
+import { hasAnyValidRegisteredDocument } from '../../utils/proving/validateDocument';
 import { checkScannedInfo, formatDateToYYMMDD } from '../../utils/utils';
 
 interface PassportNFCScanScreen {}
@@ -113,9 +114,21 @@ const PassportCameraScreen: React.FC<PassportNFCScanScreen> = ({}) => {
     },
     [store, navigation],
   );
-  const onCancelPress = useHapticNavigation('Launch', {
+  const navigateToLaunch = useHapticNavigation('Launch', {
     action: 'cancel',
   });
+  const navigateToHome = useHapticNavigation('Home', {
+    action: 'cancel',
+  });
+
+  const onCancelPress = async () => {
+    const hasValidDocument = await hasAnyValidRegisteredDocument();
+    if (hasValidDocument) {
+      navigateToHome();
+    } else {
+      navigateToLaunch();
+    }
+  };
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={white}>

--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -46,6 +46,7 @@ import {
 } from '../../utils/haptic';
 import { registerModalCallbacks } from '../../utils/modalCallbackRegistry';
 import { parseScanResponse, scan } from '../../utils/nfcScanner';
+import { hasAnyValidRegisteredDocument } from '../../utils/proving/validateDocument';
 
 const { trackEvent } = analytics();
 
@@ -275,9 +276,21 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
     openErrorModal,
   ]);
 
-  const onCancelPress = useHapticNavigation('Launch', {
+  const navigateToLaunch = useHapticNavigation('Launch', {
     action: 'cancel',
   });
+  const navigateToHome = useHapticNavigation('Home', {
+    action: 'cancel',
+  });
+
+  const onCancelPress = async () => {
+    const hasValidDocument = await hasAnyValidRegisteredDocument();
+    if (hasValidDocument) {
+      navigateToHome();
+    } else {
+      navigateToLaunch();
+    }
+  };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const _cancelScanIfRunning = useCallback(async () => {

--- a/app/src/screens/passport/PassportNFCScanScreen.web.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.web.tsx
@@ -13,13 +13,26 @@ import useHapticNavigation from '../../hooks/useHapticNavigation';
 import NFC_IMAGE from '../../images/nfc.png';
 import { ExpandableBottomLayout } from '../../layouts/ExpandableBottomLayout';
 import { black, slate100, white } from '../../utils/colors';
+import { hasAnyValidRegisteredDocument } from '../../utils/proving/validateDocument';
 
 interface PassportNFCScanScreenProps {}
 
 const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
-  const onCancelPress = useHapticNavigation('Launch', {
+  const navigateToLaunch = useHapticNavigation('Launch', {
     action: 'cancel',
   });
+  const navigateToHome = useHapticNavigation('Home', {
+    action: 'cancel',
+  });
+
+  const onCancelPress = async () => {
+    const hasValidDocument = await hasAnyValidRegisteredDocument();
+    if (hasValidDocument) {
+      navigateToHome();
+    } else {
+      navigateToLaunch();
+    }
+  };
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={black}>

--- a/app/src/screens/passport/UnsupportedPassportScreen.tsx
+++ b/app/src/screens/passport/UnsupportedPassportScreen.tsx
@@ -14,12 +14,23 @@ import { ExpandableBottomLayout } from '../../layouts/ExpandableBottomLayout';
 import analytics from '../../utils/analytics';
 import { black, white } from '../../utils/colors';
 import { notificationError } from '../../utils/haptic';
+import { hasAnyValidRegisteredDocument } from '../../utils/proving/validateDocument';
 import { styles } from '../prove/ProofRequestStatusScreen';
 
 const { flush: flushAnalytics } = analytics();
 
 const UnsupportedPassportScreen: React.FC = () => {
-  const onPress = useHapticNavigation('Launch');
+  const navigateToLaunch = useHapticNavigation('Launch');
+  const navigateToHome = useHapticNavigation('Home');
+
+  const onPress = async () => {
+    const hasValidDocument = await hasAnyValidRegisteredDocument();
+    if (hasValidDocument) {
+      navigateToHome();
+    } else {
+      navigateToLaunch();
+    }
+  };
   useEffect(() => {
     notificationError();
     // error screen, flush analytics

--- a/app/src/screens/recovery/PassportDataNotFoundScreen.tsx
+++ b/app/src/screens/recovery/PassportDataNotFoundScreen.tsx
@@ -9,11 +9,22 @@ import useHapticNavigation from '../../hooks/useHapticNavigation';
 import { ExpandableBottomLayout } from '../../layouts/ExpandableBottomLayout';
 import analytics from '../../utils/analytics';
 import { black, slate200, white } from '../../utils/colors';
+import { hasAnyValidRegisteredDocument } from '../../utils/proving/validateDocument';
 
 const { flush: flushAnalytics } = analytics();
 
 const PassportDataNotFound: React.FC = () => {
-  const onPress = useHapticNavigation('Launch');
+  const navigateToLaunch = useHapticNavigation('Launch');
+  const navigateToHome = useHapticNavigation('Home');
+
+  const onPress = async () => {
+    const hasValidDocument = await hasAnyValidRegisteredDocument();
+    if (hasValidDocument) {
+      navigateToHome();
+    } else {
+      navigateToLaunch();
+    }
+  };
 
   // error screen, flush analytics
   useEffect(() => {

--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -19,6 +19,7 @@ import { unsafe_getPrivateKey } from '../../providers/authProvider';
 import {
   clearPassportData,
   loadSelectedDocument,
+  markCurrentDocumentAsRegistered,
   reStorePassportDataWithRightCSCA,
 } from '../../providers/passportDataProvider';
 import { useProtocolStore } from '../../stores/protocolStore';
@@ -237,6 +238,20 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         trackEvent(ProofEvents.PROOF_COMPLETED, {
           circuitType: get().circuitType,
         });
+
+        // Mark document as registered onChain
+        if (get().circuitType === 'register') {
+          (async () => {
+            try {
+              await markCurrentDocumentAsRegistered();
+              console.log('Document marked as registered on-chain');
+            } catch (error) {
+              //This will be checked and updated when the app launches the next time
+              console.error('Error marking document as registered:', error);
+            }
+          })();
+        }
+
         if (get().circuitType !== 'disclose' && navigationRef.isReady()) {
           setTimeout(() => {
             navigationRef.navigate('AccountVerifiedSuccess');
@@ -709,6 +724,18 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             );
           if (isRegistered) {
             reStorePassportDataWithRightCSCA(passportData, csca as string);
+
+            // Mark document as registered since its already onChain
+            (async () => {
+              try {
+                await markCurrentDocumentAsRegistered();
+                console.log('Document marked as registered (already on-chain)');
+              } catch (error) {
+                //it will be checked and marked as registered during next app launch
+                console.error('Error marking document as registered:', error);
+              }
+            })();
+
             trackEvent(ProofEvents.ALREADY_REGISTERED);
             actor!.send({ type: 'ALREADY_REGISTERED' });
             return;

--- a/app/src/utils/proving/validateDocument.ts
+++ b/app/src/utils/proving/validateDocument.ts
@@ -25,10 +25,12 @@ import { poseidon2, poseidon5 } from 'poseidon-lite';
 import { DocumentEvents } from '../../consts/analytics';
 import {
   getAllDocuments,
+  loadDocumentCatalog,
   loadPassportDataAndSecret,
   loadSelectedDocument,
   setSelectedDocument,
   storePassportData,
+  updateDocumentRegistrationState,
 } from '../../providers/passportDataProvider';
 import { useProtocolStore } from '../../stores/protocolStore';
 import analytics from '../../utils/analytics';
@@ -328,11 +330,15 @@ export function migratePassportData(passportData: PassportData): PassportData {
   return migratedData as PassportData;
 }
 
-/**
- * This function sequentially checks all documents for a valid registered document.
- * Since it uses fetch_all and loadSelectedDocument, it cannot be parallelised.
- */
 export async function hasAnyValidRegisteredDocument(): Promise<boolean> {
+  const catalog = await loadDocumentCatalog();
+  return catalog.documents.some(doc => doc.isRegistered === true);
+}
+
+/**
+ * This function checks and updates registration states for all documents and updates the `isRegistered`.
+ */
+export async function checkAndUpdateRegistrationStates(): Promise<void> {
   const allDocuments = await getAllDocuments();
   for (const documentId of Object.keys(allDocuments)) {
     try {
@@ -345,6 +351,7 @@ export async function hasAnyValidRegisteredDocument(): Promise<boolean> {
           error: 'Passport data is not valid',
           documentId,
         });
+        console.log(`Skipping invalid document ${documentId}`);
         continue;
       }
       const migratedPassportData = migratePassportData(passportData);
@@ -363,30 +370,49 @@ export async function hasAnyValidRegisteredDocument(): Promise<boolean> {
           documentCategory,
           mock: migratedPassportData.mock,
         });
+        console.log(
+          `Skipping document ${documentId} - no authority key identifier`,
+        );
         continue;
       }
       await useProtocolStore
         .getState()
         [documentCategory].fetch_all(environment, authorityKeyIdentifier);
       const passportDataAndSecret = await loadPassportDataAndSecret();
-      if (!passportDataAndSecret) continue;
+      if (!passportDataAndSecret) {
+        console.log(
+          `Skipping document ${documentId} - no passport data and secret`,
+        );
+        continue;
+      }
+
       const { secret } = JSON.parse(passportDataAndSecret);
       const isRegistered = await isUserRegistered(migratedPassportData, secret);
+
+      // Update the registration state in the document metadata
+      await updateDocumentRegistrationState(documentId, isRegistered);
+
       if (isRegistered) {
         trackEvent(DocumentEvents.DOCUMENT_VALIDATED, {
           documentId,
           documentCategory,
           mock: migratedPassportData.mock,
         });
-        return true;
       }
+
+      console.log(
+        `Updated registration state for document ${documentId}: ${isRegistered}`,
+      );
     } catch (error) {
-      console.error(`Error in hasAnyValidRegisteredDocument: ${error}`);
+      console.error(
+        `Error checking registration state for document ${documentId}: ${error}`,
+      );
       trackEvent(DocumentEvents.VALIDATE_DOCUMENT_FAILED, {
         error: error instanceof Error ? error.message : 'Unknown error',
         documentId,
       });
     }
   }
-  return false;
+
+  console.log('Registration state check and update completed');
 }


### PR DESCRIPTION
## Changes

- Navigates to the Home or Launch screen based on the document status.
- If at least one onChain registered document is found, it will navigate to Home.
- Added `isRegistered` to the metadata of `DocumentCatalog`
- Migration for adding the `isRegistered` flag is done on the splashScreen during the first launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to track and update the registration status of documents within the app.
  * Introduced migration logic to ensure documents have accurate registration state information.

* **Bug Fixes**
  * Improved navigation logic across multiple screens to direct users to the appropriate screen based on the presence of a valid registered document.

* **Chores**
  * Enhanced internal logging and analytics for document validation and migration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->