### PR TITLE
Add composite cache actions

### DIFF
--- a/.github/actions/cache-bundler/action.yml
+++ b/.github/actions/cache-bundler/action.yml
@@ -16,10 +16,16 @@ inputs:
     required: false
     default: v1
 
+outputs:
+  cache-hit:
+    description: Whether an exact match was found for the cache key
+    value: ${{ steps.cache.outputs.cache-hit }}
+
 runs:
   using: "composite"
   steps:
-    - name: Cache Ruby gems
+    - id: cache
+      name: Cache Ruby gems
       uses: actions/cache@v4
       with:
         path: ${{ inputs.path }}

--- a/.github/actions/cache-bundler/action.yml
+++ b/.github/actions/cache-bundler/action.yml
@@ -1,0 +1,29 @@
+name: Cache Bundler
+
+description: Cache Ruby gems installed via Bundler.
+
+inputs:
+  path:
+    description: Paths to cache
+    required: false
+    default: vendor/bundle
+  lock-file:
+    description: Path to Gemfile.lock
+    required: false
+    default: Gemfile.lock
+  cache-version:
+    description: Additional cache version segment
+    required: false
+    default: v1
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Ruby gems
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ runner.os }}-gems-${{ inputs.cache-version }}-${{ hashFiles(inputs.lock-file) }}
+        restore-keys: |
+          ${{ runner.os }}-gems-${{ inputs.cache-version }}-
+          ${{ runner.os }}-gems-

--- a/.github/actions/cache-gradle/action.yml
+++ b/.github/actions/cache-gradle/action.yml
@@ -1,0 +1,27 @@
+name: Cache Gradle
+
+description: Cache Gradle wrappers and dependencies.
+
+inputs:
+  path:
+    description: Paths to cache
+    required: false
+    default: |
+      ~/.gradle/caches
+      ~/.gradle/wrapper
+  cache-version:
+    description: Additional cache version segment
+    required: false
+    default: v1
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Gradle
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ runner.os }}-gradle-${{ inputs.cache-version }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-${{ inputs.cache-version }}-
+          ${{ runner.os }}-gradle-

--- a/.github/actions/cache-gradle/action.yml
+++ b/.github/actions/cache-gradle/action.yml
@@ -14,10 +14,16 @@ inputs:
     required: false
     default: v1
 
+outputs:
+  cache-hit:
+    description: Whether an exact match was found for the cache key
+    value: ${{ steps.cache.outputs.cache-hit }}
+
 runs:
   using: "composite"
   steps:
-    - name: Cache Gradle
+    - id: cache
+      name: Cache Gradle
       uses: actions/cache@v4
       with:
         path: ${{ inputs.path }}

--- a/.github/actions/cache-pods/action.yml
+++ b/.github/actions/cache-pods/action.yml
@@ -1,0 +1,31 @@
+name: Cache Pods
+
+description: Cache CocoaPods dependencies.
+
+inputs:
+  path:
+    description: Paths to cache
+    required: false
+    default: |
+      ios/Pods
+      ~/Library/Caches/CocoaPods
+  lock-file:
+    description: Path to Podfile.lock
+    required: false
+    default: ios/Podfile.lock
+  cache-version:
+    description: Additional cache version segment
+    required: false
+    default: v1
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Pods
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ runner.os }}-pods-${{ inputs.cache-version }}-${{ hashFiles(inputs.lock-file) }}
+        restore-keys: |
+          ${{ runner.os }}-pods-${{ inputs.cache-version }}-
+          ${{ runner.os }}-pods-

--- a/.github/actions/cache-pods/action.yml
+++ b/.github/actions/cache-pods/action.yml
@@ -18,10 +18,16 @@ inputs:
     required: false
     default: v1
 
+outputs:
+  cache-hit:
+    description: Whether an exact match was found for the cache key
+    value: ${{ steps.cache.outputs.cache-hit }}
+
 runs:
   using: "composite"
   steps:
-    - name: Cache Pods
+    - id: cache
+      name: Cache Pods
       uses: actions/cache@v4
       with:
         path: ${{ inputs.path }}

--- a/.github/actions/cache-yarn/action.yml
+++ b/.github/actions/cache-yarn/action.yml
@@ -1,0 +1,30 @@
+name: Cache Yarn
+
+description: Cache Yarn dependencies with consistent keys and paths.
+
+inputs:
+  path:
+    description: Paths to cache
+    required: false
+    default: |
+      .yarn/cache
+  lock-file:
+    description: Path to yarn.lock
+    required: false
+    default: yarn.lock
+  cache-version:
+    description: Additional cache version segment
+    required: false
+    default: v1
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Yarn dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ runner.os }}-yarn-${{ inputs.cache-version }}-${{ hashFiles(inputs.lock-file) }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-${{ inputs.cache-version }}-
+          ${{ runner.os }}-yarn-

--- a/.github/actions/cache-yarn/action.yml
+++ b/.github/actions/cache-yarn/action.yml
@@ -17,10 +17,16 @@ inputs:
     required: false
     default: v1
 
+outputs:
+  cache-hit:
+    description: Whether an exact match was found for the cache key
+    value: ${{ steps.cache.outputs.cache-hit }}
+
 runs:
   using: "composite"
   steps:
-    - name: Cache Yarn dependencies
+    - id: cache
+      name: Cache Yarn dependencies
       uses: actions/cache@v4
       with:
         path: ${{ inputs.path }}

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -112,35 +112,31 @@ jobs:
 
       - name: Cache Yarn dependencies
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-yarn
         with:
           path: |
             ${{ env.APP_PATH }}/node_modules
             ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-
-            ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-
+          lock-file: yarn.lock
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}
 
       - name: Cache Ruby gems
         id: gems-cache
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-bundler
         with:
           path: ${{ env.APP_PATH }}/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-${{ hashFiles('app/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-
-            ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-
+          lock-file: app/Gemfile.lock
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}
 
       - name: Cache CocoaPods
         id: pods-cache
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-pods
         with:
-          path: ${{ env.APP_PATH }}/ios/Pods
-          key: ${{ runner.os }}-pods-${{ env.GH_CACHE_VERSION }}-${{ env.GH_PODS_CACHE_VERSION }}-${{ hashFiles('app/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-${{ env.GH_CACHE_VERSION }}-${{ env.GH_PODS_CACHE_VERSION }}-
-            ${{ runner.os }}-pods-${{ env.GH_CACHE_VERSION }}-
+          path: |
+            ${{ env.APP_PATH }}/ios/Pods
+            ~/Library/Caches/CocoaPods
+          lock-file: app/ios/Podfile.lock
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_PODS_CACHE_VERSION }}
 
       - name: Log cache status
         run: |
@@ -540,37 +536,27 @@ jobs:
 
       - name: Cache Yarn dependencies
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-yarn
         with:
           path: |
             ${{ env.APP_PATH }}/node_modules
             ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}-
-            ${{ runner.os }}-yarn-${{ env.GH_CACHE_VERSION }}-
+          lock-file: yarn.lock
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_YARN_CACHE_VERSION }}
 
       - name: Cache Ruby gems
         id: gems-cache
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-bundler
         with:
           path: ${{ env.APP_PATH }}/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-${{ hashFiles('app/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-
-            ${{ runner.os }}-gems-${{ env.GH_CACHE_VERSION }}-
+          lock-file: app/Gemfile.lock
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}
 
       - name: Cache Gradle dependencies
         id: gradle-cache
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-gradle
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GRADLE_CACHE_VERSION }}-${{ hashFiles('app/android/**/*.gradle*', 'app/android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-${{ env.GH_CACHE_VERSION }}-${{ env.GH_GRADLE_CACHE_VERSION }}-
-            ${{ runner.os }}-gradle-${{ env.GH_CACHE_VERSION }}-
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_GRADLE_CACHE_VERSION }}
 
       - name: Cache Android NDK
         id: ndk-cache

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -45,12 +45,7 @@ jobs:
       - run: corepack enable
       - run: corepack prepare yarn@4.6.0 --activate
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: .yarn/cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+        uses: ./.github/actions/cache-yarn
       - run: yarn install --immutable --silent
       - name: Cache Maestro
         id: cache-maestro
@@ -69,14 +64,7 @@ jobs:
           distribution: "temurin"
           java-version: ${{ env.JAVA_VERSION }}
       - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+        uses: ./.github/actions/cache-gradle
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
@@ -163,12 +151,7 @@ jobs:
       - run: corepack enable
       - run: corepack prepare yarn@4.6.0 --activate
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: .yarn/cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+        uses: ./.github/actions/cache-yarn
       - run: yarn install --immutable --silent
       - name: Cache Maestro
         id: cache-maestro
@@ -189,21 +172,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Cache Ruby gems
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-bundler
         with:
           path: app/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+          lock-file: app/Gemfile.lock
       - name: Cache Pods
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-pods
         with:
           path: |
             app/ios/Pods
             ~/Library/Caches/CocoaPods
-          key: ${{ runner.os }}-pods-${{ hashFiles('app/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
+          lock-file: app/ios/Podfile.lock
       - name: Cache Xcode build
         uses: actions/cache@v4
         with:

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -6,6 +6,9 @@ env:
   JAVA_VERSION: 17
   ANDROID_API_LEVEL: 33
   ANDROID_NDK_VERSION: 27.0.11718014
+  # Cache versions
+  GH_CACHE_VERSION: v1 # Global cache version
+  GH_GEMS_CACHE_VERSION: v1 # Ruby gems cache version
   # Performance optimizations
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4 -Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.caching=true
   CI: true
@@ -185,9 +188,8 @@ jobs:
         uses: ./.github/actions/cache-bundler
         with:
           path: app/vendor/bundle
-          key: ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-${{ hashFiles('app/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-ruby${{ env.RUBY_VERSION }}-gems-
+          lock-file: app/Gemfile.lock
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-ruby${{ env.RUBY_VERSION }}
       - name: Cache Pods
         uses: ./.github/actions/cache-pods
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,17 @@ yarn types
   - For Noir circuits, run `nargo test -p <crate>` in each `noir/crates/*` directory.
   - Tests for `@selfxyz/contracts` are currently disabled in CI and may be skipped.
 
+### CI Caching
+
+Use the shared composite actions in `.github/actions` when caching dependencies in GitHub workflows. They provide consistent cache paths and keys:
+
+- `cache-yarn` for Yarn dependencies
+- `cache-bundler` for Ruby gems
+- `cache-gradle` for Gradle wrappers and caches
+- `cache-pods` for CocoaPods
+
+Each action accepts an optional `cache-version` input (often combined with `GH_CACHE_VERSION` and a tool-specific version). Avoid calling `actions/cache` directly so future workflows follow the same strategy.
+
 ### Formatting
 
 - Use Prettier configuration from `.prettierrc` files.


### PR DESCRIPTION
## Summary
- add cache-yarn, cache-bundler, cache-gradle, and cache-pods composite actions
- replace direct actions/cache usage with shared actions in mobile workflows
- document caching policy in AGENTS instructions

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` (fails: HH8 config error)
- `yarn types`
- `yarn workspace @selfxyz/common test`
- `yarn workspace @selfxyz/circuits test` (fails: Unsupported signature algorithm: undefined)
- `yarn workspace @selfxyz/mobile-app test`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_6899342965d4832d857774a75648463e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Introduced shared composite actions to standardize dependency caching (Yarn, Bundler, Gradle, CocoaPods) across mobile CI.
  - Updated mobile deploy and E2E workflows to use unified, lock-file–based cache versioning and local caching actions; mobile dependency installation now uses the local setup action.

- Documentation
  - Added CI caching guidance with examples recommending the shared actions and added formatting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->