### PR TITLE
Cache dependencies in mobile workflows

### DIFF
--- a/.github/workflows/mobile-bundle-analysis.yml
+++ b/.github/workflows/mobile-bundle-analysis.yml
@@ -24,25 +24,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .yarn/cache
+            node_modules
             app/node_modules
-            ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-
       - name: Cache Ruby Bundler
         uses: actions/cache@v4
         with:
           path: app/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          key: ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ hashFiles('app/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Cache CocoaPods
-        uses: actions/cache@v4
-        with:
-          path: app/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
+            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -74,18 +68,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .yarn/cache
+            node_modules
             app/node_modules
-            ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-
       - name: Cache Ruby Bundler
         uses: actions/cache@v4
         with:
           path: app/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          key: ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ hashFiles('app/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
+            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:
@@ -93,15 +88,6 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Install Mobile Dependencies
         uses: ./.github/actions/mobile-setup
         with:

--- a/.github/workflows/mobile-bundle-analysis.yml
+++ b/.github/workflows/mobile-bundle-analysis.yml
@@ -20,6 +20,38 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Node Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/node_modules
+            ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Cache Ruby Bundler
+        uses: actions/cache@v4
+        with:
+          path: app/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: app/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Install Mobile Dependencies
         uses: ./.github/actions/mobile-setup
         with:
@@ -38,6 +70,38 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Node Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/node_modules
+            ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Cache Ruby Bundler
+        uses: actions/cache@v4
+        with:
+          path: app/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: app/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Install Mobile Dependencies
         uses: ./.github/actions/mobile-setup
         with:

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -24,34 +24,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .yarn/cache
+            node_modules
             app/node_modules
-            ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Cache Ruby Bundler
-        uses: actions/cache@v4
-        with:
-          path: app/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Cache CocoaPods
-        uses: actions/cache@v4
-        with:
-          path: app/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Build Dependencies
@@ -72,34 +50,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .yarn/cache
+            node_modules
             app/node_modules
-            ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Cache Ruby Bundler
-        uses: actions/cache@v4
-        with:
-          path: app/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Cache CocoaPods
-        uses: actions/cache@v4
-        with:
-          path: app/ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
 
@@ -125,18 +81,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .yarn/cache
+            node_modules
             app/node_modules
-            ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-
       - name: Cache Ruby Bundler
         uses: actions/cache@v4
         with:
           path: app/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          key: ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ hashFiles('app/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
+            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -20,6 +20,38 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Node Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/node_modules
+            ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Cache Ruby Bundler
+        uses: actions/cache@v4
+        with:
+          path: app/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: app/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Build Dependencies
@@ -36,6 +68,38 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Node Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/node_modules
+            ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Cache Ruby Bundler
+        uses: actions/cache@v4
+        with:
+          path: app/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: app/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
 
@@ -57,6 +121,38 @@ jobs:
           xcode-version: "16.2"
 
       - uses: actions/checkout@v4
+      - name: Cache Node Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/node_modules
+            ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Cache Ruby Bundler
+        uses: actions/cache@v4
+        with:
+          path: app/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: app/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Install Mobile Dependencies
         uses: ./.github/actions/mobile-setup
         with:

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -115,22 +115,23 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .yarn/cache
+            node_modules
             ${{ env.APP_PATH }}/node_modules
-            ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-
-            ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ env.GH_CACHE_VERSION }}-
 
       - name: Cache Ruby gems
         id: gems-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.APP_PATH }}/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-${{ hashFiles('app/Gemfile.lock') }}
+          key: ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-${{ hashFiles('app/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-
-            ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-
+            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-
+            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ env.GH_CACHE_VERSION }}-
 
       - name: Cache CocoaPods
         id: pods-cache
@@ -543,22 +544,23 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .yarn/cache
+            node_modules
             ${{ env.APP_PATH }}/node_modules
-            ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-
-            ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ env.GH_CACHE_VERSION }}-
 
       - name: Cache Ruby gems
         id: gems-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.APP_PATH }}/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-${{ hashFiles('app/Gemfile.lock') }}
+          key: ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-${{ hashFiles('app/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-
-            ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-
+            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-
+            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ env.GH_CACHE_VERSION }}-
 
       - name: Cache Gradle dependencies
         id: gradle-cache

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -48,9 +48,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .yarn/cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-
       - run: yarn install --immutable --silent
       - name: Cache Maestro
         id: cache-maestro
@@ -166,9 +166,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .yarn/cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-yarn-
       - run: yarn install --immutable --silent
       - name: Cache Maestro
         id: cache-maestro
@@ -185,16 +185,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: app/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('app/yarn.lock') }}
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION }}-${{ hashFiles('app/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node${{ env.NODE_VERSION }}-
       - name: Cache Ruby gems
         uses: actions/cache@v4
         with:
           path: app/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          key: ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ hashFiles('app/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
+            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-
       - name: Cache Pods
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- cache node modules, Ruby gems, CocoaPods and Gradle data in mobile bundle analysis
- restore the same caches before yarn-install and mobile-setup in mobile CI

## Testing
- `yarn workspace @selfxyz/mobile-sdk-alpha nice`
- `yarn workspace @selfxyz/common nice` *(failed: Require statement not part of import statement)*
- `yarn workspace @selfxyz/mobile-app nice`
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(failed: Hardhat config error)*
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` *(failed: Cannot read properties of undefined)
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`
- `nargo test -p dg1` *(command not found)
- `nargo test -p econtent` *(command not found)


------
https://chatgpt.com/codex/tasks/task_b_689934243f20832d8c9be4764cee99fc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Optimized mobile CI and bundle analysis workflows by adding dependency caching for Android and iOS, reducing build and analysis times.
  - Caches JavaScript packages, Ruby gems, CocoaPods, and Gradle artifacts to speed up lint, test, build, and analysis jobs across runs.
  - Improves pipeline efficiency and consistency without altering application behavior.
  - No changes to app features or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->