### PR TITLE
Simplify alias tooling and relax export sorting

### DIFF
--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -70,10 +70,10 @@ module.exports = {
       },
     ],
 
-    // Export sorting - using sort-exports for better type prioritization
+    // Export sorting - warn instead of error to avoid per-file overrides
 
     'sort-exports/sort-exports': [
-      'error',
+      'warn',
       { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' },
     ],
 
@@ -199,20 +199,6 @@ module.exports = {
         'header/header': 'off',
         '@typescript-eslint/no-var-requires': 'off',
         'no-undef': 'off',
-      },
-    },
-    {
-      // Disable export sorting for files with dependency issues
-      files: [
-        'src/components/NavBar/BaseNavBar.tsx',
-        'src/navigation/index.tsx',
-        'src/providers/passportDataProvider.tsx',
-        'src/utils/cloudBackup/helpers.ts',
-        'src/utils/haptic/index.ts',
-        'src/utils/proving/provingUtils.ts',
-      ],
-      rules: {
-        'sort-exports/sort-exports': 'off',
       },
     },
   ],

--- a/app/scripts/alias-imports.cjs
+++ b/app/scripts/alias-imports.cjs
@@ -3,28 +3,8 @@ const path = require('node:path');
 const { Project, SyntaxKind } = require('ts-morph');
 
 function determineAliasStrategy(dir, abs, baseDir, baseAlias) {
-  // Always use base alias with path relative to baseDir (no special '@/' handling)
   const rel = path.relative(baseDir, abs).replace(/\\/g, '/');
   return rel ? `${baseAlias}/${rel}` : baseAlias;
-}
-
-function optimizeExistingSrcImport(spec) {
-  // Convert @src/path/to/file to @/file if it's a same-directory import
-  // This migration no longer shortens to '@/' because tooling can't resolve contextual '@/'
-  if (!spec.startsWith('@src/')) return spec;
-  return spec;
-}
-
-// Migrate legacy '@/File' (same-directory shorthand) to '@src/<relative-from-src>/<File>'
-function migrateAtShorthand(spec, dir, srcDir) {
-  if (!spec.startsWith('@/')) return spec;
-  const fileBase = spec.slice(2); // remove '@/'
-  // Compute path relative to src for the current directory, then append the fileBase
-  const relFromSrcToCurrentDir = path.relative(srcDir, dir).replace(/\\/g, '/');
-  const finalPath = relFromSrcToCurrentDir
-    ? `@src/${relFromSrcToCurrentDir}/${fileBase}`
-    : `@src/${fileBase}`;
-  return finalPath;
 }
 
 function transformProjectToAliasImports(project, appRootPath) {
@@ -39,21 +19,8 @@ function transformProjectToAliasImports(project, appRootPath) {
     for (const declaration of sourceFile.getImportDeclarations()) {
       const spec = declaration.getModuleSpecifierValue();
 
-      // Handle existing @src/ imports - keep as-is (no '@/' optimization)
-      if (spec.startsWith('@src/')) {
-        const optimized = optimizeExistingSrcImport(spec, dir, srcDir);
-        if (optimized !== spec) {
-          declaration.setModuleSpecifier(optimized);
-        }
-        continue;
-      }
-
-      // Handle legacy '@/File' shorthand and migrate it
-      if (spec.startsWith('@/')) {
-        const migrated = migrateAtShorthand(spec, dir, srcDir);
-        if (migrated !== spec) {
-          declaration.setModuleSpecifier(migrated);
-        }
+      // Skip existing alias imports
+      if (spec.startsWith('@src/') || spec.startsWith('@tests/')) {
         continue;
       }
 
@@ -87,21 +54,8 @@ function transformProjectToAliasImports(project, appRootPath) {
       const spec = declaration.getModuleSpecifierValue();
       if (!spec) continue;
 
-      // Handle existing @src/ exports - keep as-is
-      if (spec.startsWith('@src/')) {
-        const optimized = optimizeExistingSrcImport(spec, dir, srcDir);
-        if (optimized !== spec) {
-          declaration.setModuleSpecifier(optimized);
-        }
-        continue;
-      }
-
-      // Handle legacy '@/File' shorthand and migrate it
-      if (spec.startsWith('@/')) {
-        const migrated = migrateAtShorthand(spec, dir, srcDir);
-        if (migrated !== spec) {
-          declaration.setModuleSpecifier(migrated);
-        }
+      // Skip existing alias exports
+      if (spec.startsWith('@src/') || spec.startsWith('@tests/')) {
         continue;
       }
 
@@ -152,21 +106,8 @@ function transformProjectToAliasImports(project, appRootPath) {
 
       const spec = arg.getLiteralValue();
 
-      // Handle existing @src/ requires - keep as-is
-      if (spec.startsWith('@src/')) {
-        const optimized = optimizeExistingSrcImport(spec, dir, srcDir);
-        if (optimized !== spec) {
-          arg.setLiteralValue(optimized);
-        }
-        continue;
-      }
-
-      // Handle legacy '@/File' shorthand and migrate it
-      if (spec.startsWith('@/')) {
-        const migrated = migrateAtShorthand(spec, dir, srcDir);
-        if (migrated !== spec) {
-          arg.setLiteralValue(migrated);
-        }
+      // Skip existing alias requires
+      if (spec.startsWith('@src/') || spec.startsWith('@tests/')) {
         continue;
       }
 

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -13,7 +13,6 @@
         "../packages/sdk-alpha/src",
         "../packages/sdk-alpha/dist"
       ],
-      "@src": ["./src"],
       "@src/*": ["./src/*"]
     }
   },


### PR DESCRIPTION
## Summary
- drop redundant `@src` path mapping in mobile app tsconfig
- strip dead code and legacy `@/` handling from alias-imports script
- soften export-sorting rule and remove file-specific overrides

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: HH8 config error)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: circom not found / rsa undefined)*
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_6897548a8264832d9029905be66051d9