### PR TITLE
feat(qrcode): modernize build pipeline

### DIFF
--- a/sdk/qrcode/package.json
+++ b/sdk/qrcode/package.json
@@ -17,24 +17,47 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.cjs",
+      "types": "./dist/esm/index.d.ts"
+    },
+    "./components/LED": {
+      "import": "./dist/esm/components/LED.js",
+      "require": "./dist/cjs/components/LED.cjs",
+      "types": "./dist/esm/components/LED.d.ts"
+    },
+    "./components/SelfQRcode": {
+      "import": "./dist/esm/components/SelfQRcode.js",
+      "require": "./dist/cjs/components/SelfQRcode.cjs",
+      "types": "./dist/esm/components/SelfQRcode.d.ts"
+    },
+    "./utils/utils": {
+      "import": "./dist/esm/utils/utils.js",
+      "require": "./dist/cjs/utils/utils.cjs",
+      "types": "./dist/esm/utils/utils.d.ts"
+    },
+    "./utils/styles": {
+      "import": "./dist/esm/utils/styles.js",
+      "require": "./dist/cjs/utils/styles.cjs",
+      "types": "./dist/esm/utils/styles.d.ts"
+    },
+    "./utils/websocket": {
+      "import": "./dist/esm/utils/websocket.js",
+      "require": "./dist/cjs/utils/websocket.cjs",
+      "types": "./dist/esm/utils/websocket.d.ts"
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.cts",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup --config tsup.config.ts",
+    "build": "tsup && yarn build:types && yarn postbuild",
+    "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "postbuild": "node ./scripts/postBuild.mjs",
+    "build:watch": "tsup --watch",
     "build:deps": "yarn workspaces foreach --from @selfxyz/qrcode --topological-dev --recursive run build",
     "format": "prettier --write .",
     "install-sdk": "yarn workspace focus @selfxyz/qrcode",

--- a/sdk/qrcode/scripts/postBuild.mjs
+++ b/sdk/qrcode/scripts/postBuild.mjs
@@ -1,0 +1,55 @@
+import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { shimConfigs } from './shimConfigs.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(__dirname, '..', 'dist');
+
+const packageJsonPath = path.resolve(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+writeFileSync(
+  path.join(DIST, 'esm', 'package.json'),
+  JSON.stringify({ type: 'module' }, null, 4),
+);
+writeFileSync(
+  path.join(DIST, 'cjs', 'package.json'),
+  JSON.stringify({ type: 'commonjs' }, null, 4),
+);
+
+const distPackageJson = {
+  name: '@selfxyz/qrcode',
+  version: packageJson.version,
+  type: 'module',
+  exports: {
+    '.': './esm/index.js',
+    './components/LED': './esm/components/LED.js',
+    './components/SelfQRcode': './esm/components/SelfQRcode.js',
+    './utils/utils': './esm/utils/utils.js',
+    './utils/styles': './esm/utils/styles.js',
+    './utils/websocket': './esm/utils/websocket.js',
+  },
+};
+writeFileSync(
+  path.join(DIST, 'package.json'),
+  JSON.stringify(distPackageJson, null, 4),
+);
+
+function createShim(shimPath, targetPath) {
+  const shimDir = path.join(DIST, shimPath);
+  mkdirSync(shimDir, { recursive: true });
+  const cjsTargetPath = targetPath
+    .replace('/esm/', '/cjs/')
+    .replace('.js', '.cjs');
+  writeFileSync(
+    path.join(shimDir, 'index.js'),
+    `module.exports = require('${cjsTargetPath}');`,
+  );
+  writeFileSync(
+    path.join(shimDir, 'index.d.ts'),
+    `export * from '${targetPath.replace('.js', '')}';`,
+  );
+}
+
+shimConfigs.forEach(c => createShim(c.shimPath, c.targetPath));

--- a/sdk/qrcode/scripts/shimConfigs.js
+++ b/sdk/qrcode/scripts/shimConfigs.js
@@ -1,0 +1,27 @@
+export const shimConfigs = [
+  {
+    shimPath: 'components/LED',
+    targetPath: '../../esm/components/LED.js',
+    name: 'components/LED',
+  },
+  {
+    shimPath: 'components/SelfQRcode',
+    targetPath: '../../esm/components/SelfQRcode.js',
+    name: 'components/SelfQRcode',
+  },
+  {
+    shimPath: 'utils/utils',
+    targetPath: '../../esm/utils/utils.js',
+    name: 'utils/utils',
+  },
+  {
+    shimPath: 'utils/styles',
+    targetPath: '../../esm/utils/styles.js',
+    name: 'utils/styles',
+  },
+  {
+    shimPath: 'utils/websocket',
+    targetPath: '../../esm/utils/websocket.js',
+    name: 'utils/websocket',
+  },
+];

--- a/sdk/qrcode/tsconfig.cjs.json
+++ b/sdk/qrcode/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist/cjs",
+    "declaration": false,
+    "emitDeclarationOnly": false
+  }
+}

--- a/sdk/qrcode/tsup.config.ts
+++ b/sdk/qrcode/tsup.config.ts
@@ -1,15 +1,57 @@
-import type { Options } from 'tsup';
+import path from 'path';
+import { defineConfig } from 'tsup';
 
-const env = process.env.NODE_ENV;
-
-export const tsup: Options = {
-  splitting: true,
-  clean: true, // clean up the dist folder
-  dts: true, // generate dts files
-  format: ['cjs', 'esm'], // generate cjs and esm files
-  skipNodeModulesBundle: true,
-  entryPoints: ['index.ts', 'animations/**/*', 'components/**/*', 'utils/**/*'],
-  watch: env === 'development',
-  target: 'es2020',
-  outDir: 'dist',
-};
+export default defineConfig([
+  {
+    tsconfig: './tsconfig.json',
+    entry: {
+      index: 'index.ts',
+      'components/LED': 'components/LED.tsx',
+      'components/SelfQRcode': 'components/SelfQRcode.tsx',
+      'utils/utils': 'utils/utils.ts',
+      'utils/styles': 'utils/styles.ts',
+      'utils/websocket': 'utils/websocket.ts',
+    },
+    format: ['esm'],
+    outDir: path.resolve(__dirname, 'dist/esm'),
+    dts: false,
+    splitting: false,
+    clean: true,
+    sourcemap: true,
+    target: 'es2020',
+    external: [
+      /^react/,
+      /^react-dom/,
+      /^lottie-react/,
+      /^qrcode.react/,
+      /^socket.io-client/,
+      /^node-forge/,
+    ],
+  },
+  {
+    tsconfig: './tsconfig.cjs.json',
+    entry: {
+      index: 'index.ts',
+      'components/LED': 'components/LED.tsx',
+      'components/SelfQRcode': 'components/SelfQRcode.tsx',
+      'utils/utils': 'utils/utils.ts',
+      'utils/styles': 'utils/styles.ts',
+      'utils/websocket': 'utils/websocket.ts',
+    },
+    format: ['cjs'],
+    outDir: path.resolve(__dirname, 'dist/cjs'),
+    dts: false,
+    splitting: false,
+    clean: false,
+    sourcemap: true,
+    target: 'es2020',
+    external: [
+      /^react/,
+      /^react-dom/,
+      /^lottie-react/,
+      /^qrcode.react/,
+      /^socket.io-client/,
+      /^node-forge/,
+    ],
+  },
+]);


### PR DESCRIPTION
## Summary
- add dual-format tsup config and shim-based postbuild for @selfxyz/qrcode

## Testing
- `yarn lint` (fails: 317 warnings)
- `yarn build`
- `yarn workspace @selfxyz/contracts build` (fails: HH8 config error)
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` (fails: unsupported signature algorithm)
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_6899336eb664832db3261c4d0cb4f00d