### PR TITLE
Refine any typings

### DIFF
--- a/app/src/components/buttons/AbstractButton.tsx
+++ b/app/src/components/buttons/AbstractButton.tsx
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import React from 'react';
-import { Platform, StyleSheet, ViewStyle } from 'react-native';
+import {
+  GestureResponderEvent,
+  Platform,
+  StyleSheet,
+  ViewStyle,
+} from 'react-native';
 import { Button, Text, ViewProps } from 'tamagui';
 
 import { shouldShowAesopRedesign } from '../../hooks/useAesopRedesign';
@@ -20,7 +25,7 @@ interface AbstractButtonProps extends ButtonProps {
   borderColor?: string;
   borderWidth?: number;
   color: string;
-  onPress?: ((e: any) => void) | null | undefined;
+  onPress?: ((e: GestureResponderEvent) => void) | null | undefined;
 }
 
 const { trackEvent: analyticsTrackEvent } = analytics();
@@ -45,7 +50,7 @@ export default function AbstractButton({
 }: AbstractButtonProps) {
   const hasBorder = borderColor ? true : false;
 
-  const handlePress = (e: any) => {
+  const handlePress = (e: GestureResponderEvent) => {
     if (trackEvent) {
       // attempt to remove event category from click event
       const parsedEvent = trackEvent?.split(':')?.[1]?.trim();

--- a/app/src/components/native/PassportCamera.tsx
+++ b/app/src/components/native/PassportCamera.tsx
@@ -6,6 +6,8 @@ import {
   PixelRatio,
   Platform,
   requireNativeComponent,
+  StyleProp,
+  ViewStyle,
 } from 'react-native';
 
 import { extractMRZInfo } from '../../utils/utils';
@@ -32,7 +34,7 @@ interface NativePassportOCRViewProps {
       stackTrace: string;
     }>,
   ) => void;
-  style?: any; // Or a more specific style type if available
+  style?: StyleProp<ViewStyle>;
 }
 
 const RCTPassportOCRViewNativeComponent = Platform.select({

--- a/app/src/components/native/QRCodeScanner.tsx
+++ b/app/src/components/native/QRCodeScanner.tsx
@@ -6,6 +6,8 @@ import {
   PixelRatio,
   Platform,
   requireNativeComponent,
+  StyleProp,
+  ViewStyle,
 } from 'react-native';
 
 import { RCTFragment } from './RCTFragment';
@@ -19,7 +21,7 @@ interface NativeQRCodeScannerViewProps {
       stackTrace: string;
     }>,
   ) => void;
-  style?: any; // Or a more specific style type
+  style?: StyleProp<ViewStyle>;
 }
 
 const QRCodeNativeComponent = Platform.select({

--- a/app/src/providers/authProvider.tsx
+++ b/app/src/providers/authProvider.tsx
@@ -54,11 +54,12 @@ const _getSecurely = async function <T>(
       signature: 'authenticated',
       data: formatter(dataString),
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in _getSecurely:', error);
+    const message = error instanceof Error ? error.message : String(error);
     trackEvent(AuthEvents.BIOMETRIC_AUTH_FAILED, {
       reason: 'unknown_error',
-      error: error.message,
+      error: message,
     });
     throw error;
   }
@@ -69,11 +70,12 @@ async function checkBiometricsAvailable(): Promise<boolean> {
     const { available } = await biometrics.isSensorAvailable();
     trackEvent(AuthEvents.BIOMETRIC_CHECK, { available });
     return available;
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error checking biometric availability:', error);
+    const message = error instanceof Error ? error.message : String(error);
     trackEvent(AuthEvents.BIOMETRIC_CHECK, {
       reason: 'unknown_error',
-      error: error.message,
+      error: message,
     });
     return false;
   }
@@ -95,10 +97,10 @@ async function restoreFromMnemonic(mnemonic: string): Promise<string | false> {
     });
     trackEvent(AuthEvents.MNEMONIC_RESTORE_SUCCESS);
     return data;
-  } catch (error: any) {
+  } catch (error: unknown) {
     trackEvent(AuthEvents.MNEMONIC_RESTORE_FAILED, {
       reason: 'unknown_error',
-      error: error.message,
+      error: error instanceof Error ? error.message : String(error),
     });
     return false;
   }
@@ -114,16 +116,16 @@ async function loadOrCreateMnemonic(): Promise<string | false> {
       console.log('Stored mnemonic parsed successfully');
       trackEvent(AuthEvents.MNEMONIC_LOADED);
       return storedMnemonic.password;
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.log(
         'Error parsing stored mnemonic, old secret format was used',
         e,
       );
       console.log('Creating a new one');
-      trackEvent(AuthEvents.MNEMONIC_RESTORE_FAILED, {
-        reason: 'unknown_error',
-        error: e.message,
-      });
+        trackEvent(AuthEvents.MNEMONIC_RESTORE_FAILED, {
+          reason: 'unknown_error',
+          error: e instanceof Error ? e.message : String(e),
+        });
     }
   }
 
@@ -138,10 +140,10 @@ async function loadOrCreateMnemonic(): Promise<string | false> {
     });
     trackEvent(AuthEvents.MNEMONIC_CREATED);
     return data;
-  } catch (error: any) {
+  } catch (error: unknown) {
     trackEvent(AuthEvents.MNEMONIC_RESTORE_FAILED, {
       reason: 'unknown_error',
-      error: error.message,
+      error: error instanceof Error ? error.message : String(error),
     });
     return false;
   }

--- a/app/src/providers/authProvider.web.tsx
+++ b/app/src/providers/authProvider.web.tsx
@@ -105,11 +105,12 @@ const _getSecurely = async function <T>(
       signature: 'authenticated',
       data: formatter(dataString),
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in _getSecurely:', error);
+    const message = error instanceof Error ? error.message : String(error);
     trackEvent(AuthEvents.BIOMETRIC_AUTH_FAILED, {
       reason: 'unknown_error',
-      error: error.message,
+      error: message,
     });
     throw error;
   }
@@ -190,8 +191,11 @@ export const AuthProvider = ({
         } else {
           return { success: false, error: 'No private key provided' };
         }
-      } catch (error: any) {
-        return { success: false, error: error.message };
+      } catch (error: unknown) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
       }
     })();
 

--- a/app/src/providers/passportDataProvider.tsx
+++ b/app/src/providers/passportDataProvider.tsx
@@ -56,7 +56,7 @@ import React, {
 import Keychain from 'react-native-keychain';
 
 import { unsafe_getPrivateKey, useAuth } from '../providers/authProvider';
-interface DocumentMetadata {
+export interface DocumentMetadata {
   id: string; // contentHash as ID for deduplication
   documentType: string; // passport, mock_passport, id_card, etc.
   documentCategory: DocumentCategory; // passport, id_card, aadhaar
@@ -65,7 +65,7 @@ interface DocumentMetadata {
   isRegistered?: boolean; // whether the document is registered onChain
 }
 
-interface DocumentCatalog {
+export interface DocumentCatalog {
   documents: DocumentMetadata[];
   selectedDocumentId?: string; // This is now a contentHash
 }

--- a/app/src/screens/dev/DevSettingsScreen.tsx
+++ b/app/src/screens/dev/DevSettingsScreen.tsx
@@ -9,7 +9,14 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { Alert, Platform, StyleProp, TextInput } from 'react-native';
+import {
+  Alert,
+  Platform,
+  StyleProp,
+  TextInput,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
 import { Adapt, Button, Select, Sheet, Text, XStack, YStack } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation';
@@ -32,7 +39,7 @@ interface DevSettingsScreenProps extends PropsWithChildren {
     | 'space-evenly';
   userSelect?: 'all' | 'text' | 'none' | 'contain';
   textAlign?: 'center' | 'left' | 'right';
-  style?: StyleProp<any>;
+  style?: StyleProp<TextStyle | ViewStyle>;
 }
 
 function SelectableText({ children, ...props }: DevSettingsScreenProps) {
@@ -85,7 +92,7 @@ const ScreenSelector = ({}) => {
   const navigation = useNavigation();
   return (
     <Select
-      onValueChange={(screen: any) => {
+      onValueChange={(screen: keyof RootStackParamList) => {
         navigation.navigate(screen);
       }}
       disablePreventBodyScroll

--- a/app/src/screens/misc/LoadingScreen.tsx
+++ b/app/src/screens/misc/LoadingScreen.tsx
@@ -38,9 +38,9 @@ const terminalStates: ProvingStateType[] = [
 
 const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
   // Animation states
-  const [animationSource, setAnimationSource] = useState<any>(
-    proveLoadingAnimation,
-  );
+  const [animationSource, setAnimationSource] = useState<
+    LottieView['props']['source']
+  >(proveLoadingAnimation);
 
   // Passport data state
   const [passportData, setPassportData] = useState<PassportData | null>(null);
@@ -82,7 +82,7 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
             const { passportData: _passportData } = JSON.parse(result);
             setPassportData(_passportData);
           }
-        } catch (error: any) {
+        } catch (error: unknown) {
           console.error('Error loading passport data:', error);
         }
       }

--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -184,10 +184,11 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
         let parsedPassportData: PassportData | null = null;
         try {
           passportData = parseScanResponse(scanResponse);
-        } catch (e: any) {
+        } catch (e: unknown) {
           console.error('Parsing NFC Response Unsuccessful');
+          const message = e instanceof Error ? e.message : String(e);
           trackEvent(PassportEvents.NFC_RESPONSE_PARSE_FAILED, {
-            error: e.message,
+            error: message,
           });
           return;
         }
@@ -241,24 +242,26 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
           // Feels better somehow
           await new Promise(resolve => setTimeout(resolve, 1000));
           navigation.navigate('ConfirmBelongingScreen', {});
-        } catch (e: any) {
+        } catch (e: unknown) {
           console.error('Passport Parsed Failed:', e);
+          const message = e instanceof Error ? e.message : String(e);
           trackEvent(PassportEvents.PASSPORT_PARSE_FAILED, {
-            error: e.message,
+            error: message,
           });
           return;
         }
-      } catch (e: any) {
+      } catch (e: unknown) {
         const scanDurationSeconds = (
           (Date.now() - scanStartTime) /
           1000
         ).toFixed(2);
+        const message = e instanceof Error ? e.message : String(e);
         console.error('NFC Scan Unsuccessful:', e);
         trackEvent(PassportEvents.NFC_SCAN_FAILED, {
-          error: e.message,
+          error: message,
           duration_seconds: parseFloat(scanDurationSeconds),
         });
-        openErrorModal(e.message);
+        openErrorModal(message);
       } finally {
         setIsNfcSheetOpen(false);
       }

--- a/app/src/screens/prove/ConfirmBelongingScreen.tsx
+++ b/app/src/screens/prove/ConfirmBelongingScreen.tsx
@@ -63,10 +63,12 @@ const ConfirmBelongingScreen: React.FC<ConfirmBelongingScreenProps> = ({}) => {
 
       // Navigate to loading screen
       navigate();
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error initializing proving process:', error);
+      const message =
+        error instanceof Error ? error.message : 'Unknown error';
       trackEvent(ProofEvents.PROVING_PROCESS_ERROR, {
-        error: error?.message || 'Unknown error',
+        error: message,
       });
     } finally {
       setRequestingPermission(false);

--- a/app/src/screens/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/recovery/AccountRecoveryChoiceScreen.tsx
@@ -81,7 +81,7 @@ const AccountRecoveryChoiceScreen: React.FC<
       trackEvent(BackupEvents.ACCOUNT_RECOVERY_COMPLETED);
       onRestoreFromCloudNext();
       setRestoring(false);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(e);
       trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN);
       setRestoring(false);

--- a/app/src/screens/settings/ManageDocumentsScreen.tsx
+++ b/app/src/screens/settings/ManageDocumentsScreen.tsx
@@ -11,7 +11,11 @@ import { PrimaryButton } from '../../components/buttons/PrimaryButton';
 import { SecondaryButton } from '../../components/buttons/SecondaryButton';
 import ButtonsContainer from '../../components/ButtonsContainer';
 import { DocumentEvents } from '../../consts/analytics';
-import { usePassport } from '../../providers/passportDataProvider';
+import {
+  usePassport,
+  type DocumentCatalog,
+  type DocumentMetadata,
+} from '../../providers/passportDataProvider';
 import analytics from '../../utils/analytics';
 import { borderColor, textBlack, white } from '../../utils/colors';
 import { extraYPadding } from '../../utils/constants';
@@ -28,10 +32,12 @@ const PassportDataSelector = () => {
     deleteDocument,
     setSelectedDocument,
   } = usePassport();
-  const [documentCatalog, setDocumentCatalog] = useState<any>({
+  const [documentCatalog, setDocumentCatalog] = useState<DocumentCatalog>({
     documents: [],
   });
-  const [_allDocuments, setAllDocuments] = useState<any>({});
+  const [_allDocuments, setAllDocuments] = useState<
+    Record<string, { metadata: DocumentMetadata }>
+  >({});
   const [loading, setLoading] = useState(true);
 
   const loadPassportDataInfo = useCallback(async () => {
@@ -110,7 +116,7 @@ const PassportDataSelector = () => {
     }
   };
 
-  const getDocumentInfo = (metadata: any): string => {
+  const getDocumentInfo = (metadata: DocumentMetadata): string => {
     const countryCode =
       extractCountryFromData(metadata.data, metadata.documentCategory) ||
       'Unknown';
@@ -187,7 +193,7 @@ const PassportDataSelector = () => {
       >
         Available Documents
       </Text>
-      {documentCatalog.documents.map((metadata: any) => (
+      {documentCatalog.documents.map((metadata: DocumentMetadata) => (
         <YStack
           key={metadata.id}
           padding="$3"


### PR DESCRIPTION
## Summary
- replace many `any` error catches with `unknown`
- add proper types for QR and passport native view styles
- export and consume `DocumentMetadata` typings in manage documents screen

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` (fails: Hardhat config error)
- `yarn types` (fails: The command failed in workspace @selfxyz/mobile-app@workspace:app)
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_688f79715854832d9b9641c14d9f9757