### PR TITLE
Document new workspaces in AGENTS files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ This repository is a Yarn v4 monorepo with several workspaces:
 - `contracts` – solidity contracts (@selfxyz/contracts)
 - `sdk/core` – core TypeScript SDK (@selfxyz/core)
 - `sdk/qrcode` – qrcode SDK (@selfxyz/qrcode)
+- `packages/sdk-alpha` – alpha version of the SDK (@selfxyz/sdk-alpha)
+- `noir` – noir circuits
 
 ## Workflow
 
@@ -39,6 +41,8 @@ yarn types
   - `yarn workspace @selfxyz/common test`
   - `yarn workspace @selfxyz/circuits test` # may fail if OpenSSL algorithms are missing
   - `yarn workspace @selfxyz/mobile-app test`
+  - `yarn workspace @selfxyz/sdk-alpha test`
+  - For Noir circuits, run `nargo test -p <crate>` in each `noir/crates/*` directory.
   - Tests for `@selfxyz/contracts` are currently disabled in CI and may be skipped.
 
 ### Formatting

--- a/noir/AGENTS.md
+++ b/noir/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS Instructions
+
+## Build
+
+- Run `nargo build -p <crate>` to compile a Noir circuit.
+
+## Test
+
+- Run `nargo test -p <crate>` for each circuit crate in `crates/`.
+
+## Formatting
+
+- Use `nargo fmt` to format Noir files.

--- a/packages/sdk-alpha/AGENTS.md
+++ b/packages/sdk-alpha/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS Instructions
+
+## Lint
+
+- Run `yarn workspace @selfxyz/sdk-alpha lint`
+
+## Build
+
+- Run `yarn workspace @selfxyz/sdk-alpha build`
+
+## Test
+
+- Run `yarn workspace @selfxyz/sdk-alpha test`
+
+## Formatting
+
+- Use the root Prettier and EditorConfig settings.


### PR DESCRIPTION
## Summary
- list new `packages/sdk-alpha` and `noir` workspaces in root instructions
- add package instructions for `@selfxyz/sdk-alpha`
- add build/test guidance for Noir circuits

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account config)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: missing circom and poseidon deps)*
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/sdk-alpha test`
- `nargo test` in `noir/crates/dg1` *(fails: could not resolve standard hashes)*
- `nargo test` in `noir/crates/econtent`


------
https://chatgpt.com/codex/tasks/task_b_68973b100d54832db0ab84d3c7b28300