### PR TITLE
feat: add native event bridge

### DIFF
--- a/packages/mobile-sdk-alpha/docs/ARCHITECTURE_CHECKLIST.md
+++ b/packages/mobile-sdk-alpha/docs/ARCHITECTURE_CHECKLIST.md
@@ -18,9 +18,9 @@ The alpha SDK follows an adapter-first, React Native–oriented design. Tree-sha
 
 ### 2. Bridge layer for native events
 
-- [ ] Wrap `NativeModules`/`NativeEventEmitter` so features register listeners through a shared adapter
-- [ ] Create unified event handling interface
-- [ ] Implement platform-specific event bridges
+- [x] Wrap `NativeModules`/`NativeEventEmitter` so features register listeners through a shared adapter
+- [x] Create unified event handling interface
+- [x] Implement platform-specific event bridges
 
 ### 3. Exception classes
 

--- a/packages/mobile-sdk-alpha/src/bridge/nativeEvents.native.ts
+++ b/packages/mobile-sdk-alpha/src/bridge/nativeEvents.native.ts
@@ -1,0 +1,27 @@
+import type { NativeEventSubscription } from 'react-native';
+import { NativeEventEmitter, NativeModules } from 'react-native';
+
+import type { NativeEventBridge } from './nativeEvents';
+
+const emitters: Record<string, NativeEventEmitter> = {};
+
+function getEmitter(moduleName: string): NativeEventEmitter {
+  if (!emitters[moduleName]) {
+    const mod = (NativeModules as Record<string, any>)[moduleName];
+    emitters[moduleName] = new NativeEventEmitter(mod);
+  }
+  return emitters[moduleName];
+}
+
+export const addListener: NativeEventBridge['addListener'] = (moduleName, eventName, handler) => {
+  const emitter = getEmitter(moduleName);
+  const sub: NativeEventSubscription = emitter.addListener(eventName, handler);
+  return () => sub.remove();
+};
+
+export const removeListener: NativeEventBridge['removeListener'] = (moduleName, eventName, handler) => {
+  const emitter = emitters[moduleName];
+  if (emitter) {
+    (emitter as any).removeListener?.(eventName, handler);
+  }
+};

--- a/packages/mobile-sdk-alpha/src/bridge/nativeEvents.native.ts
+++ b/packages/mobile-sdk-alpha/src/bridge/nativeEvents.native.ts
@@ -8,7 +8,20 @@ const emitters: Record<string, NativeEventEmitter> = {};
 function getEmitter(moduleName: string): NativeEventEmitter {
   if (!emitters[moduleName]) {
     const mod = (NativeModules as Record<string, any>)[moduleName];
-    emitters[moduleName] = new NativeEventEmitter(mod);
+    const hasExpectedShape =
+      !!mod && typeof (mod as any).addListener === 'function' && typeof (mod as any).removeListeners === 'function';
+    if (!hasExpectedShape) {
+      if (typeof __DEV__ !== 'undefined' && __DEV__) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[nativeEvents] Native module '${moduleName}' is missing or does not implement addListener/removeListeners; ` +
+            'falling back to a shared emitter. Events may not fire on iOS.',
+        );
+      }
+      emitters[moduleName] = new NativeEventEmitter();
+    } else {
+      emitters[moduleName] = new NativeEventEmitter(mod);
+    }
   }
   return emitters[moduleName];
 }

--- a/packages/mobile-sdk-alpha/src/bridge/nativeEvents.ts
+++ b/packages/mobile-sdk-alpha/src/bridge/nativeEvents.ts
@@ -1,11 +1,13 @@
 import type { Unsubscribe } from '../types/public';
 
-export type EventHandler = (...args: any[]) => void;
+export type EventHandler = (...args: unknown[]) => void;
 
 export interface NativeEventBridge {
   addListener(moduleName: string, eventName: string, handler: EventHandler): Unsubscribe;
   removeListener(moduleName: string, eventName: string, handler: EventHandler): void;
 }
 
-export const addListener: NativeEventBridge['addListener'] = () => () => {};
+export const addListener: NativeEventBridge['addListener'] = (moduleName, eventName, handler) => () =>
+  removeListener(moduleName, eventName, handler);
+
 export const removeListener: NativeEventBridge['removeListener'] = () => {};

--- a/packages/mobile-sdk-alpha/src/bridge/nativeEvents.ts
+++ b/packages/mobile-sdk-alpha/src/bridge/nativeEvents.ts
@@ -1,0 +1,11 @@
+import type { Unsubscribe } from '../types/public';
+
+export type EventHandler = (...args: any[]) => void;
+
+export interface NativeEventBridge {
+  addListener(moduleName: string, eventName: string, handler: EventHandler): Unsubscribe;
+  removeListener(moduleName: string, eventName: string, handler: EventHandler): void;
+}
+
+export const addListener: NativeEventBridge['addListener'] = () => () => {};
+export const removeListener: NativeEventBridge['removeListener'] = () => {};

--- a/packages/mobile-sdk-alpha/tests/bridge/nativeEvents.test.ts
+++ b/packages/mobile-sdk-alpha/tests/bridge/nativeEvents.test.ts
@@ -7,23 +7,26 @@ describe('nativeEvents bridge (stub)', () => {
     const handler = () => {};
     const unsub = addListener('TestModule', 'test', handler);
     expect(typeof unsub).toBe('function');
-    unsub();
+    expect(() => unsub()).not.toThrow();
     expect(() => removeListener('TestModule', 'test', handler)).not.toThrow();
   });
 });
 
 describe('nativeEvents bridge (react-native)', () => {
   it('delegates to NativeEventEmitter', async () => {
-    const addListenerMock = vi.fn(() => ({ remove: vi.fn() }));
+    const removeSubMock = vi.fn();
+    const addListenerMock = vi.fn(() => ({ remove: removeSubMock }));
     const removeListenerMock = vi.fn();
 
     vi.doMock('react-native', () => ({
-      NativeModules: { TestModule: {} },
+      NativeModules: { TestModule: { addListener: vi.fn(), removeListeners: vi.fn() } },
       NativeEventEmitter: vi.fn(() => ({
         addListener: addListenerMock,
         removeListener: removeListenerMock,
       })),
     }));
+
+    vi.resetModules();
 
     const rn = await import('../../src/bridge/nativeEvents.native');
 
@@ -35,5 +38,31 @@ describe('nativeEvents bridge (react-native)', () => {
     expect(removeListenerMock).toHaveBeenCalledWith('event', handler);
 
     unsub();
+    expect(removeSubMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches emitter per module', async () => {
+    const addListenerMock = vi.fn(() => ({ remove: vi.fn() }));
+    const NativeEventEmitterMock = vi.fn(() => ({
+      addListener: addListenerMock,
+      removeListener: vi.fn(),
+    }));
+
+    vi.doMock('react-native', () => ({
+      NativeModules: { TestModule: { addListener: vi.fn(), removeListeners: vi.fn() } },
+      NativeEventEmitter: NativeEventEmitterMock,
+    }));
+
+    vi.resetModules();
+
+    const rn = await import('../../src/bridge/nativeEvents.native');
+
+    const handler = () => {};
+    const unsub1 = rn.addListener('TestModule', 'event', handler);
+    const unsub2 = rn.addListener('TestModule', 'event', handler);
+    expect(NativeEventEmitterMock).toHaveBeenCalledTimes(1);
+
+    unsub1();
+    unsub2();
   });
 });

--- a/packages/mobile-sdk-alpha/tests/bridge/nativeEvents.test.ts
+++ b/packages/mobile-sdk-alpha/tests/bridge/nativeEvents.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { addListener, removeListener } from '../../src/bridge/nativeEvents';
+
+describe('nativeEvents bridge (stub)', () => {
+  it('returns unsubscribe function and allows removal', () => {
+    const handler = () => {};
+    const unsub = addListener('TestModule', 'test', handler);
+    expect(typeof unsub).toBe('function');
+    unsub();
+    expect(() => removeListener('TestModule', 'test', handler)).not.toThrow();
+  });
+});
+
+describe('nativeEvents bridge (react-native)', () => {
+  it('delegates to NativeEventEmitter', async () => {
+    const addListenerMock = vi.fn(() => ({ remove: vi.fn() }));
+    const removeListenerMock = vi.fn();
+
+    vi.doMock('react-native', () => ({
+      NativeModules: { TestModule: {} },
+      NativeEventEmitter: vi.fn(() => ({
+        addListener: addListenerMock,
+        removeListener: removeListenerMock,
+      })),
+    }));
+
+    const rn = await import('../../src/bridge/nativeEvents.native');
+
+    const handler = () => {};
+    const unsub = rn.addListener('TestModule', 'event', handler);
+    expect(addListenerMock).toHaveBeenCalledWith('event', handler);
+
+    rn.removeListener('TestModule', 'event', handler);
+    expect(removeListenerMock).toHaveBeenCalledWith('event', handler);
+
+    unsub();
+  });
+});


### PR DESCRIPTION
## Summary
- add platform-specific native event bridge wrapper
- mark bridge layer tasks complete in architecture checklist

## Testing
- `yarn workspace @selfxyz/mobile-sdk-alpha nice`
- `yarn workspace @selfxyz/mobile-sdk-alpha build`
- `yarn workspace @selfxyz/mobile-sdk-alpha types`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`
- `yarn workspaces foreach -A -p -v --topological-dev --since=HEAD run nice --if-present` *(no output)*
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account in Hardhat config)*
- `yarn types`
- `yarn test` *(fails: mobile-app and circuits workspace issues)*


------
https://chatgpt.com/codex/tasks/task_b_689e18edcc88832d8f91213e0d234834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a unified native event listener API for the mobile SDK, providing consistent subscribe/unsubscribe behavior across platforms with safer, fallback-aware handling.
* Documentation
  * Architecture checklist updated to mark the native event bridge and unified event handling items as completed.
* Tests
  * Added tests covering subscribe/unsubscribe behavior, platform-specific paths, and emitter caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->