### PR TITLE
SELF-622: X settings link

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -39,6 +39,19 @@ yarn install-app
 
 ```
 
+If you encounter any nokogiri build issues try running these commands first:
+
+```bash
+brew install libxml2 libxslt
+
+bundle config build.nokogiri --use-system-libraries \
+    --with-xml2-include=$(brew --prefix libxml2)/include/libxml2
+
+bundle install
+```
+
+and rerun the command.
+
 ### Android
 
 #### Using Android Studio

--- a/app/src/consts/links.ts
+++ b/app/src/consts/links.ts
@@ -17,3 +17,5 @@ export const supportedBiometricIdsUrl =
 export const telegramUrl = 'https://t.me/self_xyz';
 
 export const termsUrl = 'https://self.xyz/terms';
+
+export const xUrl = 'https://x.com/selfprotocol';

--- a/app/src/images/icons/x.svg
+++ b/app/src/images/icons/x.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 300 300" version="1.1" xmlns="http://www.w3.org/2000/svg" fill="none">
+ <path d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8 116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66" fill="currentColor"/>
+</svg>

--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -27,8 +27,8 @@ import Lock from '../../images/icons/settings_lock.svg';
 import ShareIcon from '../../images/icons/share.svg';
 import Star from '../../images/icons/star.svg';
 import Telegram from '../../images/icons/telegram.svg';
-import X from '../../images/icons/x.svg';
 import Web from '../../images/icons/webpage.svg';
+import X from '../../images/icons/x.svg';
 import type { RootStackParamList } from '../../navigation';
 import { useSettingStore } from '../../stores/settingStore';
 import {

--- a/app/src/screens/settings/SettingsScreen.tsx
+++ b/app/src/screens/settings/SettingsScreen.tsx
@@ -17,6 +17,7 @@ import {
   playStoreUrl,
   selfUrl,
   telegramUrl,
+  xUrl,
 } from '../../consts/links';
 import Github from '../../images/icons/github.svg';
 import Cloud from '../../images/icons/settings_cloud_backup.svg';
@@ -26,6 +27,7 @@ import Lock from '../../images/icons/settings_lock.svg';
 import ShareIcon from '../../images/icons/share.svg';
 import Star from '../../images/icons/star.svg';
 import Telegram from '../../images/icons/telegram.svg';
+import X from '../../images/icons/x.svg';
 import Web from '../../images/icons/webpage.svg';
 import type { RootStackParamList } from '../../navigation';
 import { useSettingStore } from '../../stores/settingStore';
@@ -104,6 +106,7 @@ const DEBUG_MENU: [React.FC<SvgProps>, string, RouteOption][] = [
 ];
 
 const social = [
+  [X, xUrl],
   [Github, gitHubUrl],
   [Web, selfUrl],
   [Telegram, telegramUrl],
@@ -140,7 +143,8 @@ const SocialButton: React.FC<SocialButtonProps> = ({ Icon, href }) => {
     <Button
       unstyled
       hitSlop={8}
-      icon={<Icon height={32} width={32} color={amber500} onPress={onPress} />}
+      onPress={onPress}
+      icon={<Icon height={32} width={32} color={amber500} />}
     />
   );
 };


### PR DESCRIPTION
This PR adds link to X/twitter on the settings page as per the recording:


https://github.com/user-attachments/assets/444ab672-28de-4ab9-89d9-aaf51be8ae02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new social icon button linking to X (formerly Twitter) on the settings screen.

* **Documentation**
  * Updated the README with troubleshooting steps for nokogiri build issues on macOS.

* **Enhancements**
  * Added a new URL constant for X (https://x.com/selfprotocol).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->