### PR TITLE
refactor: call removeListener on unsubscribe

### DIFF
--- a/packages/mobile-sdk-alpha/src/bridge/nativeEvents.native.ts
+++ b/packages/mobile-sdk-alpha/src/bridge/nativeEvents.native.ts
@@ -8,7 +8,20 @@ const emitters: Record<string, NativeEventEmitter> = {};
 function getEmitter(moduleName: string): NativeEventEmitter {
   if (!emitters[moduleName]) {
     const mod = (NativeModules as Record<string, any>)[moduleName];
-    emitters[moduleName] = new NativeEventEmitter(mod);
+    const hasExpectedShape =
+      !!mod && typeof (mod as any).addListener === 'function' && typeof (mod as any).removeListeners === 'function';
+    if (!hasExpectedShape) {
+      if (typeof __DEV__ !== 'undefined' && __DEV__) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[nativeEvents] Native module '${moduleName}' is missing or does not implement addListener/removeListeners; ` +
+            'falling back to a shared emitter. Events may not fire on iOS.',
+        );
+      }
+      emitters[moduleName] = new NativeEventEmitter();
+    } else {
+      emitters[moduleName] = new NativeEventEmitter(mod);
+    }
   }
   return emitters[moduleName];
 }

--- a/packages/mobile-sdk-alpha/src/bridge/nativeEvents.ts
+++ b/packages/mobile-sdk-alpha/src/bridge/nativeEvents.ts
@@ -1,11 +1,13 @@
 import type { Unsubscribe } from '../types/public';
 
-export type EventHandler = (...args: any[]) => void;
+export type EventHandler = (...args: unknown[]) => void;
 
 export interface NativeEventBridge {
   addListener(moduleName: string, eventName: string, handler: EventHandler): Unsubscribe;
   removeListener(moduleName: string, eventName: string, handler: EventHandler): void;
 }
 
-export const addListener: NativeEventBridge['addListener'] = () => () => {};
+export const addListener: NativeEventBridge['addListener'] = (moduleName, eventName, handler) => () =>
+  removeListener(moduleName, eventName, handler);
+
 export const removeListener: NativeEventBridge['removeListener'] = () => {};

--- a/packages/mobile-sdk-alpha/tests/bridge/nativeEvents.test.ts
+++ b/packages/mobile-sdk-alpha/tests/bridge/nativeEvents.test.ts
@@ -7,23 +7,26 @@ describe('nativeEvents bridge (stub)', () => {
     const handler = () => {};
     const unsub = addListener('TestModule', 'test', handler);
     expect(typeof unsub).toBe('function');
-    unsub();
+    expect(() => unsub()).not.toThrow();
     expect(() => removeListener('TestModule', 'test', handler)).not.toThrow();
   });
 });
 
 describe('nativeEvents bridge (react-native)', () => {
   it('delegates to NativeEventEmitter', async () => {
-    const addListenerMock = vi.fn(() => ({ remove: vi.fn() }));
+    const removeSubMock = vi.fn();
+    const addListenerMock = vi.fn(() => ({ remove: removeSubMock }));
     const removeListenerMock = vi.fn();
 
     vi.doMock('react-native', () => ({
-      NativeModules: { TestModule: {} },
+      NativeModules: { TestModule: { addListener: vi.fn(), removeListeners: vi.fn() } },
       NativeEventEmitter: vi.fn(() => ({
         addListener: addListenerMock,
         removeListener: removeListenerMock,
       })),
     }));
+
+    vi.resetModules();
 
     const rn = await import('../../src/bridge/nativeEvents.native');
 
@@ -35,5 +38,31 @@ describe('nativeEvents bridge (react-native)', () => {
     expect(removeListenerMock).toHaveBeenCalledWith('event', handler);
 
     unsub();
+    expect(removeSubMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches emitter per module', async () => {
+    const addListenerMock = vi.fn(() => ({ remove: vi.fn() }));
+    const NativeEventEmitterMock = vi.fn(() => ({
+      addListener: addListenerMock,
+      removeListener: vi.fn(),
+    }));
+
+    vi.doMock('react-native', () => ({
+      NativeModules: { TestModule: { addListener: vi.fn(), removeListeners: vi.fn() } },
+      NativeEventEmitter: NativeEventEmitterMock,
+    }));
+
+    vi.resetModules();
+
+    const rn = await import('../../src/bridge/nativeEvents.native');
+
+    const handler = () => {};
+    const unsub1 = rn.addListener('TestModule', 'event', handler);
+    const unsub2 = rn.addListener('TestModule', 'event', handler);
+    expect(NativeEventEmitterMock).toHaveBeenCalledTimes(1);
+
+    unsub1();
+    unsub2();
   });
 });


### PR DESCRIPTION
## Summary
- ensure native event bridge unsubscribe delegates to removeListener
- validate native modules before creating emitters and warn/fallback when absent
- tighten event handler typing and cover React Native unsubscription

## Testing
- `yarn workspace @selfxyz/mobile-sdk-alpha nice`
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account in Hardhat config)*
- `yarn types`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_689e6f8aa638832d89a02c109ff0bd7b