### PR TITLE
Add Maestro e2e testing

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,0 +1,56 @@
+name: Mobile E2E
+
+on:
+  push:
+    paths:
+      - 'app/**'
+      - '.github/workflows/mobile-e2e.yml'
+  pull_request:
+    paths:
+      - 'app/**'
+      - '.github/workflows/mobile-e2e.yml'
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: corepack enable
+      - run: yarn install
+      - name: Install Maestro
+        run: |
+          curl -Ls https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+      - name: Run Android flow
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          script: |
+            cd app
+            yarn build:deps
+            yarn test:e2e:android
+
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: corepack enable
+      - run: yarn install
+      - name: Install Maestro
+        run: |
+          curl -Ls https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+      - name: Build and run iOS flow
+        run: |
+          cd app
+          yarn build:deps
+          xcodebuild -workspace ios/OpenPassport.xcworkspace -scheme OpenPassport -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build
+          xcrun simctl boot "iPhone 15" || true
+          yarn test:e2e:ios

--- a/app/README.md
+++ b/app/README.md
@@ -341,6 +341,25 @@ bundle exec fastlane ios internal_test test_mode:true
 bundle exec fastlane android internal_test test_mode:true
 ```
 
+### Maestro end-to-end tests
+
+Install the Maestro CLI locally using curl or Homebrew:
+
+```bash
+curl -Ls https://get.maestro.mobile.dev | bash
+# or
+brew install maestro
+```
+
+Then build the app and run the flow:
+
+```bash
+yarn test:e2e:android  # Android
+yarn test:e2e:ios      # iOS
+```
+
+The flow definition lives in [`e2e/launch.flow.yaml`](e2e/launch.flow.yaml).
+
 ## FAQ
 
 If you get something like this:

--- a/app/e2e/launch.flow.yaml
+++ b/app/e2e/launch.flow.yaml
@@ -1,0 +1,6 @@
+appId: com.proofofpassportapp
+---
+- launchApp
+- waitFor: { visible: { id: "home-screen" }, timeout: 10000 }
+  onTimeout:
+    - waitFor: { visible: { id: "launch-screen" }, timeout: 10000 }

--- a/app/package.json
+++ b/app/package.json
@@ -61,7 +61,9 @@
     "types": "tsc --noEmit",
     "web": "vite",
     "web:build": "vite build",
-    "web:preview": "vite preview"
+    "web:preview": "vite preview",
+    "test:e2e:android": "cd android && ./gradlew assembleDebug && cd .. && maestro test app/e2e/launch.flow.yaml --platform android",
+    "test:e2e:ios": "xcodebuild -workspace ios/OpenPassport.xcworkspace -scheme OpenPassport -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build && maestro test app/e2e/launch.flow.yaml --platform ios"
   },
   "dependencies": {
     "@babel/runtime": "^7.27.4",


### PR DESCRIPTION
## Summary
- document running Maestro tests and reference flow
- add Maestro flow and npm scripts for android/ios
- add GitHub Actions workflow to run Maestro end-to-end tests

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` (fails: Invalid account for network)
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` (fails: Unsupported signature algorithm)
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_6890145be06c832d8821ecc7b51e4e37