### PR TITLE
Validate required adapters in SDK client

### DIFF
--- a/packages/sdk-alpha/README.md
+++ b/packages/sdk-alpha/README.md
@@ -17,11 +17,17 @@ Alpha SDK for registering and proving. Adapters-first, React Native-first with w
 
 ## Quick start (local, monorepo)
 
+Provide `scanner`, `network`, and `crypto` adapters. `storage`, `clock`, and `logger` default to no-ops.
+
 ```ts
 import { createSelfClient, webScannerShim, extractMRZInfo } from '@selfxyz/sdk-alpha';
 const sdk = createSelfClient({
   config: {},
-  adapters: { scanner: webScannerShim },
+  adapters: {
+    scanner: webScannerShim,
+    network: yourNetworkAdapter,
+    crypto: yourCryptoAdapter,
+  },
 });
 ```
 

--- a/packages/sdk-alpha/src/client.ts
+++ b/packages/sdk-alpha/src/client.ts
@@ -17,7 +17,30 @@ import type {
   ValidationResult,
 } from './types/public.js';
 
+const optionalDefaults: Partial<Adapters> = {
+  storage: {
+    get: async () => null,
+    set: async () => {},
+    remove: async () => {},
+  },
+  clock: {
+    now: () => Date.now(),
+    sleep: async (ms: number) => {
+      await new Promise((r) => setTimeout(r, ms));
+    },
+  },
+  logger: {
+    log: () => {},
+  },
+};
+
 export function createSelfClient({ config, adapters }: { config: Config; adapters: Partial<Adapters> }): SelfClient {
+  const required: (keyof Adapters)[] = ['scanner', 'network', 'crypto'];
+  for (const name of required) {
+    if (!(name in adapters) || !adapters[name]) throw notImplemented(name);
+  }
+
+  const _adapters = { ...optionalDefaults, ...adapters } as Adapters;
   const _cfg = { ...defaultConfig, ...config };
   const listeners = new Map<SDKEvent, Set<(p: any) => void>>();
 
@@ -29,8 +52,7 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
   }
 
   async function scanDocument(opts: ScanOpts & { signal?: AbortSignal }): Promise<ScanResult> {
-    if (!adapters.scanner) throw notImplemented('scanner');
-    return adapters.scanner.scan(opts);
+    return _adapters.scanner.scan(opts);
   }
 
   async function validateDocument(_input: ValidationInput): Promise<ValidationResult> {
@@ -38,7 +60,6 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
   }
 
   async function checkRegistration(_input: RegistrationInput): Promise<RegistrationStatus> {
-    if (!adapters.network) throw notImplemented('network');
     return { registered: false, reason: 'SELF_REG_STATUS_STUB' };
   }
 
@@ -50,8 +71,6 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
       timeoutMs?: number;
     },
   ): Promise<ProofHandle> {
-    if (!adapters.network) throw notImplemented('network');
-    if (!adapters.crypto) throw notImplemented('crypto');
     return {
       id: 'stub',
       status: 'pending',

--- a/packages/sdk-alpha/tests/client.test.ts
+++ b/packages/sdk-alpha/tests/client.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CryptoAdapter, NetworkAdapter, ScannerAdapter } from '../src/adapters/index.js';
+import { createSelfClient } from '../src/client.js';
+
+const scanner: ScannerAdapter = {
+  scan: async () => ({ mode: 'qr', data: 'stub' }),
+};
+
+const network: NetworkAdapter = {
+  http: { fetch: async () => new Response(null) },
+  ws: {
+    connect: () => ({
+      send: () => {},
+      close: () => {},
+      onMessage: () => {},
+      onError: () => {},
+      onClose: () => {},
+    }),
+  },
+};
+
+const crypto: CryptoAdapter = {
+  hash: async () => new Uint8Array(),
+  sign: async () => new Uint8Array(),
+};
+
+describe('createSelfClient', () => {
+  it('throws if scanner adapter missing', () => {
+    expect(() => createSelfClient({ config: {}, adapters: { network, crypto } })).toThrow(
+      'scanner adapter not provided',
+    );
+  });
+
+  it('throws if network adapter missing', () => {
+    expect(() => createSelfClient({ config: {}, adapters: { scanner, crypto } })).toThrow(
+      'network adapter not provided',
+    );
+  });
+
+  it('throws if crypto adapter missing', () => {
+    expect(() => createSelfClient({ config: {}, adapters: { scanner, network } })).toThrow(
+      'crypto adapter not provided',
+    );
+  });
+
+  it('creates client with required adapters and no optional ones', () => {
+    const client = createSelfClient({ config: {}, adapters: { scanner, network, crypto } });
+    expect(client).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- assert mandatory adapters at client creation
- provide no-op defaults for optional adapters
- document adapter requirements and add basic config tests

## Testing
- `yarn lint` (fails: SELF_ERR_ADAPTER_MISSING warnings)
- `yarn build`
- `yarn workspace @selfxyz/contracts build` (fails: Hardhat config error)
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` (fails: unsupported signature algorithm)
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/sdk-alpha test` (fails: MRZ processing tests)`

------
https://chatgpt.com/codex/tasks/task_b_68973a15a8dc832d9cc4a66c05729653