### PR TITLE
docs: expand React Native component migration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,8 +12,6 @@ reviews:
   high_level_summary: true
   poem: true
   review_status: true
-  review_status: true
-  auto_review:
   auto_review:
     enabled: true
     drafts: false

--- a/packages/mobile-sdk-alpha/docs/MIGRATION_CHECKLIST.md
+++ b/packages/mobile-sdk-alpha/docs/MIGRATION_CHECKLIST.md
@@ -53,18 +53,30 @@
 - Enforce CDN allowlist and Content-Length checks.
 - Stream hashing to avoid buffering large files.
 
-## 9. Sample applications
+## 9. React Native providers and hooks
+
+- Decouple context providers and hooks from adapter implementations.
+- Ensure providers accept adapter instances via props to avoid tight coupling.
+- Map provider boundaries to existing architecture tasks for crypto, sessions, attestation, protocol sync, and artifact management.
+
+## 10. Batteries-included components
+
+- Ship minimal components (e.g., scanners, buttons) that compose existing hooks and providers.
+- Expose configuration props for custom adapters while preserving sensible defaults.
+- Cross-reference component usage with architecture guidelines and adapter tasks.
+
+## 11. Sample applications
 
 - React Native and web demos showcasing core flows.
 - iOS `OpenPassport` URL scheme.
 
-## 10. Integrate SDK into `/app`
+## 12. Integrate SDK into `/app`
 
 - Consume `@selfxyz/mobile-sdk-alpha` inside the `app` workspace.
 - Replace MRZ modules with SDK adapters and wire processing helpers.
 - Validate builds and unit tests.
 
-## 11. In-SDK lightweight demo
+## 13. In-SDK lightweight demo
 
 - Embedded React Native demo inside the SDK with theming hooks.
 - Provide build and run instructions.

--- a/packages/mobile-sdk-alpha/docs/MIGRATION_PROMPTS.md
+++ b/packages/mobile-sdk-alpha/docs/MIGRATION_PROMPTS.md
@@ -214,7 +214,46 @@ yarn build
 
 </details>
 
-## 9. Sample applications
+## 9. React Native providers and hooks
+
+<details>
+<summary><strong>Decouple providers from adapters</strong></summary>
+
+1. Extract context providers for crypto, session, attestation, protocol sync, and artifact management.
+2. Accept adapter instances via props to enable swapping implementations.
+3. Export companion hooks (e.g., `useCrypto`) that consume these contexts.
+
+</details>
+
+<details>
+<summary><strong>Validate provider boundaries</strong></summary>
+
+1. Compare each provider's API with architecture guidelines.
+2. Ensure providers expose only adapter-defined methods.
+3. Document interactions with related migration tasks for future audits.
+
+</details>
+
+## 10. Batteries-included components
+
+<details>
+<summary><strong>Create starter components</strong></summary>
+
+1. Build minimal components such as `PassportScanner` or `ProofButton` using the decoupled hooks.
+2. Expose configuration props to inject custom adapters or callbacks.
+3. Provide basic styling and theming hooks to guide consumers.
+
+</details>
+
+<details>
+<summary><strong>Cross-reference architecture tasks</strong></summary>
+
+1. Link component responsibilities to the corresponding adapter and architecture tasks.
+2. Add notes for open questions or follow-ups in `MIGRATION_PROMPTS.md` for future iterations.
+
+</details>
+
+## 11. Sample applications
 
 <details>
 <summary><strong>Add React Native sample</strong></summary>
@@ -244,7 +283,7 @@ yarn build
 
 </details>
 
-## 10. Integrate SDK into `/app`
+## 12. Integrate SDK into `/app`
 
 <details>
 <summary><strong>Integrate SDK in /app</strong></summary>
@@ -256,7 +295,7 @@ yarn build
 
 </details>
 
-## 11. In-SDK lightweight demo
+## 13. In-SDK lightweight demo
 
 <details>
 <summary><strong>Create embedded demo app</strong></summary>


### PR DESCRIPTION
## Summary
- add dedicated checklist steps for React Native providers/hooks and batteries-included components before sample apps
- flesh out matching migration prompts for provider decoupling and starter components

## Testing
- `yarn workspaces foreach --since=HEAD -p -v --topological-dev run nice`
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account for network)*
- `yarn types`
- `yarn workspace @selfxyz/mobile-sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_689e8b02e6c8832da0e42fe2159201e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Reorganized Migration Checklist with new sections on React Native providers/hooks and batteries‑included components; renumbered affected sections.
  - Expanded Migration Prompts to introduce a decoupled provider pattern, validation of provider boundaries, starter components, and cross‑references to architecture tasks.
  - Updated sample application guidance (React Native and web) and platform scheme configuration; moved Integrate SDK into /app and In‑SDK demo sections accordingly.

- Chores
  - Cleaned up review configuration by removing duplicate entries and a stray header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->