### PR TITLE
Use sdkError for web scanner shim

### DIFF
--- a/packages/sdk-alpha/src/adapters/web/shims.ts
+++ b/packages/sdk-alpha/src/adapters/web/shims.ts
@@ -1,3 +1,4 @@
+import { SCANNER_ERROR_CODES, sdkError } from '../../errors.js';
 import type { ScannerAdapter, ScanOpts, ScanResult } from '../../types/public.js';
 
 export const webScannerShim: ScannerAdapter = {
@@ -6,23 +7,11 @@ export const webScannerShim: ScannerAdapter = {
       case 'qr':
         return { mode: 'qr', data: 'self://stub-qr' };
       case 'mrz':
-        throw Object.assign(new Error('MRZ scan not supported in web shim'), {
-          code: 'SELF_ERR_SCANNER_UNAVAILABLE',
-          category: 'scanner',
-          retryable: false,
-        });
+        throw sdkError('MRZ scan not supported in web shim', SCANNER_ERROR_CODES.UNAVAILABLE, 'scanner');
       case 'nfc':
-        throw Object.assign(new Error('NFC not supported in web shim'), {
-          code: 'SELF_ERR_NFC_NOT_SUPPORTED',
-          category: 'scanner',
-          retryable: false,
-        });
+        throw sdkError('NFC not supported in web shim', SCANNER_ERROR_CODES.NFC_NOT_SUPPORTED, 'scanner');
       default:
-        throw Object.assign(new Error('Unknown scan mode'), {
-          code: 'SELF_ERR_SCANNER_MODE',
-          category: 'scanner',
-          retryable: false,
-        });
+        throw sdkError('Unknown scan mode', SCANNER_ERROR_CODES.INVALID_MODE, 'scanner');
     }
   },
 };

--- a/packages/sdk-alpha/src/errors.ts
+++ b/packages/sdk-alpha/src/errors.ts
@@ -1,7 +1,15 @@
 export type SdkErrorCategory = 'scanner' | 'network' | 'protocol' | 'proof' | 'crypto' | 'validation' | 'config';
+
+export const SCANNER_ERROR_CODES = {
+  UNAVAILABLE: 'SELF_ERR_SCANNER_UNAVAILABLE',
+  NFC_NOT_SUPPORTED: 'SELF_ERR_NFC_NOT_SUPPORTED',
+  INVALID_MODE: 'SELF_ERR_SCANNER_MODE',
+} as const;
+
 export function sdkError(message: string, code: string, category: SdkErrorCategory, retryable = false) {
   return Object.assign(new Error(message), { code, category, retryable });
 }
+
 export function notImplemented(name: string) {
   return sdkError(`${name} adapter not provided`, 'SELF_ERR_ADAPTER_MISSING', 'config', false);
 }


### PR DESCRIPTION
## Summary
- centralize scanner error codes
- use sdkError in web shim scanner

## Testing
- `yarn lint` *(fails: 309 warnings)*
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account in config)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm: undefined)*
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/sdk-alpha test` *(fails: MRZ tests)*

------
https://chatgpt.com/codex/tasks/task_b_68973a1ca2e0832dafc7746eecd4de57