### PR TITLE
Enable edge-to-edge system bars

### DIFF
--- a/app/android/app/src/main/res/values/styles.xml
+++ b/app/android/app/src/main/res/values/styles.xml
@@ -1,13 +1,8 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="Theme.EdgeToEdge">
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
-        <item name="android:statusBarColor">#000000</item>
-        <item name="android:navigationBarColor">#000000</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
         <item name="android:windowBackground">#000000</item>
     </style>
 

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1868,9 +1868,9 @@ PODS:
   - segment-analytics-react-native (2.21.1):
     - React-Core
     - sovran-react-native
-  - Sentry (8.53.1):
-    - Sentry/Core (= 8.53.1)
-  - Sentry/Core (8.53.1)
+  - Sentry (8.54.0):
+    - Sentry/Core (= 8.54.0)
+  - Sentry/Core (8.54.0)
   - Sentry/HybridSDK (8.48.0)
   - SentryPrivate (8.21.0)
   - SocketRocket (0.7.0)

--- a/app/package.json
+++ b/app/package.json
@@ -114,6 +114,7 @@
     "react-native-cloud-storage": "^2.2.2",
     "react-native-device-info": "^14.0.4",
     "react-native-dotenv": "^3.4.11",
+    "react-native-edge-to-edge": "^1.6.2",
     "react-native-gesture-handler": "2.24.0",
     "react-native-get-random-values": "^1.11.0",
     "react-native-haptic-feedback": "^2.3.3",

--- a/app/src/components/NavBar/BaseNavBar.tsx
+++ b/app/src/components/NavBar/BaseNavBar.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronLeft, X } from '@tamagui/lucide-icons';
 import React, { useMemo } from 'react';
-import { StatusBar, StatusBarStyle } from 'react-native';
+import { SystemBars, SystemBarStyle } from 'react-native-edge-to-edge';
 import {
   Button,
   TextProps,
@@ -17,7 +17,7 @@ import { Title } from '../typography/Title';
 interface NavBarProps extends XStackProps {
   children: React.ReactNode;
   backgroundColor?: string;
-  barStyle?: StatusBarStyle;
+  barStyle?: SystemBarStyle;
 }
 interface LeftActionProps extends ViewProps {
   component?: 'back' | 'close' | React.ReactNode;
@@ -114,7 +114,7 @@ const Container: React.FC<NavBarProps> = ({
 }) => {
   return (
     <>
-      <StatusBar backgroundColor={backgroundColor} barStyle={barStyle} />
+      <SystemBars style={barStyle} />
       <XStack
         backgroundColor={backgroundColor}
         flexGrow={1}

--- a/app/src/components/NavBar/DefaultNavBar.tsx
+++ b/app/src/components/NavBar/DefaultNavBar.tsx
@@ -25,8 +25,8 @@ export const DefaultNavBar = (props: NativeStackHeaderProps) => {
       barStyle={
         options.headerTintColor === white ||
         (options.headerTitleStyle as TextStyle)?.color === white
-          ? 'light-content'
-          : 'dark-content'
+          ? 'light'
+          : 'dark'
       }
     >
       <NavBar.LeftAction

--- a/app/src/components/NavBar/HomeNavBar.tsx
+++ b/app/src/components/NavBar/HomeNavBar.tsx
@@ -17,7 +17,7 @@ export const HomeNavBar = (props: NativeStackHeaderProps) => {
   return (
     <NavBar.Container
       backgroundColor={black}
-      barStyle={'light-content'}
+      barStyle={'light'}
       padding={16}
       justifyContent="space-between"
       paddingTop={Math.max(insets.top, 15) + extraYPadding}

--- a/app/src/components/NavBar/ProgressNavBar.tsx
+++ b/app/src/components/NavBar/ProgressNavBar.tsx
@@ -53,8 +53,8 @@ export const ProgressNavBar = (props: NativeStackHeaderProps) => {
         barStyle={
           options.headerTintColor === white ||
           (options.headerTitleStyle as TextStyle)?.color === white
-            ? 'light-content'
-            : 'dark-content'
+            ? 'light'
+            : 'dark'
         }
       >
         <XStack width="100%" alignItems="center">

--- a/app/src/layouts/ExpandableBottomLayout.tsx
+++ b/app/src/layouts/ExpandableBottomLayout.tsx
@@ -42,9 +42,7 @@ const Layout: React.FC<ExpandableBottomLayoutProps> = ({
 }) => {
   return (
     <View flex={1} flexDirection="column" backgroundColor={backgroundColor}>
-      <SystemBars
-        style={backgroundColor === black ? 'light' : 'dark'}
-      />
+      <SystemBars style={backgroundColor === black ? 'light' : 'dark'} />
       {children}
     </View>
   );

--- a/app/src/layouts/ExpandableBottomLayout.tsx
+++ b/app/src/layouts/ExpandableBottomLayout.tsx
@@ -6,9 +6,9 @@ import {
   PixelRatio,
   Platform,
   ScrollView,
-  StatusBar,
   StyleSheet,
 } from 'react-native';
+import { SystemBars } from 'react-native-edge-to-edge';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { View, ViewProps } from 'tamagui';
 
@@ -42,9 +42,8 @@ const Layout: React.FC<ExpandableBottomLayoutProps> = ({
 }) => {
   return (
     <View flex={1} flexDirection="column" backgroundColor={backgroundColor}>
-      <StatusBar
-        barStyle={backgroundColor === black ? 'light-content' : 'dark-content'}
-        backgroundColor={backgroundColor}
+      <SystemBars
+        style={backgroundColor === black ? 'light' : 'dark'}
       />
       {children}
     </View>

--- a/app/src/navigation/misc.tsx
+++ b/app/src/navigation/misc.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import React, { lazy } from 'react';
-import { StatusBar } from 'react-native';
+import React from 'react';
+import { SystemBars } from 'react-native-edge-to-edge';
 
 // Important: SplashScreen is imported directly and not lazy-loaded.
 // This is because it's used as a fallback for the Suspense boundary in the root navigator,
@@ -18,9 +18,7 @@ const miscScreens = {
   Launch: {
     screen: LaunchScreen,
     options: {
-      header: () => (
-        <StatusBar barStyle="light-content" backgroundColor={black} />
-      ),
+      header: () => <SystemBars style="light" />,
       navigationBarColor: black,
     },
   },
@@ -43,9 +41,7 @@ const miscScreens = {
   Splash: {
     screen: SplashScreen,
     options: {
-      header: () => (
-        <StatusBar barStyle="light-content" backgroundColor={black} />
-      ),
+      header: () => <SystemBars style="light" />,
       navigationBarColor: black,
     },
   },

--- a/app/src/navigation/misc.tsx
+++ b/app/src/navigation/misc.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import React from 'react';
+import React, { lazy } from 'react';
 import { SystemBars } from 'react-native-edge-to-edge';
 
 // Important: SplashScreen is imported directly and not lazy-loaded.

--- a/app/src/screens/aesop/PassportOnboardingScreen.tsx
+++ b/app/src/screens/aesop/PassportOnboardingScreen.tsx
@@ -2,7 +2,8 @@
 
 import LottieView from 'lottie-react-native';
 import React, { useEffect, useRef } from 'react';
-import { StatusBar, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { SystemBars } from 'react-native-edge-to-edge';
 
 import passportOnboardingAnimation from '../../assets/animations/passport_onboarding.json';
 import { PrimaryButton } from '../../components/buttons/PrimaryButton';
@@ -47,7 +48,7 @@ const PassportOnboardingScreen: React.FC<
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={white}>
-      <StatusBar barStyle="light-content" backgroundColor={white} />
+      <SystemBars style="light" />
       <ExpandableBottomLayout.TopSection backgroundColor={white}>
         <LottieView
           ref={animationRef}

--- a/app/src/screens/passport/PassportOnboardingScreen.tsx
+++ b/app/src/screens/passport/PassportOnboardingScreen.tsx
@@ -3,7 +3,8 @@
 import { useNavigation } from '@react-navigation/native';
 import LottieView from 'lottie-react-native';
 import React, { useEffect, useRef } from 'react';
-import { StatusBar, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { SystemBars } from 'react-native-edge-to-edge';
 
 import passportOnboardingAnimation from '../../assets/animations/passport_onboarding.json';
 import { PrimaryButton } from '../../components/buttons/PrimaryButton';
@@ -39,7 +40,7 @@ const PassportOnboardingScreen: React.FC<
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={black}>
-      <StatusBar barStyle="light-content" backgroundColor={black} />
+      <SystemBars style="light" />
       <ExpandableBottomLayout.TopSection roundTop backgroundColor={black}>
         <LottieView
           ref={animationRef}

--- a/app/src/screens/prove/ProofRequestStatusScreen.tsx
+++ b/app/src/screens/prove/ProofRequestStatusScreen.tsx
@@ -2,8 +2,9 @@
 
 import { useIsFocused } from '@react-navigation/native';
 import LottieView from 'lottie-react-native';
-import React, { useEffect, useState } from 'react';
-import { Linking, StatusBar, StyleSheet, View } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Linking, StyleSheet, View } from 'react-native';
+import { SystemBars } from 'react-native-edge-to-edge';
 import { ScrollView, Spinner } from 'tamagui';
 
 import loadingAnimation from '../../assets/animations/loading/misc.json';
@@ -169,7 +170,7 @@ const SuccessScreen: React.FC = () => {
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={white}>
-      <StatusBar barStyle="dark-content" backgroundColor={white} />
+      <SystemBars style="dark" />
       <ExpandableBottomLayout.TopSection
         roundTop
         marginTop={20}

--- a/app/src/screens/prove/ProofRequestStatusScreen.tsx
+++ b/app/src/screens/prove/ProofRequestStatusScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useIsFocused } from '@react-navigation/native';
 import LottieView from 'lottie-react-native';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Linking, StyleSheet, View } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { ScrollView, Spinner } from 'tamagui';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4696,6 +4696,7 @@ __metadata:
     react-native-cloud-storage: "npm:^2.2.2"
     react-native-device-info: "npm:^14.0.4"
     react-native-dotenv: "npm:^3.4.11"
+    react-native-edge-to-edge: "npm:^1.6.2"
     react-native-gesture-handler: "npm:2.24.0"
     react-native-get-random-values: "npm:^1.11.0"
     react-native-haptic-feedback: "npm:^2.3.3"
@@ -21017,6 +21018,16 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.20.6
   checksum: 10c0/9ed4a37fb59030706d17a1cc49d05af9d8fc57dcb2ef97e122b844f3ab6f6331ebc089afac559fe5bddf37806aa282b4118005f1b27aae5e37fdc3fc8bd7625c
+  languageName: node
+  linkType: hard
+
+"react-native-edge-to-edge@npm:^1.6.2":
+  version: 1.6.2
+  resolution: "react-native-edge-to-edge@npm:1.6.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/4c9defc3075aedff2bcef2a39ed97d037f220342baa95d374f3c68dee9e4493429f2f8f3b3dbb7ba355cdfb89a00d6400218c90944cc80e84283d3eb8646c584
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
From the play store

<img width="885" height="305" alt="edge-to-edge copy" src="https://github.com/user-attachments/assets/9a228f7b-3871-4585-ac94-6b81381eda53" />


## Summary
- install `react-native-edge-to-edge`
- use `Theme.EdgeToEdge` for Android theme
- swap `StatusBar` for `SystemBars`
- map nav bar props to new style values

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account for Hardhat)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm)*
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_688abdc8aea8832d9065525d0af04aff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved system bar appearance and behavior by adopting edge-to-edge styling across the app.
  * Enhanced support for immersive layouts by updating the Android app theme.

* **Chores**
  * Added the "react-native-edge-to-edge" library as a new dependency.

* **Refactor**
  * Replaced usage of the native StatusBar component with the new SystemBars component for consistent system bar styling.
  * Simplified system bar style settings throughout navigation bars and screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->