### PR TITLE
feat: add TEE input helpers

### DIFF
--- a/packages/mobile-sdk-alpha/package.json
+++ b/packages/mobile-sdk-alpha/package.json
@@ -51,6 +51,10 @@
     "validate:pkg": "node ./scripts/verify-conditions.mjs"
   },
   "dependencies": {
+    "@openpassport/zk-kit-lean-imt": "^0.0.6",
+    "@openpassport/zk-kit-smt": "^0.0.1",
+    "@selfxyz/common": "workspace:*",
+    "poseidon-lite": "^0.2.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -37,6 +37,8 @@ export { SCANNER_ERROR_CODES, notImplemented, sdkError } from './errors';
 export { createSelfClient } from './client';
 export { defaultConfig } from './config/defaults';
 export { extractMRZInfo, formatDateToYYMMDD } from './processing/mrz';
+export { generateTEEInputsDisclose } from './proving/discloseInputs';
+export { generateTEEInputsRegister } from './proving/registerInputs';
 export { parseNFCResponse } from './processing/nfc';
 // Error handling
 export { webScannerShim } from './adapters/web/shims';

--- a/packages/mobile-sdk-alpha/src/proving/discloseInputs.ts
+++ b/packages/mobile-sdk-alpha/src/proving/discloseInputs.ts
@@ -1,0 +1,114 @@
+import { poseidon2 } from 'poseidon-lite';
+
+import {
+  attributeToPosition,
+  attributeToPosition_ID,
+  DEFAULT_MAJORITY,
+  ID_CARD_ATTESTATION_ID,
+  PASSPORT_ATTESTATION_ID,
+} from '@selfxyz/common/constants';
+import type { DocumentCategory, PassportData } from '@selfxyz/common/types';
+import type { SelfApp, SelfAppDisclosureConfig } from '@selfxyz/common/utils';
+import {
+  calculateUserIdentifierHash,
+  generateCircuitInputsVCandDisclose,
+  hashEndpointWithScope,
+} from '@selfxyz/common/utils';
+
+import { LeanIMT } from '@openpassport/zk-kit-lean-imt';
+import { SMT } from '@openpassport/zk-kit-smt';
+
+export function generateTEEInputsDisclose(
+  secret: string,
+  passportData: PassportData,
+  selfApp: SelfApp,
+  ofacTrees: {
+    passportNoAndNationality: any;
+    nameAndDob: any;
+    nameAndYob: any;
+  },
+  commitmentTree: any,
+) {
+  const { scope, disclosures, endpoint, userId, userDefinedData, chainID } = selfApp;
+  const userIdentifierHash = calculateUserIdentifierHash(chainID, userId, userDefinedData);
+  const scope_hash = hashEndpointWithScope(endpoint, scope);
+  const document: DocumentCategory = passportData.documentCategory;
+
+  const selector_dg1 = getSelectorDg1(document, disclosures);
+
+  const majority = disclosures.minimumAge ? disclosures.minimumAge.toString() : DEFAULT_MAJORITY;
+  const selector_older_than = disclosures.minimumAge ? '1' : '0';
+
+  const selector_ofac = disclosures.ofac ? 1 : 0;
+
+  let passportNoAndNationalitySMT: SMT | null = null;
+  const nameAndDobSMT = new SMT(poseidon2, true);
+  const nameAndYobSMT = new SMT(poseidon2, true);
+  if (document === 'passport') {
+    passportNoAndNationalitySMT = new SMT(poseidon2, true);
+    passportNoAndNationalitySMT.import(ofacTrees.passportNoAndNationality);
+  }
+  nameAndDobSMT.import(ofacTrees.nameAndDob);
+  nameAndYobSMT.import(ofacTrees.nameAndYob);
+
+  const tree = LeanIMT.import((a, b) => poseidon2([a, b]), commitmentTree);
+  const inputs = generateCircuitInputsVCandDisclose(
+    secret,
+    document === 'passport' ? PASSPORT_ATTESTATION_ID : ID_CARD_ATTESTATION_ID,
+    passportData,
+    scope_hash,
+    selector_dg1,
+    selector_older_than,
+    tree,
+    majority,
+    passportNoAndNationalitySMT,
+    nameAndDobSMT,
+    nameAndYobSMT,
+    selector_ofac,
+    disclosures.excludedCountries ?? [],
+    userIdentifierHash.toString(),
+  );
+  return {
+    inputs,
+    circuitName: passportData.documentCategory === 'passport' ? 'vc_and_disclose' : 'vc_and_disclose_id',
+    endpointType: selfApp.endpointType,
+    endpoint: selfApp.endpoint,
+  };
+}
+
+function getSelectorDg1(document: DocumentCategory, disclosures: SelfAppDisclosureConfig) {
+  switch (document) {
+    case 'passport':
+      return getSelectorDg1Passport(disclosures);
+    case 'id_card':
+      return getSelectorDg1IdCard(disclosures);
+  }
+}
+
+function getSelectorDg1Passport(disclosures: SelfAppDisclosureConfig) {
+  const selector_dg1 = Array(88).fill('0');
+  Object.entries(disclosures).forEach(([attribute, reveal]) => {
+    if (['ofac', 'excludedCountries', 'minimumAge'].includes(attribute)) {
+      return;
+    }
+    if (reveal) {
+      const [start, end] = attributeToPosition[attribute as keyof typeof attributeToPosition];
+      selector_dg1.fill('1', start, end + 1);
+    }
+  });
+  return selector_dg1;
+}
+
+function getSelectorDg1IdCard(disclosures: SelfAppDisclosureConfig) {
+  const selector_dg1 = Array(90).fill('0');
+  Object.entries(disclosures).forEach(([attribute, reveal]) => {
+    if (['ofac', 'excludedCountries', 'minimumAge'].includes(attribute)) {
+      return;
+    }
+    if (reveal) {
+      const [start, end] = attributeToPosition_ID[attribute as keyof typeof attributeToPosition_ID];
+      selector_dg1.fill('1', start, end + 1);
+    }
+  });
+  return selector_dg1;
+}

--- a/packages/mobile-sdk-alpha/src/proving/registerInputs.ts
+++ b/packages/mobile-sdk-alpha/src/proving/registerInputs.ts
@@ -1,0 +1,15 @@
+import type { PassportData } from '@selfxyz/common/types';
+import { generateCircuitInputsRegister, getCircuitNameFromPassportData } from '@selfxyz/common/utils';
+
+export function generateTEEInputsRegister(
+  secret: string,
+  passportData: PassportData,
+  dscTree: string,
+  env: 'prod' | 'stg',
+) {
+  const inputs = generateCircuitInputsRegister(secret, passportData, dscTree);
+  const circuitName = getCircuitNameFromPassportData(passportData, 'register');
+  const endpointType = env === 'stg' ? 'staging_celo' : 'celo';
+  const endpoint = 'https://self.xyz';
+  return { inputs, circuitName, endpointType, endpoint };
+}

--- a/packages/mobile-sdk-alpha/tests/proving/discloseInputs.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/discloseInputs.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PassportData } from '@selfxyz/common/types';
+import type { SelfApp } from '@selfxyz/common/utils';
+import { generateCircuitInputsVCandDisclose } from '@selfxyz/common/utils';
+
+import { generateTEEInputsDisclose } from '../../src';
+
+vi.mock('@selfxyz/common/utils', () => ({
+  calculateUserIdentifierHash: vi.fn(() => BigInt(1)),
+  hashEndpointWithScope: vi.fn(() => 'scope_hash'),
+  generateCircuitInputsVCandDisclose: vi.fn(() => ({ mocked: true })),
+}));
+
+vi.mock('@openpassport/zk-kit-lean-imt', () => ({
+  LeanIMT: { import: vi.fn(() => 'tree') },
+}));
+
+vi.mock('@openpassport/zk-kit-smt', () => {
+  const SMT = vi.fn().mockImplementation(() => ({ import: vi.fn() }));
+  return { SMT };
+});
+
+vi.mock('poseidon-lite', () => ({ poseidon2: vi.fn() }));
+
+describe('generateTEEInputsDisclose', () => {
+  it('builds disclose inputs with endpoint info', () => {
+    const passportData = { documentCategory: 'passport' } as PassportData;
+      const selfApp = {
+        scope: 's',
+        disclosures: {},
+        endpoint: 'https://e',
+        endpointType: 'https',
+        userId: 'u',
+        userDefinedData: '0x0',
+        chainID: 1,
+      } as any;
+    const ofacTrees = {
+      passportNoAndNationality: [],
+      nameAndDob: [],
+      nameAndYob: [],
+    } as any;
+    const commitmentTree = [['0']];
+      const result = generateTEEInputsDisclose('sec', passportData, selfApp as SelfApp, ofacTrees, commitmentTree as any);
+    expect(generateCircuitInputsVCandDisclose).toHaveBeenCalled();
+    expect(result).toEqual({
+      inputs: { mocked: true },
+      circuitName: 'vc_and_disclose',
+      endpointType: 'https',
+      endpoint: 'https://e',
+    });
+  });
+});

--- a/packages/mobile-sdk-alpha/tests/proving/registerInputs.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/registerInputs.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PassportData } from '@selfxyz/common/types';
+import { generateCircuitInputsRegister, getCircuitNameFromPassportData } from '@selfxyz/common/utils';
+
+import { generateTEEInputsRegister } from '../../src';
+
+vi.mock('@selfxyz/common/utils', () => ({
+  generateCircuitInputsRegister: vi.fn(() => ({ mocked: true })),
+  getCircuitNameFromPassportData: vi.fn(() => 'reg'),
+}));
+
+describe('generateTEEInputsRegister', () => {
+  it('builds register inputs with endpoint info', () => {
+    const passportData = { documentCategory: 'passport' } as PassportData;
+    const result = generateTEEInputsRegister('sec', passportData, 'tree', 'stg');
+    expect(generateCircuitInputsRegister).toHaveBeenCalledWith('sec', passportData, 'tree');
+    expect(getCircuitNameFromPassportData).toHaveBeenCalledWith(passportData, 'register');
+    expect(result).toEqual({
+      inputs: { mocked: true },
+      circuitName: 'reg',
+      endpointType: 'staging_celo',
+      endpoint: 'https://self.xyz',
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4779,7 +4779,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@selfxyz/common@workspace:^, @selfxyz/common@workspace:common":
+"@selfxyz/common@workspace:*, @selfxyz/common@workspace:^, @selfxyz/common@workspace:common":
   version: 0.0.0-use.local
   resolution: "@selfxyz/common@workspace:common"
   dependencies:
@@ -5048,6 +5048,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@selfxyz/mobile-sdk-alpha@workspace:packages/mobile-sdk-alpha"
   dependencies:
+    "@openpassport/zk-kit-lean-imt": "npm:^0.0.6"
+    "@openpassport/zk-kit-smt": "npm:^0.0.1"
+    "@selfxyz/common": "workspace:*"
     "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
     "@typescript-eslint/parser": "npm:^7.18.0"
     eslint: "npm:^8.57.0"
@@ -5056,6 +5059,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.5.4"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     eslint-plugin-sort-exports: "npm:^0.8.0"
+    poseidon-lite: "npm:^0.2.0"
     prettier: "npm:^3.5.3"
     tslib: "npm:^2.6.2"
     tsup: "npm:^8.0.1"


### PR DESCRIPTION
## Summary
- port register TEE input generator accepting environment and DSC tree
- port disclose TEE input generator using passed OFAC and commitment trees
- expose helpers via package index and add unit tests

## Testing
- `yarn workspace @selfxyz/mobile-sdk-alpha nice`
- `yarn workspace @selfxyz/mobile-sdk-alpha build`
- `yarn workspace @selfxyz/mobile-sdk-alpha types`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_689c068145d8832d9c9c7425db710527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added APIs to generate TEE inputs for disclose and register flows, expanding the mobile SDK’s proving capabilities. Supports multiple document types and returns inputs with circuit and endpoint metadata.

* **Tests**
  * Added unit tests validating the new disclose and register input generators, including environment-specific endpoint handling.

* **Chores**
  * Added dependencies to support ZK components, shared workspace utilities, and hashing, improving cryptographic and tree-handling capabilities without altering existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->