### PR TITLE
Add client tests

### DIFF
--- a/packages/sdk-alpha/tests/client.test.ts
+++ b/packages/sdk-alpha/tests/client.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSelfClient } from '../src/index.js';
+
+describe('createSelfClient', () => {
+  it('throws when scanner adapter missing', async () => {
+    const client = createSelfClient({ config: {}, adapters: {} });
+    await expect(client.scanDocument({ mode: 'qr' } as any)).rejects.toMatchObject({
+      code: 'SELF_ERR_ADAPTER_MISSING',
+      category: 'config',
+    });
+  });
+
+  it('scans document with provided adapter', async () => {
+    const scanMock = vi.fn().mockResolvedValue({ mode: 'qr', data: 'self://ok' });
+    const client = createSelfClient({
+      config: {},
+      adapters: { scanner: { scan: scanMock } },
+    });
+    const result = await client.scanDocument({ mode: 'qr' });
+    expect(result).toEqual({ mode: 'qr', data: 'self://ok' });
+    expect(scanMock).toHaveBeenCalledWith({ mode: 'qr' });
+  });
+
+  it('propagates scanner errors', async () => {
+    const err = new Error('scan failed');
+    const scanMock = vi.fn().mockRejectedValue(err);
+    const client = createSelfClient({
+      config: {},
+      adapters: { scanner: { scan: scanMock } },
+    });
+    await expect(client.scanDocument({ mode: 'qr' })).rejects.toBe(err);
+  });
+
+  it('throws when network adapter missing for checkRegistration', async () => {
+    const client = createSelfClient({ config: {}, adapters: {} });
+    await expect(
+      client.checkRegistration({ scan: { mode: 'qr', data: 'self://a' } } as any),
+    ).rejects.toMatchObject({ code: 'SELF_ERR_ADAPTER_MISSING' });
+  });
+
+  it('throws when network adapter missing for proof generation', async () => {
+    const crypto = { hash: vi.fn(), sign: vi.fn() } as any;
+    const client = createSelfClient({ config: {}, adapters: { crypto } });
+    await expect(client.generateProof({ type: 'register', payload: {} })).rejects.toMatchObject({
+      code: 'SELF_ERR_ADAPTER_MISSING',
+    });
+  });
+
+  it('throws when crypto adapter missing for proof generation', async () => {
+    const network = { http: { fetch: vi.fn() }, ws: { connect: vi.fn() } } as any;
+    const client = createSelfClient({ config: {}, adapters: { network } });
+    await expect(client.generateProof({ type: 'register', payload: {} })).rejects.toMatchObject({
+      code: 'SELF_ERR_ADAPTER_MISSING',
+    });
+  });
+
+  it('returns stub proof handle when adapters provided', async () => {
+    const network = { http: { fetch: vi.fn() }, ws: { connect: vi.fn() } } as any;
+    const crypto = { hash: vi.fn(), sign: vi.fn() } as any;
+    const client = createSelfClient({ config: {}, adapters: { network, crypto } });
+    const handle = await client.generateProof({ type: 'register', payload: {} });
+    expect(handle.id).toBe('stub');
+    expect(handle.status).toBe('pending');
+    expect(await handle.result()).toEqual({ ok: false, reason: 'SELF_ERR_PROOF_STUB' });
+    expect(() => handle.cancel()).not.toThrow();
+  });
+
+  it('emits and unsubscribes events', () => {
+    const client = createSelfClient({ config: {}, adapters: {} });
+    const cb = vi.fn();
+    const originalSet = Map.prototype.set;
+    let eventSet: Set<(p: any) => void> | undefined;
+    Map.prototype.set = function (key: any, value: any) {
+      if (key === 'progress') eventSet = value;
+      return originalSet.call(this, key, value);
+    };
+    const unsub = client.on('progress', cb);
+    Map.prototype.set = originalSet;
+
+    eventSet?.forEach((fn) => fn({ step: 'one' }));
+    expect(cb).toHaveBeenCalledWith({ step: 'one' });
+    unsub();
+    eventSet?.forEach((fn) => fn({ step: 'two' }));
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/packages/sdk-alpha/tests/webShim.test.ts
+++ b/packages/sdk-alpha/tests/webShim.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { webScannerShim } from '../src/adapters/web/shims.js';
+
+describe('webScannerShim', () => {
+  it('returns stub qr data', async () => {
+    await expect(webScannerShim.scan({ mode: 'qr' })).resolves.toEqual({
+      mode: 'qr',
+      data: 'self://stub-qr',
+    });
+  });
+
+  it('rejects MRZ scans', async () => {
+    await expect(webScannerShim.scan({ mode: 'mrz' } as any)).rejects.toMatchObject({
+      code: 'SELF_ERR_SCANNER_UNAVAILABLE',
+      category: 'scanner',
+    });
+  });
+
+  it('rejects NFC scans', async () => {
+    await expect(webScannerShim.scan({ mode: 'nfc' } as any)).rejects.toMatchObject({
+      code: 'SELF_ERR_NFC_NOT_SUPPORTED',
+      category: 'scanner',
+    });
+  });
+
+  it('rejects unknown scan modes', async () => {
+    await expect(webScannerShim.scan({ mode: 'foo' as any })).rejects.toMatchObject({
+      code: 'SELF_ERR_SCANNER_MODE',
+      category: 'scanner',
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- test createSelfClient adapter validation, proof stubs and event emission
- cover webScannerShim QR and error paths

## Testing
- `yarn lint` *(fails: 309 warnings)*
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Hardhat config error)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: unsupported signature algorithm)*
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/sdk-alpha test` *(fails: MRZ tests)*
- `npx vitest run tests/client.test.ts tests/webShim.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68973a1989ac832d95021334e3ff58a8