### PR TITLE
Add SDK alpha CI workflow

### DIFF
--- a/.github/workflows/sdk-alpha-ci.yml
+++ b/.github/workflows/sdk-alpha-ci.yml
@@ -1,0 +1,46 @@
+name: SDK Alpha CI
+
+on:
+  pull_request:
+    paths:
+      - "packages/sdk-alpha/**"
+      - ".github/workflows/sdk-alpha-ci.yml"
+      - ".github/actions/**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Build dependencies
+        shell: bash
+        run: yarn workspace @selfxyz/sdk-alpha build
+      - name: Run linter
+        run: yarn lint
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Build dependencies
+        shell: bash
+        run: yarn workspace @selfxyz/sdk-alpha build
+      - name: Yarn types
+        shell: bash
+        run: yarn types
+
+  test-sdk-alpha:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Build dependencies
+        shell: bash
+        run: yarn workspace @selfxyz/sdk-alpha build
+      - name: Run @selfxyz/sdk-alpha tests
+        run: yarn workspace @selfxyz/sdk-alpha test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint, type-check, and test packages/sdk-alpha

## Testing
- `yarn lint` (warnings only)
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account #0 for network mainnet)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm: undefined)*
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_68973ca7beb0832d98cda109bad08a0d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new continuous integration workflow to automatically lint, type-check, and test changes related to the SDK Alpha package on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->