### PR TITLE
Remove Android orientation lock

### DIFF
--- a/app/android/android-passport-reader/app/src/main/AndroidManifest.xml
+++ b/app/android/android-passport-reader/app/src/main/AndroidManifest.xml
@@ -24,17 +24,17 @@
             android:value="ocr" />
 
         <activity android:name=".ui.activities.CameraActivity"
-            android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar.FullScreen"
-            android:windowSoftInputMode="stateAlwaysHidden" />
+            android:windowSoftInputMode="stateAlwaysHidden"
+            android:resizeableActivity="true" />
 
         <activity android:name=".ui.activities.NfcActivity"
-            android:screenOrientation="nosensor"
-            android:keepScreenOn="true" />
+            android:keepScreenOn="true"
+            android:resizeableActivity="true" />
 
         <activity android:name=".ui.activities.SelectionActivity"
-            android:screenOrientation="nosensor" />
+            android:resizeableActivity="true" />
     </application>
 
 </manifest>

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -27,8 +27,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTop"
-        android:screenOrientation="portrait"
         android:windowSoftInputMode="adjustResize"
+        android:resizeableActivity="true"
         android:exported="true">
 
         <intent-filter>

--- a/app/tests/src/androidManifest.test.ts
+++ b/app/tests/src/androidManifest.test.ts
@@ -123,7 +123,8 @@ describe('Android Manifest Configuration', () => {
       expect(manifestContent).toContain('android:name=".MainActivity"');
       expect(manifestContent).toContain('android:exported="true"');
       expect(manifestContent).toContain('android:launchMode="singleTop"');
-      expect(manifestContent).toContain('android:screenOrientation="portrait"');
+      expect(manifestContent).toContain('android:resizeableActivity="true"');
+      expect(manifestContent).not.toContain('android:screenOrientation');
     });
 
     it('should have main launcher intent filter', () => {


### PR DESCRIPTION
## Summary
- allow resizing in `MainActivity`
- remove orientation restrictions from passport reader library
- update manifest tests

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm)*
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_688abdca6b94832db8c9ef700a75488f