### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -19,7 +19,7 @@ jobs:
   lint:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Run linter
@@ -32,7 +32,7 @@ jobs:
   test:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
 
@@ -45,7 +45,7 @@ jobs:
   build:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -53,7 +53,7 @@ jobs:
           # some cocoapods won't compile with xcode 16.3
           xcode-version: "16.2"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Mobile Dependencies
         uses: ./.github/actions/mobile-setup
         with:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install cpp dependencies
         run: |

--- a/.github/workflows/circuits.yml
+++ b/.github/workflows/circuits.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Circom installation from https://github.com/erhant/circomkit/blob/main/.github/workflows/tests.yml
       - name: Install dependencies

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Build Common Dependencies

--- a/.github/workflows/general-checks.yml
+++ b/.github/workflows/general-checks.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Run linter
@@ -15,7 +15,7 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Build dependencies
@@ -24,7 +24,7 @@ jobs:
   test-common:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
       - name: Build dependencies

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -54,7 +54,7 @@ jobs:
           # some cocoapods won't compile with xcode 16.3
           xcode-version: "16.2"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Mobile Dependencies
         uses: ./.github/actions/mobile-setup
         with:
@@ -367,7 +367,7 @@ jobs:
     if: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Mobile Dependencies
         uses: ./.github/actions/mobile-setup
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
       qrcode_changed: ${{ steps.check-version.outputs.qrcode_changed }}
       common_changed: ${{ steps.check-version.outputs.common_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -47,7 +47,7 @@ jobs:
     if: needs.detect-changes.outputs.core_changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -77,7 +77,7 @@ jobs:
     if: needs.detect-changes.outputs.qrcode_changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -107,13 +107,13 @@ jobs:
     if: needs.detect-changes.outputs.common_changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
 


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.
Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0