### PR TITLE
docs: remove nfc and non migration tasks

### DIFF
--- a/.cursor/rules/mobile-sdk-migration.mdc
+++ b/.cursor/rules/mobile-sdk-migration.mdc
@@ -47,12 +47,11 @@ contextUsageNote: If this file is used to add in-context notes, include a single
 
 ## Migration Checklist Items
 
-### 1. Processing Helpers (MRZ & NFC)
-**Current Location**: `app/src/utils/` (MRZ utilities, NFC scanner)
+### 1. Processing Helpers (MRZ)
+**Current Location**: `app/src/utils/` (MRZ utilities)
 **Target Location**: `packages/mobile-sdk-alpha/src/processing/`
 **Testing Strategy**:
 - Create MRZ parsing tests with sample passport data
-- Create NFC response parser tests with mock NFC data
 - Test cross-platform compatibility (React Native vs Web)
 
 ### 2. Validation Module
@@ -114,42 +113,12 @@ contextUsageNote: If this file is used to add in-context notes, include a single
 - Test signature verification
 - Test storage adapter integration
 
-### 9. Scanning Adapters & NFC Lifecycle
-**Current Location**: `app/src/utils/nfcScanner.ts`
-**Target Location**: `packages/mobile-sdk-alpha/src/adapters/`
-**Testing Strategy**:
-- Test cross-platform scanner interfaces
-- Test React Native MRZ and NFC adapters
-- Test screen-on hooks integration
-- Test flow chaining (MRZ → NFC)
-
-### 10. Sample Applications
-**Target Location**: `packages/mobile-sdk-alpha/examples/`
-**Testing Strategy**:
-- Create React Native demo with core flows
-- Create web demo with browser adapters
-- Test iOS `OpenPassport` URL scheme
-
-### 11. SDK Integration into App
+### 9. SDK Integration into App
 **Migration Strategy**:
 - Replace existing modules with SDK imports
 - Update import paths throughout app
 - Validate all existing functionality works
 - Ensure no regression in app behavior
-
-### 12. In-SDK Lightweight Demo
-**Target Location**: `packages/mobile-sdk-alpha/demo/`
-**Testing Strategy**:
-- Embedded React Native demo
-- Test theming hooks integration
-- Validate build and run instructions
-
-### 13. Partner Feedback Integration
-**Enhancements**:
-- OAuth-style branding customization
-- Callback hooks for async operations
-- Expanded document coverage
-- Bundle size optimization
 
 ## Testing Best Practices
 

--- a/.cursor/rules/mobile-sdk-migration.mdc
+++ b/.cursor/rules/mobile-sdk-migration.mdc
@@ -113,12 +113,26 @@ contextUsageNote: If this file is used to add in-context notes, include a single
 - Test signature verification
 - Test storage adapter integration
 
-### 9. SDK Integration into App
+### 9. Sample Applications
+**Target Location**: `packages/mobile-sdk-alpha/samples/`
+**Testing Strategy**:
+- Create React Native demo with MRZ → proof flow
+- Create web demo with browser-based MRZ input
+- Test iOS `OpenPassport` URL scheme
+
+### 10. SDK Integration into App
 **Migration Strategy**:
 - Replace existing modules with SDK imports
 - Update import paths throughout app
 - Validate all existing functionality works
 - Ensure no regression in app behavior
+
+### 11. In-SDK Lightweight Demo
+**Target Location**: `packages/mobile-sdk-alpha/demo/`
+**Testing Strategy**:
+- Embedded React Native demo using MRZ → proof flow
+- Test theming hooks integration
+- Validate build and run instructions
 
 ## Testing Best Practices
 

--- a/packages/mobile-sdk-alpha/docs/ARCHITECTURE_CHECKLIST.md
+++ b/packages/mobile-sdk-alpha/docs/ARCHITECTURE_CHECKLIST.md
@@ -10,9 +10,9 @@ The alpha SDK follows an adapter-first, React Native–oriented design. Tree-sha
 
 ### 1. Modular feature directories ✅ COMPLETED
 
-- [x] Group new capabilities (e.g., `mrz/`, `nfc/`, `qr/`) in their own folders
+- [x] Group new capabilities (e.g., `mrz/`, `qr/`) in their own folders
 - [x] Re-export from `src/index.ts` using explicit named exports (avoid `export *`)
-- [x] Create `src/nfc/`, `src/mrz/`, and `src/qr/` modules
+- [x] Create `src/mrz/` and `src/qr/` modules
 - [x] Implement proper error handling with `notImplemented` helper
 - [x] Use type aliases instead of empty interfaces for better tree shaking
 
@@ -44,12 +44,12 @@ The alpha SDK follows an adapter-first, React Native–oriented design. Tree-sha
 
 - [ ] Integrate the SDK into the monorepo's `app` workspace
 - [ ] Validate real flows
-- [ ] Replace existing MRZ/NFC modules with SDK adapters
+- [ ] Replace existing MRZ modules with SDK adapters
 
 ### 7. Android demo app
 
 - [ ] Ship a minimal React Native Android project
-- [ ] Demonstrate MRZ → NFC → proof generation flow
+- [ ] Demonstrate MRZ → proof generation flow
 - [ ] Provide build and run instructions
 
 ## Working in Parallel

--- a/packages/mobile-sdk-alpha/docs/ARCHITECTURE_PROMPTS.md
+++ b/packages/mobile-sdk-alpha/docs/ARCHITECTURE_PROMPTS.md
@@ -22,7 +22,7 @@ yarn build
 <details>
 <summary><strong>Split features into dedicated folders</strong></summary>
 
-1. Under `src/`, create folders like `mrz/`, `nfc/`, and `qr/` as features are added.
+1. Under `src/`, create folders like `mrz/` and `qr/` as features are added.
 2. Re-export feature APIs from `src/index.ts` using explicit named exports to keep tree shaking intact.
 
 </details>
@@ -82,7 +82,7 @@ yarn build
 <details>
 <summary><strong>Provide minimal Android sample</strong></summary>
 
-1. Under `samples/android/`, scaffold a basic React Native project showing MRZ → NFC → proof generation.
+1. Under `samples/android/`, scaffold a basic React Native project showing MRZ → proof generation.
 2. Document setup steps in `samples/android/README.md`.
 
 </details>

--- a/packages/mobile-sdk-alpha/docs/MIGRATION_CHECKLIST.md
+++ b/packages/mobile-sdk-alpha/docs/MIGRATION_CHECKLIST.md
@@ -53,8 +53,18 @@
 - Enforce CDN allowlist and Content-Length checks.
 - Stream hashing to avoid buffering large files.
 
-## 9. Integrate SDK into `/app`
+## 9. Sample applications
+
+- React Native and web demos showcasing core flows.
+- iOS `OpenPassport` URL scheme.
+
+## 10. Integrate SDK into `/app`
 
 - Consume `@selfxyz/mobile-sdk-alpha` inside the `app` workspace.
 - Replace MRZ modules with SDK adapters and wire processing helpers.
 - Validate builds and unit tests.
+
+## 11. In-SDK lightweight demo
+
+- Embedded React Native demo inside the SDK with theming hooks.
+- Provide build and run instructions.

--- a/packages/mobile-sdk-alpha/docs/MIGRATION_CHECKLIST.md
+++ b/packages/mobile-sdk-alpha/docs/MIGRATION_CHECKLIST.md
@@ -2,13 +2,13 @@
 
 > Detailed task prompts are listed in [MIGRATION_PROMPTS.md](./MIGRATION_PROMPTS.md).
 
-- [x] Group new capabilities into modular directories and re-export them from `src/index.ts` using named exports (initial stubs: `mrz/`, `nfc/`, `qr/`).
+- [x] Group new capabilities into modular directories and re-export them from `src/index.ts` using named exports (initial stubs: `mrz/`, `qr/`).
 
-## 1. Processing helpers (MRZ & NFC) ✅ COMPLETED
+## 1. Processing helpers (MRZ) ✅ COMPLETED
 
-- [x] Finalize MRZ utilities and add an NFC response parser.
+- [x] Finalize MRZ utilities.
 - [x] Re-export helpers through the SDK entry point.
-- [x] Create modular structure with `src/nfc/`, `src/mrz/`, and `src/qr/` modules.
+- [x] Create modular structure with `src/mrz/` and `src/qr/` modules.
 - [x] Implement proper error handling using `notImplemented` helper.
 - [x] Use type aliases instead of empty interfaces for better tree shaking.
 
@@ -53,31 +53,8 @@
 - Enforce CDN allowlist and Content-Length checks.
 - Stream hashing to avoid buffering large files.
 
-## 9. Scanning adapters & NFC lifecycle
-
-- Define cross-platform scanner interfaces.
-- Implement React Native MRZ and NFC adapters with screen-on hooks.
-- Provide a sample flow chaining MRZ to NFC scanning.
-
-## 10. Sample applications
-
-- React Native and web demos showcasing core flows.
-- iOS `OpenPassport` URL scheme.
-
-## 11. Integrate SDK into `/app`
+## 9. Integrate SDK into `/app`
 
 - Consume `@selfxyz/mobile-sdk-alpha` inside the `app` workspace.
-- Replace MRZ/NFC modules with SDK adapters and wire processing helpers.
+- Replace MRZ modules with SDK adapters and wire processing helpers.
 - Validate builds and unit tests.
-
-## 12. In-SDK lightweight demo
-
-- Embedded React Native demo inside the SDK with theming hooks.
-- Provide build and run instructions.
-
-## 13. Partner feedback
-
-- OAuth-style branding: logo, colors, copy, optional fonts.
-- Callback hook so the host app can trigger push notifications after async proof verification.
-- Expand ID document coverage for US digital licenses and AADHAR.
-- Document bundle size targets and provide a runnable integration example.

--- a/packages/mobile-sdk-alpha/docs/MIGRATION_PROMPTS.md
+++ b/packages/mobile-sdk-alpha/docs/MIGRATION_PROMPTS.md
@@ -7,7 +7,7 @@ Each chapter from the migration checklist includes granular tasks below. Pick ta
 ## Before you start
 
 - Run `yarn find:migration` to locate and open `.cursor/rules/mobile-sdk-migration.mdc` for full context.
-- Group new capabilities in their own directories (e.g., `processing/`, `validation/`, `mrz/`, `nfc/`, `qr/`) and re-export them from `src/index.ts` using explicit named exports.
+- Group new capabilities in their own directories (e.g., `processing/`, `validation/`, `mrz/`, `qr/`) and re-export them from `src/index.ts` using explicit named exports.
 
 ## Pre-flight checks
 
@@ -22,7 +22,7 @@ yarn lint
 yarn build
 ```
 
-## 1. Processing helpers (MRZ & NFC) ✅ COMPLETED
+## 1. Processing helpers (MRZ) ✅ COMPLETED
 
 <details>
 <summary><strong>Test MRZ parsing utilities</strong></summary>
@@ -33,19 +33,10 @@ yarn build
 </details>
 
 <details>
-<summary><strong>Add NFC response parser</strong></summary>
-
-1. ✅ Create `src/processing/nfc.ts` exporting a pure function to parse NFC chip responses into DG1/DG2 structures.
-2. Write tests in `tests/processing/nfc.test.ts`.
-3. ✅ Ensure no React Native dependencies.
-
-</details>
-
-<details>
 <summary><strong>Expose processing utilities</strong></summary>
 
-1. ✅ Update `src/index.ts` to re-export MRZ and NFC helpers.
-2. ✅ Create modular structure with `src/nfc/`, `src/mrz/`, and `src/qr/` modules.
+1. ✅ Update `src/index.ts` to re-export MRZ helpers.
+2. ✅ Create modular structure with `src/mrz/` and `src/qr/` modules.
 3. ✅ Implement proper error handling using `notImplemented` helper.
 4. ✅ Use type aliases instead of empty interfaces for better tree shaking.
 5. Document them in `README.md` under a "Processing utilities" section.
@@ -214,98 +205,14 @@ yarn build
 
 </details>
 
-## 9. Scanning adapters & NFC lifecycle
-
-<details>
-<summary><strong>Create scanning adapter interface</strong></summary>
-
-1. In `src/adapters/`, add `scanner.ts` exporting TypeScript interfaces for `MRZScanner` and `NFCScanner`.
-2. Reference React Native camera/NFC packages only through these interfaces.
-3. Document usage in `README.md`. Include a "Privacy & PII" subsection: forbid logging MRZ/NFC data, enable on-device processing only, and provide redaction utilities for debug.
-4. Never log MRZ strings, NFC APDUs, or chip contents anywhere (including telemetry).
-5. Ensure camera frames and NFC/APDU processing occur on-device with analytics disabled for those paths by default.
-6. Provide a redact/sanitize helper function for debug builds only.
-
-</details>
-
-<details>
-<summary><strong>Implement React Native MRZ adapter</strong></summary>
-
-1. Add `mrz-rn.ts` in `src/adapters/` implementing `MRZScanner` via `react-native-vision-camera`.
-2. Expose configuration for permissions, preview, and result handling.
-3. Write unit tests under `tests/` mocking camera output.
-
-</details>
-
-<details>
-<summary><strong>Implement React Native NFC adapter</strong></summary>
-
-1. Create `nfc-rn.ts` in `src/adapters/` implementing `NFCScanner` with `react-native-nfc-manager`.
-2. Provide lifecycle hooks so the app can call `keepScreenOn(true|false)` during sessions.
-3. Document app-level setup in `MIGRATION_CHECKLIST.md`.
-
-</details>
-
-<details>
-<summary><strong>Add scanning sample</strong></summary>
-
-1. Under `samples/`, add a React Native demo showing MRZ then NFC scanning.
-2. Include simple error handling and log output.
-3. Reference the sample from `README.md`.
-
-</details>
-
-## 10. Sample applications
-
-<details>
-<summary><strong>Add React Native sample</strong></summary>
-
-1. Under `samples/react-native/`, scaffold a bare-bones app using Expo or React Native CLI.
-2. Demonstrate MRZ scanning, NFC reading, and registration flow using SDK APIs.
-3. Include instructions in a `README.md`.
-
-</details>
-
-<details>
-<summary><strong>Add web sample</strong></summary>
-
-1. Under `samples/web/`, set up a Vite/React project showing browser-based MRZ input and proof generation.
-2. Document setup and build steps.
-
-</details>
-
-<details>
-<summary><strong>Configure OpenPassport scheme</strong></summary>
-
-1. In the React Native sample's iOS project, add URL type `OpenPassport` to `Info.plist`.
-2. Document Android intent filters (AndroidManifest.xml). Ensure scheme uniqueness and validate redirect origins to prevent hijacking.
-3. Choose a scheme unique to your app (e.g., using reverse-domain or app-identifier prefix).
-4. Detect and handle collisions (fallback checks, verify caller package/signature).
-5. Verify redirect domains and consider app-claimed links/Android App Links and iOS Universal Links for stronger security.
-
-</details>
-
-## 11. Integrate SDK into `/app`
+## 9. Integrate SDK into `/app`
 
 <details>
 <summary><strong>Integrate SDK in /app</strong></summary>
 
 1. Add `@selfxyz/mobile-sdk-alpha` to `app/package.json`.
-2. Replace existing MRZ/NFC scanning modules with SDK adapters.
+2. Replace existing MRZ scanning modules with SDK adapters.
 3. Wire app screens to SDK processing and validation helpers.
 4. Validate builds and unit tests in the `app` workspace.
-
-</details>
-
-## 12. In-SDK lightweight demo
-
-<details>
-<summary><strong>Create embedded demo app</strong></summary>
-
-1. Scaffold `demo/` under the SDK as a minimal React Native project.
-2. Use SDK APIs for MRZ → NFC → registration flow.
-3. Expose simple theming configuration.
-4. Add `demo/README.md` with build/run instructions.
-5. Add publishing guardrails: exclude `demo/` from npm and add a CI step to verify the published tarball contents.
 
 </details>

--- a/packages/mobile-sdk-alpha/docs/MIGRATION_PROMPTS.md
+++ b/packages/mobile-sdk-alpha/docs/MIGRATION_PROMPTS.md
@@ -205,7 +205,37 @@ yarn build
 
 </details>
 
-## 9. Integrate SDK into `/app`
+## 9. Sample applications
+
+<details>
+<summary><strong>Add React Native sample</strong></summary>
+
+1. Under `samples/react-native/`, scaffold a bare-bones app using Expo or React Native CLI.
+2. Demonstrate MRZ scanning and registration flow using SDK APIs.
+3. Include instructions in a `README.md`.
+
+</details>
+
+<details>
+<summary><strong>Add web sample</strong></summary>
+
+1. Under `samples/web/`, set up a Vite/React project showing browser-based MRZ input and proof generation.
+2. Document setup and build steps.
+
+</details>
+
+<details>
+<summary><strong>Configure OpenPassport scheme</strong></summary>
+
+1. In the React Native sample's iOS project, add URL type `OpenPassport` to `Info.plist`.
+2. Document Android intent filters (AndroidManifest.xml). Ensure scheme uniqueness and validate redirect origins to prevent hijacking.
+3. Choose a scheme unique to your app (e.g., using reverse-domain or app-identifier prefix).
+4. Detect and handle collisions (fallback checks, verify caller package/signature).
+5. Verify redirect domains and consider app-claimed links/Android App Links and iOS Universal Links for stronger security.
+
+</details>
+
+## 10. Integrate SDK into `/app`
 
 <details>
 <summary><strong>Integrate SDK in /app</strong></summary>
@@ -214,5 +244,18 @@ yarn build
 2. Replace existing MRZ scanning modules with SDK adapters.
 3. Wire app screens to SDK processing and validation helpers.
 4. Validate builds and unit tests in the `app` workspace.
+
+</details>
+
+## 11. In-SDK lightweight demo
+
+<details>
+<summary><strong>Create embedded demo app</strong></summary>
+
+1. Scaffold `demo/` under the SDK as a minimal React Native project.
+2. Use SDK APIs for MRZ → proof flow.
+3. Expose simple theming configuration.
+4. Add `demo/README.md` with build/run instructions.
+5. Add publishing guardrails: exclude `demo/` from npm and add a CI step to verify the published tarball contents.
 
 </details>


### PR DESCRIPTION
## Summary
- drop NFC references from migration checklist, prompts, and architecture docs
- remove sample app and demo sections to avoid unused fluff
- align migration rules with trimmed checklist

## Testing
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account: #0 for network)*
- `yarn types`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_689e5f799e6c832dbd5e56faa408d981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Streamlined SDK docs to focus on MRZ (and QR); removed NFC-related content.
  * Updated architecture and migration checklists/prompts to exclude NFC modules/exports.
  * Reworked processing helpers to MRZ-only and clarified target locations.
  * Simplified Android flow to MRZ → proof generation.
  * Removed sections on NFC scanning adapters/lifecycle, demos, and partner feedback.
  * Renumbered and repositioned SDK integration guidance with a migration strategy block.
* Bug Fixes
  * No changes to public API or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->