### PR TITLE
Refine any typings

### DIFF
--- a/app/src/RemoteConfig.ts
+++ b/app/src/RemoteConfig.ts
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import remoteConfig from '@react-native-firebase/remote-config';
+import remoteConfig, {
+  ConfigDefaults,
+  ConfigSettings,
+} from '@react-native-firebase/remote-config';
 
 import {
   clearAllLocalOverrides as clearAllLocalOverridesShared,
@@ -38,10 +41,10 @@ const mobileRemoteConfigBackend: RemoteConfigBackend = {
   getAll: () => {
     return remoteConfig().getAll();
   },
-  setDefaults: async (defaults: Record<string, any>) => {
+  setDefaults: async (defaults: ConfigDefaults) => {
     await remoteConfig().setDefaults(defaults);
   },
-  setConfigSettings: async (settings: any) => {
+  setConfigSettings: async (settings: ConfigSettings) => {
     await remoteConfig().setConfigSettings(settings);
   },
   fetchAndActivate: async (): Promise<boolean> => {

--- a/app/src/RemoteConfig.web.ts
+++ b/app/src/RemoteConfig.web.ts
@@ -33,14 +33,14 @@ const webStorageBackend: StorageBackend = {
 // Mock Firebase Remote Config for web (since Firebase Web SDK for Remote Config is not installed)
 // In a real implementation, you would import and use the Firebase Web SDK
 class MockFirebaseRemoteConfig implements RemoteConfigBackend {
-  private config: Record<string, any> = {};
-  private settings: any = {};
+  private config: Record<string, unknown> = {};
+  private settings: Record<string, unknown> = {};
 
-  setDefaults(defaults: Record<string, any>) {
+  setDefaults(defaults: Record<string, unknown>) {
     this.config = { ...defaults };
   }
 
-  setConfigSettings(settings: any) {
+  setConfigSettings(settings: Record<string, unknown>) {
     this.settings = settings;
   }
 

--- a/app/src/components/buttons/AbstractButton.tsx
+++ b/app/src/components/buttons/AbstractButton.tsx
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import React from 'react';
-import { Platform, StyleSheet, ViewStyle } from 'react-native';
+import {
+  GestureResponderEvent,
+  Platform,
+  StyleSheet,
+  ViewStyle,
+} from 'react-native';
 import { Button, Text, ViewProps } from 'tamagui';
 
 import { shouldShowAesopRedesign } from '../../hooks/useAesopRedesign';
@@ -20,7 +25,7 @@ interface AbstractButtonProps extends ButtonProps {
   borderColor?: string;
   borderWidth?: number;
   color: string;
-  onPress?: ((e: any) => void) | null | undefined;
+  onPress?: ((e: GestureResponderEvent) => void) | null | undefined;
 }
 
 const { trackEvent: analyticsTrackEvent } = analytics();
@@ -45,7 +50,7 @@ export default function AbstractButton({
 }: AbstractButtonProps) {
   const hasBorder = borderColor ? true : false;
 
-  const handlePress = (e: any) => {
+  const handlePress = (e: GestureResponderEvent) => {
     if (trackEvent) {
       // attempt to remove event category from click event
       const parsedEvent = trackEvent?.split(':')?.[1]?.trim();

--- a/app/src/components/native/PassportCamera.tsx
+++ b/app/src/components/native/PassportCamera.tsx
@@ -6,6 +6,8 @@ import {
   PixelRatio,
   Platform,
   requireNativeComponent,
+  StyleProp,
+  ViewStyle,
 } from 'react-native';
 
 import { extractMRZInfo } from '../../utils/utils';
@@ -32,7 +34,7 @@ interface NativePassportOCRViewProps {
       stackTrace: string;
     }>,
   ) => void;
-  style?: any; // Or a more specific style type if available
+  style?: StyleProp<ViewStyle>;
 }
 
 const RCTPassportOCRViewNativeComponent = Platform.select({

--- a/app/src/components/native/QRCodeScanner.tsx
+++ b/app/src/components/native/QRCodeScanner.tsx
@@ -6,6 +6,8 @@ import {
   PixelRatio,
   Platform,
   requireNativeComponent,
+  StyleProp,
+  ViewStyle,
 } from 'react-native';
 
 import { RCTFragment } from './RCTFragment';
@@ -19,7 +21,7 @@ interface NativeQRCodeScannerViewProps {
       stackTrace: string;
     }>,
   ) => void;
-  style?: any; // Or a more specific style type
+  style?: StyleProp<ViewStyle>;
 }
 
 const QRCodeNativeComponent = Platform.select({

--- a/app/src/providers/authProvider.tsx
+++ b/app/src/providers/authProvider.tsx
@@ -54,11 +54,12 @@ const _getSecurely = async function <T>(
       signature: 'authenticated',
       data: formatter(dataString),
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in _getSecurely:', error);
+    const message = error instanceof Error ? error.message : String(error);
     trackEvent(AuthEvents.BIOMETRIC_AUTH_FAILED, {
       reason: 'unknown_error',
-      error: error.message,
+      error: message,
     });
     throw error;
   }
@@ -69,11 +70,12 @@ async function checkBiometricsAvailable(): Promise<boolean> {
     const { available } = await biometrics.isSensorAvailable();
     trackEvent(AuthEvents.BIOMETRIC_CHECK, { available });
     return available;
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error checking biometric availability:', error);
+    const message = error instanceof Error ? error.message : String(error);
     trackEvent(AuthEvents.BIOMETRIC_CHECK, {
       reason: 'unknown_error',
-      error: error.message,
+      error: message,
     });
     return false;
   }
@@ -95,10 +97,10 @@ async function restoreFromMnemonic(mnemonic: string): Promise<string | false> {
     });
     trackEvent(AuthEvents.MNEMONIC_RESTORE_SUCCESS);
     return data;
-  } catch (error: any) {
+  } catch (error: unknown) {
     trackEvent(AuthEvents.MNEMONIC_RESTORE_FAILED, {
       reason: 'unknown_error',
-      error: error.message,
+      error: error instanceof Error ? error.message : String(error),
     });
     return false;
   }
@@ -114,16 +116,16 @@ async function loadOrCreateMnemonic(): Promise<string | false> {
       console.log('Stored mnemonic parsed successfully');
       trackEvent(AuthEvents.MNEMONIC_LOADED);
       return storedMnemonic.password;
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.log(
         'Error parsing stored mnemonic, old secret format was used',
         e,
       );
       console.log('Creating a new one');
-      trackEvent(AuthEvents.MNEMONIC_RESTORE_FAILED, {
-        reason: 'unknown_error',
-        error: e.message,
-      });
+        trackEvent(AuthEvents.MNEMONIC_RESTORE_FAILED, {
+          reason: 'unknown_error',
+          error: e instanceof Error ? e.message : String(e),
+        });
     }
   }
 
@@ -138,10 +140,10 @@ async function loadOrCreateMnemonic(): Promise<string | false> {
     });
     trackEvent(AuthEvents.MNEMONIC_CREATED);
     return data;
-  } catch (error: any) {
+  } catch (error: unknown) {
     trackEvent(AuthEvents.MNEMONIC_RESTORE_FAILED, {
       reason: 'unknown_error',
-      error: error.message,
+      error: error instanceof Error ? error.message : String(error),
     });
     return false;
   }

--- a/app/src/providers/authProvider.web.tsx
+++ b/app/src/providers/authProvider.web.tsx
@@ -105,11 +105,12 @@ const _getSecurely = async function <T>(
       signature: 'authenticated',
       data: formatter(dataString),
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in _getSecurely:', error);
+    const message = error instanceof Error ? error.message : String(error);
     trackEvent(AuthEvents.BIOMETRIC_AUTH_FAILED, {
       reason: 'unknown_error',
-      error: error.message,
+      error: message,
     });
     throw error;
   }
@@ -190,8 +191,11 @@ export const AuthProvider = ({
         } else {
           return { success: false, error: 'No private key provided' };
         }
-      } catch (error: any) {
-        return { success: false, error: error.message };
+      } catch (error: unknown) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
       }
     })();
 

--- a/app/src/providers/passportDataProvider.tsx
+++ b/app/src/providers/passportDataProvider.tsx
@@ -56,7 +56,7 @@ import React, {
 import Keychain from 'react-native-keychain';
 
 import { unsafe_getPrivateKey, useAuth } from '../providers/authProvider';
-interface DocumentMetadata {
+export interface DocumentMetadata {
   id: string; // contentHash as ID for deduplication
   documentType: string; // passport, mock_passport, id_card, etc.
   documentCategory: DocumentCategory; // passport, id_card, aadhaar
@@ -65,7 +65,7 @@ interface DocumentMetadata {
   isRegistered?: boolean; // whether the document is registered onChain
 }
 
-interface DocumentCatalog {
+export interface DocumentCatalog {
   documents: DocumentMetadata[];
   selectedDocumentId?: string; // This is now a contentHash
 }

--- a/app/src/screens/dev/DevSettingsScreen.tsx
+++ b/app/src/screens/dev/DevSettingsScreen.tsx
@@ -9,7 +9,14 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { Alert, Platform, StyleProp, TextInput } from 'react-native';
+import {
+  Alert,
+  Platform,
+  StyleProp,
+  TextInput,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
 import { Adapt, Button, Select, Sheet, Text, XStack, YStack } from 'tamagui';
 
 import { RootStackParamList } from '../../navigation';
@@ -32,7 +39,7 @@ interface DevSettingsScreenProps extends PropsWithChildren {
     | 'space-evenly';
   userSelect?: 'all' | 'text' | 'none' | 'contain';
   textAlign?: 'center' | 'left' | 'right';
-  style?: StyleProp<any>;
+  style?: StyleProp<TextStyle | ViewStyle>;
 }
 
 function SelectableText({ children, ...props }: DevSettingsScreenProps) {
@@ -85,7 +92,7 @@ const ScreenSelector = ({}) => {
   const navigation = useNavigation();
   return (
     <Select
-      onValueChange={(screen: any) => {
+      onValueChange={(screen: keyof RootStackParamList) => {
         navigation.navigate(screen);
       }}
       disablePreventBodyScroll
@@ -94,7 +101,7 @@ const ScreenSelector = ({}) => {
         <Select.Value placeholder="Select screen to jump to" />
       </Select.Trigger>
 
-      <Adapt when={'sm' as any} platform="touch">
+      <Adapt when="sm" platform="touch">
         <Sheet native modal dismissOnSnapToBottom animation="medium">
           <Sheet.Frame>
             <Sheet.ScrollView>

--- a/app/src/screens/misc/LoadingScreen.tsx
+++ b/app/src/screens/misc/LoadingScreen.tsx
@@ -38,9 +38,9 @@ const terminalStates: ProvingStateType[] = [
 
 const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
   // Animation states
-  const [animationSource, setAnimationSource] = useState<any>(
-    proveLoadingAnimation,
-  );
+  const [animationSource, setAnimationSource] = useState<
+    LottieView['props']['source']
+  >(proveLoadingAnimation);
 
   // Passport data state
   const [passportData, setPassportData] = useState<PassportData | null>(null);
@@ -82,7 +82,7 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
             const { passportData: _passportData } = JSON.parse(result);
             setPassportData(_passportData);
           }
-        } catch (error: any) {
+        } catch (error: unknown) {
           console.error('Error loading passport data:', error);
         }
       }

--- a/app/src/screens/misc/SplashScreen.tsx
+++ b/app/src/screens/misc/SplashScreen.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import LottieView from 'lottie-react-native';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet } from 'react-native';
@@ -17,13 +18,17 @@ import {
 import { useSettingStore } from '../../stores/settingStore';
 import { black } from '../../utils/colors';
 import { impactLight } from '../../utils/haptic';
+import type { RootStackParamList } from '../../navigation';
 
 const SplashScreen: React.FC = ({}) => {
-  const navigation = useNavigation();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { checkBiometricsAvailable } = useAuth();
   const { setBiometricsAvailable } = useSettingStore();
   const [isAnimationFinished, setIsAnimationFinished] = useState(false);
-  const [nextScreen, setNextScreen] = useState<string | null>(null);
+  const [nextScreen, setNextScreen] = useState<
+    keyof RootStackParamList | null
+  >(null);
   const dataLoadInitiatedRef = useRef(false);
 
   useEffect(() => {
@@ -83,7 +88,7 @@ const SplashScreen: React.FC = ({}) => {
     if (isAnimationFinished && nextScreen) {
       console.log(`Navigating to ${nextScreen}`);
       requestAnimationFrame(() => {
-        navigation.navigate(nextScreen as any);
+        navigation.navigate(nextScreen);
       });
     }
   }, [isAnimationFinished, nextScreen, navigation]);

--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -184,10 +184,11 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
         let parsedPassportData: PassportData | null = null;
         try {
           passportData = parseScanResponse(scanResponse);
-        } catch (e: any) {
+        } catch (e: unknown) {
           console.error('Parsing NFC Response Unsuccessful');
+          const message = e instanceof Error ? e.message : String(e);
           trackEvent(PassportEvents.NFC_RESPONSE_PARSE_FAILED, {
-            error: e.message,
+            error: message,
           });
           return;
         }
@@ -241,24 +242,26 @@ const PassportNFCScanScreen: React.FC<PassportNFCScanScreenProps> = ({}) => {
           // Feels better somehow
           await new Promise(resolve => setTimeout(resolve, 1000));
           navigation.navigate('ConfirmBelongingScreen', {});
-        } catch (e: any) {
+        } catch (e: unknown) {
           console.error('Passport Parsed Failed:', e);
+          const message = e instanceof Error ? e.message : String(e);
           trackEvent(PassportEvents.PASSPORT_PARSE_FAILED, {
-            error: e.message,
+            error: message,
           });
           return;
         }
-      } catch (e: any) {
+      } catch (e: unknown) {
         const scanDurationSeconds = (
           (Date.now() - scanStartTime) /
           1000
         ).toFixed(2);
+        const message = e instanceof Error ? e.message : String(e);
         console.error('NFC Scan Unsuccessful:', e);
         trackEvent(PassportEvents.NFC_SCAN_FAILED, {
-          error: e.message,
+          error: message,
           duration_seconds: parseFloat(scanDurationSeconds),
         });
-        openErrorModal(e.message);
+        openErrorModal(message);
       } finally {
         setIsNfcSheetOpen(false);
       }

--- a/app/src/screens/prove/ConfirmBelongingScreen.tsx
+++ b/app/src/screens/prove/ConfirmBelongingScreen.tsx
@@ -63,10 +63,12 @@ const ConfirmBelongingScreen: React.FC<ConfirmBelongingScreenProps> = ({}) => {
 
       // Navigate to loading screen
       navigate();
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error initializing proving process:', error);
+      const message =
+        error instanceof Error ? error.message : 'Unknown error';
       trackEvent(ProofEvents.PROVING_PROCESS_ERROR, {
-        error: error?.message || 'Unknown error',
+        error: message,
       });
     } finally {
       setRequestingPermission(false);

--- a/app/src/screens/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/recovery/AccountRecoveryChoiceScreen.tsx
@@ -81,7 +81,7 @@ const AccountRecoveryChoiceScreen: React.FC<
       trackEvent(BackupEvents.ACCOUNT_RECOVERY_COMPLETED);
       onRestoreFromCloudNext();
       setRestoring(false);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(e);
       trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN);
       setRestoring(false);

--- a/app/src/screens/settings/ManageDocumentsScreen.tsx
+++ b/app/src/screens/settings/ManageDocumentsScreen.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Check, Eraser } from '@tamagui/lucide-icons';
 import React, { useCallback, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
@@ -11,9 +12,14 @@ import { PrimaryButton } from '../../components/buttons/PrimaryButton';
 import { SecondaryButton } from '../../components/buttons/SecondaryButton';
 import ButtonsContainer from '../../components/ButtonsContainer';
 import { DocumentEvents } from '../../consts/analytics';
-import { usePassport } from '../../providers/passportDataProvider';
+import {
+  usePassport,
+  type DocumentCatalog,
+  type DocumentMetadata,
+} from '../../providers/passportDataProvider';
 import analytics from '../../utils/analytics';
 import { borderColor, textBlack, white } from '../../utils/colors';
+import type { RootStackParamList } from '../../navigation';
 import { extraYPadding } from '../../utils/constants';
 import { impactLight } from '../../utils/haptic';
 
@@ -28,10 +34,12 @@ const PassportDataSelector = () => {
     deleteDocument,
     setSelectedDocument,
   } = usePassport();
-  const [documentCatalog, setDocumentCatalog] = useState<any>({
+  const [documentCatalog, setDocumentCatalog] = useState<DocumentCatalog>({
     documents: [],
   });
-  const [_allDocuments, setAllDocuments] = useState<any>({});
+  const [_allDocuments, setAllDocuments] = useState<
+    Record<string, { metadata: DocumentMetadata }>
+  >({});
   const [loading, setLoading] = useState(true);
 
   const loadPassportDataInfo = useCallback(async () => {
@@ -110,7 +118,7 @@ const PassportDataSelector = () => {
     }
   };
 
-  const getDocumentInfo = (metadata: any): string => {
+  const getDocumentInfo = (metadata: DocumentMetadata): string => {
     const countryCode =
       extractCountryFromData(metadata.data, metadata.documentCategory) ||
       'Unknown';
@@ -187,7 +195,7 @@ const PassportDataSelector = () => {
       >
         Available Documents
       </Text>
-      {documentCatalog.documents.map((metadata: any) => (
+      {documentCatalog.documents.map((metadata: DocumentMetadata) => (
         <YStack
           key={metadata.id}
           padding="$3"
@@ -258,7 +266,8 @@ const PassportDataSelector = () => {
 };
 
 const ManageDocumentsScreen: React.FC<ManageDocumentsScreenProps> = ({}) => {
-  const navigation = useNavigation();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { bottom } = useSafeAreaInsets();
 
   useEffect(() => {
@@ -268,13 +277,13 @@ const ManageDocumentsScreen: React.FC<ManageDocumentsScreenProps> = ({}) => {
   const handleScanDocument = () => {
     impactLight();
     trackEvent(DocumentEvents.ADD_NEW_SCAN_SELECTED);
-    navigation.navigate('PassportOnboarding' as any);
+    navigation.navigate('PassportOnboarding');
   };
 
   const handleGenerateMock = () => {
     impactLight();
     trackEvent(DocumentEvents.ADD_NEW_MOCK_SELECTED);
-    navigation.navigate('CreateMock' as any);
+    navigation.navigate('CreateMock');
   };
 
   return (

--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Bug, FileText } from '@tamagui/lucide-icons';
 import React, { PropsWithChildren, useCallback, useMemo } from 'react';
 import { Linking, Platform, Share } from 'react-native';
@@ -28,7 +29,7 @@ import ShareIcon from '../../images/icons/share.svg';
 import Star from '../../images/icons/star.svg';
 import Telegram from '../../images/icons/telegram.svg';
 import Web from '../../images/icons/webpage.svg';
-import { RootStackParamList } from '../../navigation';
+import type { RootStackParamList } from '../../navigation';
 import { useSettingStore } from '../../stores/settingStore';
 import {
   amber500,
@@ -43,10 +44,6 @@ import { getCountry, getLocales, getTimeZone } from '../../utils/locale';
 
 interface SettingsScreenProps {}
 interface MenuButtonProps extends PropsWithChildren {
-  Icon: React.FC<SvgProps>;
-  onPress: () => void;
-}
-interface MenuButtonProps {
   Icon: React.FC<SvgProps>;
   onPress: () => void;
 }
@@ -146,7 +143,8 @@ const SocialButton: React.FC<SocialButtonProps> = ({ Icon, href }) => {
 const SettingsScreen: React.FC<SettingsScreenProps> = ({}) => {
   const { isDevMode, setDevModeOn } = useSettingStore();
   useSettingStore();
-  const navigation = useNavigation();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const screenRoutes = useMemo(() => {
     return isDevMode ? [...routes, ...DEBUG_MENU] : routes;
@@ -200,11 +198,11 @@ ${deviceInfo.map(([k, v]) => `${k}=${v}`).join('; ')}
             break;
 
           case 'ManageDocuments':
-            navigation.navigate('ManageDocuments' as any);
+            navigation.navigate('ManageDocuments');
             break;
 
           default:
-            navigation.navigate(menuRoute as any);
+            navigation.navigate(menuRoute);
             break;
         }
       };

--- a/app/src/stores/selfAppStore.tsx
+++ b/app/src/stores/selfAppStore.tsx
@@ -77,11 +77,11 @@ export const useSelfAppStore = create<SelfAppState>((set, get) => ({
       });
 
       // Listen for the event only once per connection attempt
-      socket.once('self_app', (data: any) => {
+      socket.once('self_app', (data: unknown) => {
         console.log('[SelfAppStore] Received self_app event with data:', data);
         try {
           const appData: SelfApp =
-            typeof data === 'string' ? JSON.parse(data) : data;
+            typeof data === 'string' ? JSON.parse(data) : (data as SelfApp);
 
           // Basic validation
           if (!appData || typeof appData !== 'object' || !appData.sessionId) {

--- a/app/src/utils/analytics.ts
+++ b/app/src/utils/analytics.ts
@@ -36,16 +36,16 @@ export interface EventParams {
   reason?: string | null;
   duration_seconds?: number;
   attempt_count?: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 const segmentClient = createSegmentClient();
 
-function cleanParams(params: Record<string, any>) {
-  const newParams = {};
+function cleanParams(params: Record<string, unknown>) {
+  const newParams: Record<string, unknown> = {};
   for (const key of Object.keys(params)) {
     if (typeof params[key] !== 'function') {
-      (newParams as Record<string, any>)[key] = params[key];
+      newParams[key] = params[key];
     }
   }
   return newParams;
@@ -56,23 +56,16 @@ function cleanParams(params: Record<string, any>) {
  * - Ensures numeric values are properly formatted
  */
 function validateParams(
-  properties?: Record<string, any>,
-): Record<string, any> | undefined {
+  properties?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
   if (!properties) return undefined;
 
-  const validatedProps = { ...properties };
+  const validatedProps = { ...properties } as EventParams;
 
   // Ensure duration is formatted as a number with at most 2 decimal places
   if (validatedProps.duration_seconds !== undefined) {
-    if (typeof validatedProps.duration_seconds === 'string') {
-      validatedProps.duration_seconds = parseFloat(
-        validatedProps.duration_seconds,
-      );
-    }
-    // Format to 2 decimal places
-    validatedProps.duration_seconds = parseFloat(
-      validatedProps.duration_seconds.toFixed(2),
-    );
+    const duration = Number(validatedProps.duration_seconds);
+    validatedProps.duration_seconds = parseFloat(duration.toFixed(2));
   }
 
   return cleanParams(validatedProps);
@@ -86,7 +79,7 @@ const analytics = () => {
   function _track(
     type: 'event' | 'screen',
     eventName: string,
-    properties?: Record<string, any>,
+    properties?: Record<string, unknown>,
   ) {
     // Validate and clean properties
     const validatedProps = validateParams(properties);
@@ -102,7 +95,7 @@ const analytics = () => {
     if (!segmentClient) {
       return;
     }
-    const trackMethod = (e: string, p?: Record<string, any>) =>
+    const trackMethod = (e: string, p?: Record<string, unknown>) =>
       type === 'screen'
         ? segmentClient.screen(e, p)
         : segmentClient.track(e, p);
@@ -121,7 +114,10 @@ const analytics = () => {
     trackEvent: (eventName: string, properties?: EventParams) => {
       _track('event', eventName, properties);
     },
-    trackScreenView: (screenName: string, properties?: Record<string, any>) => {
+    trackScreenView: (
+      screenName: string,
+      properties?: Record<string, unknown>,
+    ) => {
       _track('screen', screenName, properties);
     },
     flush: () => {

--- a/app/src/utils/cloudBackup/index.ts
+++ b/app/src/utils/cloudBackup/index.ts
@@ -12,6 +12,18 @@ import { createGDrive } from './google';
 import { FILE_NAME, parseMnemonic, withRetries } from './helpers';
 import * as ios from './ios';
 
+interface DriveFile {
+  id?: string;
+}
+
+function isDriveFile(file: unknown): file is DriveFile {
+  return (
+    typeof file === 'object' &&
+    file !== null &&
+    typeof (file as { id?: unknown }).id === 'string'
+  );
+}
+
 export const STORAGE_NAME = Platform.OS === 'ios' ? 'iCloud' : 'Google Drive';
 
 export function useBackupMnemonic() {
@@ -62,18 +74,17 @@ export async function download() {
     spaces: APP_DATA_FOLDER_ID,
     q: `name = '${FILE_NAME}'`,
   });
-  if (!files.length) {
+
+  const driveFiles: unknown[] = files;
+  const firstFile = driveFiles[0];
+
+  if (!isDriveFile(firstFile)) {
     throw new Error(
       'Couldnt find the encrypted backup, did you back it up previously?',
     );
   }
-  const fileId = (files[0] as any).id as string;
-  if (!fileId) {
-    throw new Error(
-      'Couldnt find the encrypted backup, did you back it up previously?',
-    );
-  }
-  const mnemonicString = await withRetries(() => gdrive.files.getText(fileId));
+
+  const mnemonicString = await withRetries(() => gdrive.files.getText(firstFile.id));
   try {
     const mnemonic = parseMnemonic(mnemonicString);
     return mnemonic;
@@ -96,10 +107,14 @@ export async function disableBackup() {
     spaces: APP_DATA_FOLDER_ID,
     q: `name = '${FILE_NAME}'`,
   });
+
+  const driveFiles: unknown[] = files;
+
   await Promise.all(
-    files.map((f: any) => {
-      const id = f.id as string;
-      return id ? gdrive.files.delete(id) : Promise.resolve();
+    driveFiles.map(file => {
+      return isDriveFile(file) && file.id
+        ? gdrive.files.delete(file.id)
+        : Promise.resolve();
     }),
   );
 }

--- a/app/src/utils/nfcScanner.ts
+++ b/app/src/utils/nfcScanner.ts
@@ -61,13 +61,28 @@ const scanIOS = async (inputs: Inputs) => {
   );
 };
 
-export const parseScanResponse = (response: any) => {
+interface AndroidScanResponse {
+  mrz: string;
+  eContent: string;
+  encryptedDigest: string;
+  _photo?: string;
+  _digestAlgorithm?: string;
+  _signerInfoDigestAlgorithm?: string;
+  _digestEncryptionAlgorithm?: string;
+  _LDSVersion?: string;
+  _unicodeVersion?: string;
+  encapContent: string;
+  documentSigningCertificate: string;
+  dataGroupHashes: string;
+}
+
+export const parseScanResponse = (response: unknown) => {
   return Platform.OS === 'android'
-    ? handleResponseAndroid(response)
-    : handleResponseIOS(response);
+    ? handleResponseAndroid(response as AndroidScanResponse)
+    : handleResponseIOS(response as string);
 };
 
-const handleResponseIOS = (response: any) => {
+const handleResponseIOS = (response: string) => {
   const parsed = JSON.parse(response);
   const dgHashesObj = JSON.parse(parsed?.dataGroupHashes);
   const dg1HashString = dgHashesObj?.DG1?.sodHash;
@@ -124,7 +139,7 @@ const handleResponseIOS = (response: any) => {
   } as PassportData;
 };
 
-const handleResponseAndroid = (response: any): PassportData => {
+const handleResponseAndroid = (response: AndroidScanResponse): PassportData => {
   const {
     mrz,
     eContent,

--- a/app/src/utils/notifications/notificationService.ts
+++ b/app/src/utils/notifications/notificationService.ts
@@ -14,10 +14,10 @@ import {
 export { getStateMessage };
 // Determine if running in test environment
 const isTestEnv = process.env.NODE_ENV === 'test';
-const log = (...args: any[]) => {
+const log = (...args: unknown[]) => {
   if (!isTestEnv) console.log(...args);
 };
-const error = (...args: any[]) => {
+const error = (...args: unknown[]) => {
   if (!isTestEnv) console.error(...args);
 };
 

--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -9,7 +9,12 @@ import {
 import forge from 'node-forge';
 import socketIo, { Socket } from 'socket.io-client';
 import { v4 } from 'uuid';
-import { AnyActorRef, createActor, createMachine } from 'xstate';
+import {
+  AnyActorRef,
+  createActor,
+  createMachine,
+  StateFrom,
+} from 'xstate';
 import { create } from 'zustand';
 
 import { PassportEvents, ProofEvents } from '../../consts/analytics';
@@ -157,14 +162,14 @@ export type ProvingStateType =
 
 interface ProvingState {
   currentState: ProvingStateType;
-  attestation: any;
+  attestation: number[] | null;
   serverPublicKey: string | null;
   sharedKey: Buffer | null;
   wsConnection: WebSocket | null;
   socketConnection: Socket | null;
   uuid: string | null;
   userConfirmed: boolean;
-  passportData: any | null;
+  passportData: PassportData | null;
   secret: string | null;
   circuitType: provingMachineCircuitType | null;
   error_code: string | null;
@@ -184,7 +189,7 @@ interface ProvingState {
   postProving: () => void;
   setUserConfirmed: () => void;
   _closeConnections: () => void;
-  _generatePayload: () => Promise<any>;
+  _generatePayload: () => Promise<unknown>;
   _handleWebSocketMessage: (event: MessageEvent) => Promise<void>;
   _handleRegisterErrorOrFailure: () => void;
   _startSocketIOStatusListener: (
@@ -197,10 +202,12 @@ interface ProvingState {
 }
 
 export const useProvingStore = create<ProvingState>((set, get) => {
-  let actor: AnyActorRef | null = null;
+  let actor: AnyActorRef<StateFrom<typeof provingMachine>> | null = null;
 
-  function setupActorSubscriptions(newActor: AnyActorRef) {
-    newActor.subscribe((state: any) => {
+  function setupActorSubscriptions(
+    newActor: AnyActorRef<StateFrom<typeof provingMachine>>,
+  ) {
+    newActor.subscribe((state: StateFrom<typeof provingMachine>) => {
       console.log(`State transition: ${state.value}`);
       trackEvent(ProofEvents.PROVING_STATE_CHANGE, { state: state.value });
       set({ currentState: state.value as ProvingStateType });
@@ -394,12 +401,12 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         console.error('Error processing WebSocket message:', error);
         if (get().currentState === 'init_tee_connexion') {
           trackEvent(ProofEvents.TEE_CONN_FAILED, {
-            message: (error as any).message,
+            message: error instanceof Error ? error.message : String(error),
           });
           actor!.send({ type: 'CONNECT_ERROR' });
         } else {
           trackEvent(ProofEvents.TEE_WS_ERROR, {
-            error: (error as any).message,
+            error: error instanceof Error ? error.message : String(error),
           });
           trackEvent(ProofEvents.PROOF_FAILED, {
             circuitType: get().circuitType,
@@ -452,7 +459,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       socket.on('connect_error', error => {
         console.error('SocketIO connection error:', error);
         trackEvent(ProofEvents.SOCKETIO_CONNECT_ERROR, {
-          message: (error as any).message,
+          message: error instanceof Error ? error.message : String(error),
         });
         trackEvent(ProofEvents.PROOF_FAILED, {
           circuitType: get().circuitType,
@@ -480,7 +487,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         set({ socketConnection: null });
       });
 
-      socket.on('status', (message: any) => {
+      socket.on('status', (message: unknown) => {
         const data =
           typeof message === 'string' ? JSON.parse(message) : message;
         console.log('Received status update with status:', data.status);
@@ -668,7 +675,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       } catch (error) {
         console.error('Error fetching data:', error);
         trackEvent(ProofEvents.FETCH_DATA_FAILED, {
-          message: (error as any).message,
+          message: error instanceof Error ? error.message : String(error),
         });
         actor!.send({ type: 'FETCH_ERROR' });
       }
@@ -764,7 +771,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       } catch (error) {
         console.error('Error validating passport:', error);
         trackEvent(ProofEvents.VALIDATION_FAILED, {
-          message: (error as any).message,
+          message: error instanceof Error ? error.message : String(error),
         });
         actor!.send({ type: 'VALIDATION_ERROR' });
       }
@@ -884,7 +891,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           } catch (error) {
             console.error('Error registering device token:', error);
             trackEvent(ProofEvents.DEVICE_TOKEN_REG_FAILED, {
-              message: (error as any).message,
+              message: error instanceof Error ? error.message : String(error),
             });
             // Continue with the proving process even if token registration fails
           }

--- a/app/src/utils/proving/validateDocument.ts
+++ b/app/src/utils/proving/validateDocument.ts
@@ -306,10 +306,14 @@ export function isPassportDataValid(passportData: PassportData) {
   return true;
 }
 
+interface MigratedPassportData extends PassportData {
+  documentType?: string;
+}
+
 export function migratePassportData(passportData: PassportData): PassportData {
-  const migratedData = { ...passportData } as any;
+  const migratedData: MigratedPassportData = { ...passportData };
   if (!('documentCategory' in migratedData) || !('mock' in migratedData)) {
-    if ('documentType' in migratedData && migratedData.documentType) {
+    if (migratedData.documentType) {
       migratedData.mock = migratedData.documentType.startsWith('mock');
       migratedData.documentCategory = migratedData.documentType.includes(
         'passport',
@@ -323,7 +327,7 @@ export function migratePassportData(passportData: PassportData): PassportData {
     }
     // console.log('Migrated passport data:', migratedData);
   }
-  return migratedData as PassportData;
+  return migratedData;
 }
 
 export async function hasAnyValidRegisteredDocument(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- add DriveFile interface and runtime guard for Google Drive responses to avoid any casts
- extend passport migration with typed documentType instead of any
- type navigation for splash, settings, and manage document screens and drop any casts
- remove temporary cast on Dev settings Adapt component

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` (fails: Invalid account: #0 for network)
- `yarn types` (fails: The command failed in workspace @selfxyz/mobile-app@workspace:app with exit code 2)
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` (fails: Cannot read properties of undefined (reading 'rsa'))
- `yarn workspace @selfxyz/mobile-app test` (worker process failed to exit gracefully)


------
https://chatgpt.com/codex/tasks/task_b_688f79715854832d9b9641c14d9f9757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across the app by replacing most uses of `any` with more specific or stricter types such as `unknown`, explicit interfaces, or React Native style types.
  * Enhanced error handling by safely extracting error messages and using `unknown` for caught errors.
  * Introduced and exported new interfaces to clarify data structures and enable safer type checking.
  * Updated navigation and event handler types for better type safety and code clarity.
  * Added runtime type guards for safer data validation.
  * No changes to user-facing features or app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->