### PR TITLE
Add DSC parsing check

### DIFF
--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -657,6 +657,14 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       trackEvent(ProofEvents.FETCH_DATA_STARTED);
       try {
         const { passportData, env } = get();
+        if (!passportData?.dsc_parsed) {
+          console.error('Missing parsed DSC in passport data');
+          trackEvent(ProofEvents.FETCH_DATA_FAILED, {
+            message: 'Missing parsed DSC in passport data',
+          });
+          actor!.send({ type: 'FETCH_ERROR' });
+          return;
+        }
         const document: DocumentCategory = passportData.documentCategory;
         await useProtocolStore
           .getState()

--- a/app/tests/utils/proving/provingMachine.startFetchingData.test.ts
+++ b/app/tests/utils/proving/provingMachine.startFetchingData.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+import { jest } from '@jest/globals';
+
+import { useProtocolStore } from '../../../src/stores/protocolStore';
+import { useProvingStore } from '../../../src/utils/proving/provingMachine';
+import { actorMock } from './actorMock';
+
+jest.mock('xstate', () => {
+  const actual = jest.requireActual('xstate') as any;
+  const { actorMock: mockActor } = require('./actorMock');
+  return { ...actual, createActor: jest.fn(() => mockActor) };
+});
+
+jest.mock('../../../src/utils/analytics', () => () => ({
+  trackEvent: jest.fn(),
+}));
+jest.mock('../../../src/providers/passportDataProvider', () => ({
+  loadSelectedDocument: jest.fn(),
+}));
+jest.mock('../../../src/providers/authProvider', () => ({
+  unsafe_getPrivateKey: jest.fn(),
+}));
+
+describe('startFetchingData', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const {
+      loadSelectedDocument,
+    } = require('../../../src/providers/passportDataProvider');
+    loadSelectedDocument.mockResolvedValue({
+      data: {
+        documentCategory: 'passport',
+        mock: false,
+        dsc_parsed: { authorityKeyIdentifier: 'key' },
+      },
+    });
+    const {
+      unsafe_getPrivateKey,
+    } = require('../../../src/providers/authProvider');
+    unsafe_getPrivateKey.mockResolvedValue('secret');
+    useProtocolStore.setState({
+      passport: { fetch_all: jest.fn().mockResolvedValue(undefined) },
+    } as any);
+    await useProvingStore.getState().init('register');
+    actorMock.send.mockClear();
+    useProtocolStore.setState({
+      passport: { fetch_all: jest.fn() },
+    } as any);
+    useProvingStore.setState({
+      passportData: { documentCategory: 'passport', mock: false },
+      env: 'prod',
+    });
+  });
+
+  it('emits FETCH_ERROR when dsc_parsed is missing', async () => {
+    await useProvingStore.getState().startFetchingData();
+
+    expect(
+      useProtocolStore.getState().passport.fetch_all,
+    ).not.toHaveBeenCalled();
+    expect(actorMock.send).toHaveBeenCalledWith({ type: 'FETCH_ERROR' });
+  });
+});


### PR DESCRIPTION
## Summary
- guard fetching with passportData.dsc_parsed check to avoid crashes
- add regression test for missing dsc_parsed when fetching protocol data

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` (fails: HH8 invalid account)
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` (fails: unsupported signature algorithm)
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_688efe22e524832da8990b892c08ff97