### PR TITLE
Implement typed event emitter

### DIFF
--- a/packages/mobile-sdk-alpha/src/browser.ts
+++ b/packages/mobile-sdk-alpha/src/browser.ts
@@ -18,6 +18,7 @@ export type {
   RegistrationInput,
   RegistrationStatus,
   SDKEvent,
+  SDKEventMap,
   ScanMode,
   ScanOpts,
   ScanResult,

--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -56,8 +56,12 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
   function emit<E extends SDKEvent>(event: E, payload: SDKEventMap[E]): void {
     const set = listeners.get(event);
     if (!set) return;
-    for (const cb of set) {
-      (cb as (p: SDKEventMap[E]) => void)(payload);
+    for (const cb of Array.from(set)) {
+      try {
+        (cb as (p: SDKEventMap[E]) => void)(payload);
+      } catch (err) {
+        _adapters.logger.log('error', `event-listener error for event '${event}'`, { event, error: err });
+      }
     }
   }
 

--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -12,6 +12,7 @@ import type {
   ScanOpts,
   ScanResult,
   SDKEvent,
+  SDKEventMap,
   SelfClient,
   Unsubscribe,
   ValidationInput,
@@ -43,14 +44,21 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
   }
 
   const _adapters = { ...optionalDefaults, ...adapters } as Adapters;
-  const _cfg = { ...defaultConfig, ...config };
   const listeners = new Map<SDKEvent, Set<(p: any) => void>>();
 
-  function on(event: SDKEvent, cb: (payload: any) => void): Unsubscribe {
+  function on<E extends SDKEvent>(event: E, cb: (payload: SDKEventMap[E]) => void): Unsubscribe {
     const set = listeners.get(event) ?? new Set();
-    set.add(cb);
+    set.add(cb as any);
     listeners.set(event, set);
-    return () => set.delete(cb);
+    return () => set.delete(cb as any);
+  }
+
+  function emit<E extends SDKEvent>(event: E, payload: SDKEventMap[E]): void {
+    const set = listeners.get(event);
+    if (!set) return;
+    for (const cb of set) {
+      (cb as (p: SDKEventMap[E]) => void)(payload);
+    }
   }
 
   async function scanDocument(opts: ScanOpts & { signal?: AbortSignal }): Promise<ScanResult> {
@@ -76,7 +84,7 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
     if (!adapters.network) throw notImplemented('network');
     if (!adapters.crypto) throw notImplemented('crypto');
     const timeoutMs = opts.timeoutMs ?? cfg.timeouts?.proofMs ?? defaultConfig.timeouts.proofMs;
-    void timeoutMs;
+    void _adapters.clock.sleep(timeoutMs!, opts.signal).then(() => emit('error', new Error('timeout')));
     return {
       id: 'stub',
       status: 'pending',
@@ -91,5 +99,6 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
     checkRegistration,
     generateProof,
     on,
+    emit,
   };
 }

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -16,6 +16,7 @@ export type {
   RegistrationInput,
   RegistrationStatus,
   SDKEvent,
+  SDKEventMap,
   ScanMode,
   ScanOpts,
   ScanResult,

--- a/packages/mobile-sdk-alpha/src/types/public.ts
+++ b/packages/mobile-sdk-alpha/src/types/public.ts
@@ -88,7 +88,12 @@ export interface RegistrationStatus {
   reason?: string;
 }
 
-export type SDKEvent = 'progress' | 'state' | 'error';
+export interface SDKEventMap {
+  progress: Progress;
+  state: string;
+  error: Error;
+}
+export type SDKEvent = keyof SDKEventMap;
 
 export type ScanMode = 'mrz' | 'nfc' | 'qr';
 export interface ScanOpts {
@@ -121,7 +126,8 @@ export interface SelfClient {
       timeoutMs?: number;
     },
   ): Promise<ProofHandle>;
-  on(event: SDKEvent, cb: (payload: any) => void): Unsubscribe;
+  on<E extends SDKEvent>(event: E, cb: (payload: SDKEventMap[E]) => void): Unsubscribe;
+  emit<E extends SDKEvent>(event: E, payload: SDKEventMap[E]): void;
 }
 export type Unsubscribe = () => void;
 export interface StorageAdapter {


### PR DESCRIPTION
## Summary
- clean up unused config merging and timeout scaffolding
- add typed SDK event map and emit helper
- export event types for browser and node builds

## Testing
- `yarn workspace @selfxyz/mobile-sdk-alpha nice`
- `yarn workspace @selfxyz/common nice` *(fails: Require statement not part of import statement)*
- `yarn workspace @selfxyz/app nice` *(fails: Workspace '@selfxyz/app' not found)*
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Hardhat config error)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(fails: Unsupported signature algorithm: undefined)*
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_6898c5c2ebe0832db1332f91ff4f4e14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a strongly-typed event system, ensuring event listeners and emitters receive and send payloads with the correct types.
  * Added an event emission method to the client, allowing external code to trigger events with type-safe payloads.

* **Refactor**
  * Updated event-related type definitions for improved type safety and consistency across the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->