### PR TITLE
Guard recovery prompts

### DIFF
--- a/app/src/hooks/useRecoveryPrompts.ts
+++ b/app/src/hooks/useRecoveryPrompts.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { navigationRef } from '../navigation';
 import { usePassport } from '../providers/passportDataProvider';
@@ -27,6 +27,8 @@ export default function useRecoveryPrompts() {
     onModalDismiss: () => {},
   } as const);
 
+  const lastPromptCount = useRef<number | null>(null);
+
   useEffect(() => {
     async function maybePrompt() {
       if (!navigationRef.isReady()) {
@@ -40,8 +42,13 @@ export default function useRecoveryPrompts() {
           }
           const shouldPrompt =
             loginCount > 0 && (loginCount <= 3 || (loginCount - 3) % 5 === 0);
-          if (shouldPrompt) {
+          if (
+            shouldPrompt &&
+            !visible &&
+            lastPromptCount.current !== loginCount
+          ) {
             showModal();
+            lastPromptCount.current = loginCount;
           }
         } catch (error) {
           // Silently fail to avoid breaking the hook
@@ -55,6 +62,7 @@ export default function useRecoveryPrompts() {
     loginCount,
     cloudBackupEnabled,
     hasViewedRecoveryPhrase,
+    visible,
     showModal,
     getAllDocuments,
   ]);


### PR DESCRIPTION
## Summary
- prevent recovery prompt from showing repeatedly by checking visibility and last login count
- test recovery prompt behavior across login counts and when state changes

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account: #0 for network: mainnet - Expected string, received undefined)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm: undefined)*
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_688efe0b2bd8832daff1b8d9d5f0f466