### PR TITLE
fix: simplify getCountryCode function return type

### DIFF
--- a/common/src/constants/constants.ts
+++ b/common/src/constants/constants.ts
@@ -560,7 +560,7 @@ export const countryCodes = {
   ZWE: 'Zimbabwe',
 };
 
-export function getCountryCode(countryName: string): string | string {
+export function getCountryCode(countryName: string): string {
   const entries = Object.entries(countryCodes);
   const found = entries.find(([_, name]) => name.toLowerCase() === countryName.toLowerCase());
   return found ? found[0] : 'undefined';


### PR DESCRIPTION
Change return type from "string | string" to "string" in getCountryCode function to remove redundant type annotation.
Reopen #849 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the return type of the country code lookup function to consistently return a single string value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->