### PR TITLE
Improve CI caching setup

### DIFF
--- a/.github/actions/cache-bundler/action.yml
+++ b/.github/actions/cache-bundler/action.yml
@@ -1,0 +1,25 @@
+name: Cache Bundler
+
+description: Setup Ruby and restore Bundler cache
+
+inputs:
+  ruby_version:
+    description: Ruby version
+    required: true
+  working_directory:
+    description: Directory containing Gemfile
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Bundler cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.working_directory }}/vendor/bundle
+        key: bundler-${{ hashFiles(format('{0}/Gemfile.lock', inputs.working_directory)) }}
+        restore-keys: bundler-
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby_version }}

--- a/.github/actions/cache-gradle/action.yml
+++ b/.github/actions/cache-gradle/action.yml
@@ -1,0 +1,22 @@
+name: Cache Gradle
+
+description: Restore Gradle caches
+
+inputs:
+  gradle_cache_version:
+    description: Manual cache version
+    required: false
+    default: v1
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Gradle cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+          **/gradle/wrapper
+        key: gradle-${{ inputs.gradle_cache_version }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: gradle-${{ inputs.gradle_cache_version }}-

--- a/.github/actions/cache-pods/action.yml
+++ b/.github/actions/cache-pods/action.yml
@@ -1,0 +1,20 @@
+name: Cache CocoaPods
+
+description: Restore CocoaPods cache
+
+inputs:
+  working_directory:
+    description: Directory containing iOS project
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore CocoaPods cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ inputs.working_directory }}/ios/Pods
+          ~/.cocoapods
+        key: pods-${{ hashFiles(format('{0}/ios/Podfile.lock', inputs.working_directory)) }}
+        restore-keys: pods-

--- a/.github/actions/cache-yarn/action.yml
+++ b/.github/actions/cache-yarn/action.yml
@@ -17,7 +17,10 @@ runs:
     - name: Restore Yarn cache
       uses: actions/cache@v4
       with:
-        path: .yarn/cache
+        path: |
+          .yarn/cache
+          .yarn/install-state.gz
+          node_modules
         key: |
           yarn-${{ hashFiles('yarn.lock') }}${{ inputs.workspace != '' && format('-%s', hashFiles(format('{0}/package.json', inputs.workspace))) }}
         restore-keys: |

--- a/.github/actions/cache-yarn/action.yml
+++ b/.github/actions/cache-yarn/action.yml
@@ -1,0 +1,33 @@
+name: Cache Yarn
+
+description: Setup Node and restore Yarn cache
+
+inputs:
+  node_version:
+    description: Node.js version
+    required: true
+  workspace:
+    description: Path to workspace directory
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Yarn cache
+      uses: actions/cache@v4
+      with:
+        path: .yarn/cache
+        key: |
+          yarn-${{ hashFiles('yarn.lock') }}${{ inputs.workspace != '' && format('-%s', hashFiles(format('{0}/package.json', inputs.workspace))) }}
+        restore-keys: |
+          yarn-
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node_version }}
+    - name: Enable Corepack
+      shell: bash
+      run: |
+        corepack enable
+        corepack prepare yarn@4.6.0 --activate

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -1,10 +1,8 @@
 name: App CI
 env:
-  # Build environment versions
   NODE_VERSION: 18
   RUBY_VERSION: 3.2
   JAVA_VERSION: 17
-  # Path configuration
   WORKSPACE: ${{ github.workspace }}
   APP_PATH: ${{ github.workspace }}/app
 on:
@@ -16,12 +14,37 @@ on:
       - ".github/actions/**"
 
 jobs:
-  lint:
+  deps:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - name: Install Dependencies
-        uses: ./.github/actions/yarn-install
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+          workspace: app
+      - uses: ./.github/actions/cache-bundler
+        with:
+          ruby_version: ${{ env.RUBY_VERSION }}
+          working_directory: app
+      - uses: ./.github/actions/cache-pods
+        with:
+          working_directory: app
+      - uses: ./.github/actions/cache-gradle
+      - run: yarn install --immutable
+      - run: bundle install --jobs 4 --retry 3 --path vendor/bundle
+        working-directory: ./app
+      - run: bundle exec pod install
+        working-directory: ./app/ios
+
+  lint:
+    runs-on: macos-14
+    needs: deps
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+          workspace: app
       - name: Build Dependencies
         run: yarn build:deps
         working-directory: ./app
@@ -34,36 +57,41 @@ jobs:
 
   test:
     runs-on: macos-14
+    needs: deps
     steps:
       - uses: actions/checkout@v4
-      - name: Install Dependencies
-        uses: ./.github/actions/yarn-install
-
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+          workspace: app
       - name: Build
         run: yarn build:deps
         working-directory: ./app
       - name: Test
         run: yarn test
         working-directory: ./app
+
   build:
     runs-on: macos-14
+    needs: deps
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          # some cocoapods won't compile with xcode 16.3
           xcode-version: "16.2"
-
-      - uses: actions/checkout@v4
-      - name: Install Mobile Dependencies
-        uses: ./.github/actions/mobile-setup
+      - uses: ./.github/actions/cache-yarn
         with:
-          app_path: ${{ env.APP_PATH }}
           node_version: ${{ env.NODE_VERSION }}
+          workspace: app
+      - uses: ./.github/actions/cache-bundler
+        with:
           ruby_version: ${{ env.RUBY_VERSION }}
-          workspace: ${{ env.WORKSPACE }}
+          working_directory: app
+      - uses: ./.github/actions/cache-pods
+        with:
+          working_directory: app
+      - uses: ./.github/actions/cache-gradle
       - name: Install And Build
         run: yarn install-app
         working-directory: ./app

--- a/.github/workflows/circuits.yml
+++ b/.github/workflows/circuits.yml
@@ -23,8 +23,6 @@ jobs:
     environment: development
     steps:
       - uses: actions/checkout@v4
-
-      # Circom installation from https://github.com/erhant/circomkit/blob/main/.github/workflows/tests.yml
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -34,27 +32,30 @@ jobs:
             libsodium-dev \
             nasm \
             nlohmann-json3-dev
-
-      - name: Set Node.js 18.x
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/cache-yarn
         with:
-          node-version: 18
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
+          node_version: 18
+          workspace: circuits
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Restore cargo cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo
+          key: cargo-${{ hashFiles('circuits/Cargo.lock') }}
+      - name: Restore target cache
+        uses: actions/cache@v4
+        with:
+          path: circuits/target
+          key: target-${{ hashFiles('circuits/Cargo.lock') }}
       - name: Download Circom Binary v2.1.9
         run: |
           wget -qO /home/runner/work/circom https://github.com/iden3/circom/releases/download/v2.1.9/circom-linux-amd64
           chmod +x /home/runner/work/circom
           sudo mv /home/runner/work/circom /bin/circom
-
       - name: Print Circom version
         run: circom --version
-      - name: "enable yarn"
-        run: corepack enable yarn
       - name: Install Yarn dependencies
         run: yarn workspaces focus @selfxyz/circuits
-
       - name: Run lint
         run: yarn workspace @selfxyz/circuits lint
       - name: Run Tests (Circuits)

--- a/.github/workflows/general-checks.yml
+++ b/.github/workflows/general-checks.yml
@@ -2,37 +2,50 @@ name: General Self CI
 
 on:
   pull_request:
+
 jobs:
-  lint:
+  deps:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Dependencies
-        uses: ./.github/actions/yarn-install
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: 20
+      - run: yarn install --immutable
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: deps
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: 20
       - name: Build dependencies
-        shell: bash
         run: yarn workspace @selfxyz/common build
       - name: Run linter
         run: yarn lint
 
   type-check:
     runs-on: ubuntu-latest
+    needs: deps
     steps:
       - uses: actions/checkout@v4
-      - name: Install Dependencies
-        uses: ./.github/actions/yarn-install
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: 20
       - name: Yarn types
-        shell: bash
         run: yarn types
 
   test-common:
     runs-on: ubuntu-latest
+    needs: deps
     steps:
       - uses: actions/checkout@v4
-      - name: Install Dependencies
-        uses: ./.github/actions/yarn-install
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: 20
       - name: Build dependencies
-        shell: bash
         run: yarn workspace @selfxyz/common build
       - name: Run @selfxyz/common tests
         run: yarn workspace @selfxyz/common test

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -8,14 +8,26 @@ on:
       - ".github/actions/**"
 
 jobs:
-  web-build:
+  deps:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Dependencies
-        uses: ./.github/actions/yarn-install
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: 20
+          workspace: app
+      - run: yarn install --immutable
+
+  web-build:
+    runs-on: ubuntu-latest
+    needs: deps
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cache-yarn
+        with:
+          node_version: 20
+          workspace: app
       - name: Build dependencies
-        shell: bash
         run: yarn workspace @selfxyz/common build
       - name: Build web app
         run: yarn web:build


### PR DESCRIPTION
## Summary
- add modular cache actions for Yarn, Bundler, Gradle, and CocoaPods
- share dependency install via new deps job across workflows
- refine Yarn cache keys and add caches to circuits workflow

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account for network)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: TypeError: Cannot read properties of undefined)*
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_688e59b307a4832db1383bd0262d22cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced custom GitHub Actions for caching dependencies: Bundler, Gradle, CocoaPods, and Yarn.
  * Added centralized dependency installation and caching jobs to workflows for streamlined setup across platforms (Node.js, Ruby, iOS, Android).
* **Refactor**
  * Updated workflows to use new caching actions, reducing redundant installation steps and improving performance.
  * Consolidated dependency management into dedicated jobs, ensuring consistent and efficient caching throughout all CI jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->