### PR TITLE
chore(web): fix web app not working

### DIFF
--- a/app/src/mocks/react-native-clipboard.ts
+++ b/app/src/mocks/react-native-clipboard.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+import type { EmitterSubscription } from 'react-native';
+
+// Mock for the react-native-clipboard package, implements only the methods that are used in the app,
+// everything else will throw an error so that it's clearly visible what needs to be implemented
+export default {
+  getString(): Promise<string> {
+    if (navigator.clipboard) {
+      return navigator.clipboard.readText();
+    }
+
+    console.error('Clipboard is not supported in this browser');
+
+    return Promise.resolve('');
+  },
+
+  setString(content: string): void {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(content);
+    }
+
+    console.error('Clipboard is not supported in this browser');
+  },
+
+  getStrings(): Promise<string[]> {
+    throw new Error('Method not implemented');
+  },
+
+  getImagePNG(): Promise<string> {
+    throw new Error('Method not implemented');
+  },
+
+  getImageJPG(): Promise<string> {
+    throw new Error('Method not implemented');
+  },
+
+  setImage(_: string): void {
+    throw new Error('Method not implemented');
+  },
+
+  getImage(): Promise<string> {
+    throw new Error('Method not implemented');
+  },
+
+  setStrings(_: string[]): void {
+    throw new Error('Method not implemented');
+  },
+
+  hasString(): Promise<boolean> {
+    throw new Error('Method not implemented');
+  },
+
+  hasImage(): Promise<boolean> {
+    throw new Error('Method not implemented');
+  },
+
+  hasURL(): Promise<boolean> | undefined {
+    throw new Error('Method not implemented');
+  },
+
+  hasNumber(): Promise<boolean> | undefined {
+    throw new Error('Method not implemented');
+  },
+
+  hasWebURL(): Promise<boolean> | undefined {
+    throw new Error('Method not implemented');
+  },
+
+  addListener(_: () => void): EmitterSubscription {
+    throw new Error('Method not implemented');
+  },
+
+  removeAllListeners(): void {
+    throw new Error('Method not implemented');
+  },
+};

--- a/app/src/mocks/react-native-safe-area-context.js
+++ b/app/src/mocks/react-native-safe-area-context.js
@@ -2,7 +2,22 @@
 
 import { createContext, createElement, Fragment } from 'react';
 
-export const SafeAreaContext = createContext(initialWindowMetrics);
+const safeAreaInitialWindowMetrics = {
+  insets: {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+  frame: {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  },
+};
+
+export const SafeAreaContext = createContext(safeAreaInitialWindowMetrics);
 
 export const SafeAreaInsetsContext = createContext({
   top: 0,
@@ -20,20 +35,7 @@ export function SafeAreaView(props) {
   return createElement('div', props, props.children);
 }
 
-export const initialWindowMetrics = {
-  insets: {
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
-  },
-  frame: {
-    x: 0,
-    y: 0,
-    width: 0,
-    height: 0,
-  },
-};
+export const initialWindowMetrics = safeAreaInitialWindowMetrics;
 
 export function useSafeAreaFrame() {
   return { x: 0, y: 0, width: 0, height: 0 };

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -40,6 +40,10 @@ export default defineConfig({
         __dirname,
         'src/mocks/react-native-gesture-handler.ts',
       ),
+      '@react-native-clipboard/clipboard': path.resolve(
+        __dirname,
+        'src/mocks/react-native-clipboard.ts',
+      ),
     },
   },
   plugins: [


### PR DESCRIPTION
Two separate issues prevented web from working properly (or to display the launch screen at least):

1. Due to export sorting in `react-native-safe-area-context` a variable was used before initialization
2. `@react-native-clipboard/clipboard` package does not support web and was using `TurboModules` under the hood which is undefined for web hence causing the web to fail

Both issues are addressed by this PR.