### PR TITLE
chore: fix ios e2e workflow; upgrade to Xcode 16.4

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -126,6 +126,19 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
+      - name: Configure Xcode path
+        run: |
+          echo "🔧 Configuring Xcode path to fix iOS SDK issues..."
+          # Fix for macOS 15 runner iOS SDK issues
+          # See: https://github.com/actions/runner-images/issues/12758
+          sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+          echo "✅ Xcode path configured"
+
+          # Verify Xcode setup
+          echo "Xcode version:"
+          xcodebuild -version
+          echo "Xcode path:"
+          xcode-select -p
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -5,7 +5,7 @@ env:
   RUBY_VERSION: 3.2
   JAVA_VERSION: 17
   ANDROID_NDK_VERSION: 27.0.11718014
-  XCODE_VERSION: 16.2
+  XCODE_VERSION: 16.4
   # Path configuration
   WORKSPACE: ${{ github.workspace }}
   APP_PATH: ${{ github.workspace }}/app

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -5,6 +5,7 @@ env:
   RUBY_VERSION: 3.2
   JAVA_VERSION: 17
   ANDROID_NDK_VERSION: 27.0.11718014
+  XCODE_VERSION: 16.2
   # Path configuration
   WORKSPACE: ${{ github.workspace }}
   APP_PATH: ${{ github.workspace }}/app
@@ -124,7 +125,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -125,6 +125,13 @@ jobs:
         with:
           xcode-version: "16.2"
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: false
+          working-directory: ./app
+
       - uses: actions/checkout@v4
       - name: Cache Node Modules
         uses: actions/cache@v4
@@ -183,10 +190,15 @@ jobs:
       - name: Build Dependencies
         run: yarn build:deps
         working-directory: ./app
+      - name: Install Ruby Dependencies
+        run: |
+          echo "Installing Ruby dependencies..."
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs 4 --retry 3
+        working-directory: ./app
       - name: Install iOS Dependencies
         run: |
           echo "Installing iOS dependencies..."
-          cd app/ios
 
           # Clean Pods directory if it's corrupted or empty
           if [ ! -d "Pods" ] || [ -z "$(ls -A Pods 2>/dev/null)" ]; then
@@ -214,10 +226,10 @@ jobs:
           fi
 
           echo "✅ iOS dependencies installed successfully"
+        working-directory: ./app/ios
       - name: Verify iOS Workspace
         run: |
           echo "Verifying iOS workspace setup..."
-          cd app/ios
 
           if [ ! -f "OpenPassport.xcworkspace/contents.xcworkspacedata" ]; then
             echo "❌ OpenPassport.xcworkspace is missing or corrupted"
@@ -230,6 +242,7 @@ jobs:
           fi
 
           echo "✅ iOS workspace is properly configured"
+        working-directory: ./app/ios
       - name: Build iOS
         run: yarn ios
         working-directory: ./app

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -4,6 +4,7 @@ env:
   # Node version is read from .nvmrc during workflow execution
   RUBY_VERSION: 3.2
   JAVA_VERSION: 17
+  ANDROID_NDK_VERSION: 27.0.11718014
   # Path configuration
   WORKSPACE: ${{ github.workspace }}
   APP_PATH: ${{ github.workspace }}/app
@@ -185,6 +186,22 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/gradle-wrapper.properties', 'app/android/**/gradle-wrapper.jar') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Setup Java environment
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ env.JAVA_VERSION }}
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          accept-android-sdk-licenses: true
+      - name: Cache NDK
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.ANDROID_HOME }}/ndk/${{ env.ANDROID_NDK_VERSION }}
+          key: ${{ runner.os }}-ndk-${{ env.ANDROID_NDK_VERSION }}
+      - name: Install NDK
+        run: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
       - name: Install Mobile Dependencies
         uses: ./.github/actions/yarn-install
       - name: Build Dependencies

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -6,6 +6,7 @@ env:
   JAVA_VERSION: 17
   ANDROID_API_LEVEL: 35
   ANDROID_NDK_VERSION: 27.0.11718014
+  XCODE_VERSION: 16.2
 
   # Cache versioning - increment these to bust caches when needed
   GH_CACHE_VERSION: v1 # Global cache version
@@ -119,7 +120,7 @@ jobs:
         if: inputs.platform != 'android'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Cache Yarn dependencies
         id: yarn-cache

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -121,6 +121,20 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
+      - name: Configure Xcode path
+        if: inputs.platform != 'android'
+        run: |
+          echo "🔧 Configuring Xcode path to fix iOS SDK issues..."
+          # Fix for macOS 15 runner iOS SDK issues
+          # See: https://github.com/actions/runner-images/issues/12758
+          sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+          echo "✅ Xcode path configured"
+
+          # Verify Xcode setup
+          echo "Xcode version:"
+          xcodebuild -version
+          echo "Xcode path:"
+          xcode-select -p
 
       - name: Cache Yarn dependencies
         id: yarn-cache

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -6,7 +6,7 @@ env:
   JAVA_VERSION: 17
   ANDROID_API_LEVEL: 35
   ANDROID_NDK_VERSION: 27.0.11718014
-  XCODE_VERSION: 16.2
+  XCODE_VERSION: 16.4
 
   # Cache versioning - increment these to bust caches when needed
   GH_CACHE_VERSION: v1 # Global cache version

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -5,6 +5,7 @@ env:
   JAVA_VERSION: 17
   ANDROID_API_LEVEL: 33
   ANDROID_NDK_VERSION: 27.0.11718014
+  XCODE_VERSION: 16.2
   # Cache versions
   GH_CACHE_VERSION: v1 # Global cache version
   GH_GEMS_CACHE_VERSION: v1 # Ruby gems cache version
@@ -211,7 +212,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          xcode-version: ${{ env.XCODE_VERSION }}
       - name: Cache Node modules
         uses: actions/cache@v4
         with:
@@ -329,11 +330,11 @@ jobs:
           if [ -z "$AVAILABLE_SIMULATOR" ]; then
             echo "❌ No available iPhone simulator found"
             echo "Creating a new iPhone SE (3rd generation) simulator..."
-            # Create a new iPhone SE (3rd generation) simulator with the latest iOS version
-            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" "iOS17.5" || {
+            # Create a new iPhone SE (3rd generation) simulator with default iOS version
+            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" || {
               echo "❌ Failed to create iPhone SE (3rd generation) simulator"
               echo "Trying to create any iPhone SE simulator..."
-              xcrun simctl create "iPhone SE" "iPhone SE" "iOS17.5" || {
+              xcrun simctl create "iPhone SE" "iPhone SE" || {
                 echo "❌ Failed to create simulator"
                 exit 1
               }
@@ -397,8 +398,8 @@ jobs:
           echo "✅ Using scheme: ${{ env.IOS_PROJECT_SCHEME }}"
 
           # Use cached derived data and enable parallel builds for faster compilation
-          # Use generic iOS Simulator destination that works with any available simulator
-          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -destination "generic/platform=iOS Simulator" -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
+          # Use any available iOS simulator version with iPhone SE
+          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -destination "platform=iOS Simulator,name=iPhone SE (3rd generation)" -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
           echo "✅ iOS build succeeded"
       - name: Install and Test on iOS
         run: |

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -330,11 +330,11 @@ jobs:
           if [ -z "$AVAILABLE_SIMULATOR" ]; then
             echo "❌ No available iPhone simulator found"
             echo "Creating a new iPhone SE (3rd generation) simulator..."
-            # Create a new iPhone SE (3rd generation) simulator with default iOS version
-            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" || {
+            # Create a new iPhone SE (3rd generation) simulator with iOS 18.2 (bundled with Xcode 16.2)
+            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" "iOS18.2" || {
               echo "❌ Failed to create iPhone SE (3rd generation) simulator"
               echo "Trying to create any iPhone SE simulator..."
-              xcrun simctl create "iPhone SE" "iPhone SE" || {
+              xcrun simctl create "iPhone SE" "iPhone SE" "iOS18.2" || {
                 echo "❌ Failed to create simulator"
                 exit 1
               }
@@ -398,8 +398,8 @@ jobs:
           echo "✅ Using scheme: ${{ env.IOS_PROJECT_SCHEME }}"
 
           # Use cached derived data and enable parallel builds for faster compilation
-          # Use any available iOS simulator version with iPhone SE
-          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -destination "platform=iOS Simulator,name=iPhone SE (3rd generation)" -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
+          # Use the simulator that was set up earlier in the workflow
+          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -destination "id=${{ env.IOS_SIMULATOR_ID }}" -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
           echo "✅ iOS build succeeded"
       - name: Install and Test on iOS
         run: |

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -213,6 +213,19 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
+      - name: Configure Xcode path
+        run: |
+          echo "🔧 Configuring Xcode path to fix iOS SDK issues..."
+          # Fix for macOS 15 runner iOS SDK issues
+          # See: https://github.com/actions/runner-images/issues/12758
+          sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+          echo "✅ Xcode path configured"
+
+          # Verify Xcode setup
+          echo "Xcode version:"
+          xcodebuild -version
+          echo "Xcode path:"
+          xcode-select -p
       - name: Cache Node modules
         uses: actions/cache@v4
         with:
@@ -260,41 +273,11 @@ jobs:
           key: ${{ runner.os }}-simulator-v1
           restore-keys: |
             ${{ runner.os }}-simulator-
-      - name: Install iOS Runtime
+      - name: Verify iOS Runtime
         run: |
-          echo "📱 Checking iOS Runtime availability..."
-          echo "Available iOS runtimes (JSON):"
-          xcrun simctl list -j runtimes || true
-
-          echo "Available iOS runtimes (human readable):"
+          echo "📱 Verifying iOS Runtime availability..."
+          echo "Available iOS runtimes:"
           xcrun simctl list runtimes | grep iOS || true
-
-          # Determine latest available iOS runtime identifier
-          if command -v jq >/dev/null 2>&1; then
-            RUNTIME_ID=$(
-              xcrun simctl list -j runtimes \
-                | jq -r '.runtimes[]
-                    | select(.platform=="iOS" and .isAvailable==true)
-                    | .identifier' \
-                | sort -V \
-                | tail -1
-            )
-          else
-            # Fallback: parse human output (less reliable)
-            RUNTIME_ID=$(
-              xcrun simctl list runtimes \
-                | awk '/iOS/ && /com.apple.CoreSimulator.SimRuntime.iOS-/ {print $NF}' \
-                | tail -1
-            )
-          fi
-          if [ -n "$RUNTIME_ID" ] && [[ "$RUNTIME_ID" == com.apple.CoreSimulator.SimRuntime.iOS-* ]]; then
-            echo "✅ Latest iOS runtime: $RUNTIME_ID"
-            echo "RUNTIME_ID=$RUNTIME_ID" >> $GITHUB_ENV
-          else
-            echo "⚠️ Could not determine an iOS runtime identifier"
-            echo "Available runtimes:"
-            xcrun simctl list runtimes
-          fi
       - name: Build dependencies (outside main flow)
         run: |
           echo "Building dependencies..."
@@ -337,47 +320,15 @@ jobs:
           if [ -z "$AVAILABLE_SIMULATOR" ]; then
             echo "❌ No available iPhone simulator found"
             echo "Creating a new iPhone SE (3rd generation) simulator..."
-
-            # Use the runtime ID that was determined in the previous step
-            RUNTIME_ID="${RUNTIME_ID:-}"
-            if [ -z "$RUNTIME_ID" ]; then
-              echo "Determining latest available iOS runtime..."
-              if command -v jq >/dev/null 2>&1; then
-                RUNTIME_ID=$(
-                  xcrun simctl list -j runtimes \
-                    | jq -r '.runtimes[]
-                        | select(.platform=="iOS" and .isAvailable==true)
-                        | .identifier' \
-                    | sort -V \
-                    | tail -1
-                )
-              else
-                # Fallback: parse human output
-                RUNTIME_ID=$(
-                  xcrun simctl list runtimes \
-                    | awk '/iOS/ && /com.apple.CoreSimulator.SimRuntime.iOS-/ {print $NF}' \
-                    | tail -1
-                )
-              fi
-            fi
-
-            if [ -n "$RUNTIME_ID" ] && [[ "$RUNTIME_ID" == com.apple.CoreSimulator.SimRuntime.iOS-* ]]; then
-              echo "✅ Using iOS runtime: $RUNTIME_ID"
-              # Create a new iPhone SE (3rd generation) simulator with the latest available iOS runtime
-              xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" "$RUNTIME_ID" || {
-                echo "❌ Failed to create iPhone SE (3rd generation) simulator"
-                echo "Trying to create any iPhone SE simulator..."
-                xcrun simctl create "iPhone SE" "iPhone SE" "$RUNTIME_ID" || {
-                  echo "❌ Failed to create simulator"
-                  exit 1
-                }
+            # Create a new iPhone SE (3rd generation) simulator
+            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" || {
+              echo "❌ Failed to create iPhone SE (3rd generation) simulator"
+              echo "Trying to create any iPhone SE simulator..."
+              xcrun simctl create "iPhone SE" "iPhone SE" || {
+                echo "❌ Failed to create simulator"
+                exit 1
               }
-            else
-              echo "❌ Could not determine iOS runtime identifier"
-              echo "Available runtimes:"
-              xcrun simctl list runtimes
-              exit 1
-            fi
+            }
             AVAILABLE_SIMULATOR=$(xcrun simctl list devices | grep "iPhone SE" | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
           fi
 

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -397,7 +397,8 @@ jobs:
           echo "✅ Using scheme: ${{ env.IOS_PROJECT_SCHEME }}"
 
           # Use cached derived data and enable parallel builds for faster compilation
-          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -sdk iphonesimulator -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
+          # Use the same iPhone SE simulator that gets set up earlier in the workflow
+          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -destination "platform=iOS Simulator,name=iPhone SE (3rd generation)" -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
           echo "✅ iOS build succeeded"
       - name: Install and Test on iOS
         run: |

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -186,7 +186,7 @@ jobs:
         uses: ./.github/actions/cache-yarn
         with:
           cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.NODE_VERSION_SANITIZED }}
-      - run: yarn workspaces focus @selfxyz/mobile-app --production
+      - run: yarn workspaces focus @selfxyz/mobile-app
       - name: Cache Maestro
         id: cache-maestro
         uses: actions/cache@v4

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -186,7 +186,7 @@ jobs:
         uses: ./.github/actions/cache-yarn
         with:
           cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.NODE_VERSION_SANITIZED }}
-      - run: yarn workspaces focus @selfxyz/mobile-app --mode=skip-build --silent
+      - run: yarn workspaces focus @selfxyz/mobile-app --production
       - name: Cache Maestro
         id: cache-maestro
         uses: actions/cache@v4

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -163,6 +163,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-ios-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      # iOS project configuration - using same environment variables as mobile-deploy.yml for consistency
+      IOS_PROJECT_NAME: "Self"
+      IOS_PROJECT_SCHEME: "Self"
     steps:
       - uses: actions/checkout@v4
       - name: Read and sanitize Node.js version
@@ -233,7 +237,7 @@ jobs:
             app/ios/build
             ~/Library/Developer/Xcode/DerivedData
             ~/Library/Caches/com.apple.dt.Xcode
-          key: ${{ runner.os }}-xcode-${{ hashFiles('app/ios/Podfile.lock') }}-${{ hashFiles('app/ios/OpenPassport.xcworkspace/contents.xcworkspacedata') }}
+          key: ${{ runner.os }}-xcode-${{ hashFiles('app/ios/Podfile.lock') }}-${{ hashFiles('app/ios/${{ env.IOS_PROJECT_NAME }}.xcworkspace/contents.xcworkspacedata') }}
           restore-keys: |
             ${{ runner.os }}-xcode-${{ hashFiles('app/ios/Podfile.lock') }}-
             ${{ runner.os }}-xcode-
@@ -364,8 +368,33 @@ jobs:
       - name: Build iOS App
         run: |
           echo "Building iOS app..."
+          echo "Project: ${{ env.IOS_PROJECT_NAME }}, Scheme: ${{ env.IOS_PROJECT_SCHEME }}"
+
+          # Verify workspace exists before building
+          WORKSPACE_PATH="app/ios/${{ env.IOS_PROJECT_NAME }}.xcworkspace"
+          if [ ! -d "$WORKSPACE_PATH" ]; then
+            echo "❌ Workspace not found at: $WORKSPACE_PATH"
+            echo "Available workspaces:"
+            find app/ios -name "*.xcworkspace" -type d
+            exit 1
+          fi
+
+          # Verify scheme exists by listing available schemes
+          echo "Verifying scheme availability..."
+          AVAILABLE_SCHEMES=$(xcodebuild -list -workspace "$WORKSPACE_PATH" 2>/dev/null | grep -A 100 "Schemes:" | grep -v "Schemes:" | head -10 | xargs)
+          echo "Available schemes: $AVAILABLE_SCHEMES"
+
+          if [[ ! "$AVAILABLE_SCHEMES" =~ ${{ env.IOS_PROJECT_SCHEME }} ]]; then
+            echo "❌ Scheme '${{ env.IOS_PROJECT_SCHEME }}' not found"
+            echo "Available schemes: $AVAILABLE_SCHEMES"
+            exit 1
+          fi
+
+          echo "✅ Using workspace: $WORKSPACE_PATH"
+          echo "✅ Using scheme: ${{ env.IOS_PROJECT_SCHEME }}"
+
           # Use cached derived data and enable parallel builds for faster compilation
-          xcodebuild -workspace app/ios/OpenPassport.xcworkspace -scheme OpenPassport -configuration Release -sdk iphonesimulator -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
+          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -sdk iphonesimulator -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
           echo "✅ iOS build succeeded"
       - name: Install and Test on iOS
         run: |

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -397,8 +397,8 @@ jobs:
           echo "✅ Using scheme: ${{ env.IOS_PROJECT_SCHEME }}"
 
           # Use cached derived data and enable parallel builds for faster compilation
-          # Use the same iPhone SE simulator that gets set up earlier in the workflow
-          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -destination "platform=iOS Simulator,name=iPhone SE (3rd generation)" -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
+          # Use generic iOS Simulator destination that works with any available simulator
+          xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Release -destination "generic/platform=iOS Simulator" -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet || { echo "❌ iOS build failed"; exit 1; }
           echo "✅ iOS build succeeded"
       - name: Install and Test on iOS
         run: |

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -265,6 +265,10 @@ jobs:
           echo "📱 Checking iOS Runtime availability..."
           echo "Available iOS runtimes (JSON):"
           xcrun simctl list -j runtimes || true
+
+          echo "Available iOS runtimes (human readable):"
+          xcrun simctl list runtimes | grep iOS || true
+
           # Determine latest available iOS runtime identifier
           if command -v jq >/dev/null 2>&1; then
             RUNTIME_ID=$(
@@ -285,8 +289,11 @@ jobs:
           fi
           if [ -n "$RUNTIME_ID" ] && [[ "$RUNTIME_ID" == com.apple.CoreSimulator.SimRuntime.iOS-* ]]; then
             echo "✅ Latest iOS runtime: $RUNTIME_ID"
+            echo "RUNTIME_ID=$RUNTIME_ID" >> $GITHUB_ENV
           else
             echo "⚠️ Could not determine an iOS runtime identifier"
+            echo "Available runtimes:"
+            xcrun simctl list runtimes
           fi
       - name: Build dependencies (outside main flow)
         run: |
@@ -330,15 +337,47 @@ jobs:
           if [ -z "$AVAILABLE_SIMULATOR" ]; then
             echo "❌ No available iPhone simulator found"
             echo "Creating a new iPhone SE (3rd generation) simulator..."
-            # Create a new iPhone SE (3rd generation) simulator with iOS 18.2 (bundled with Xcode 16.2)
-            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" "iOS18.2" || {
-              echo "❌ Failed to create iPhone SE (3rd generation) simulator"
-              echo "Trying to create any iPhone SE simulator..."
-              xcrun simctl create "iPhone SE" "iPhone SE" "iOS18.2" || {
-                echo "❌ Failed to create simulator"
-                exit 1
+
+            # Use the runtime ID that was determined in the previous step
+            RUNTIME_ID="${RUNTIME_ID:-}"
+            if [ -z "$RUNTIME_ID" ]; then
+              echo "Determining latest available iOS runtime..."
+              if command -v jq >/dev/null 2>&1; then
+                RUNTIME_ID=$(
+                  xcrun simctl list -j runtimes \
+                    | jq -r '.runtimes[]
+                        | select(.platform=="iOS" and .isAvailable==true)
+                        | .identifier' \
+                    | sort -V \
+                    | tail -1
+                )
+              else
+                # Fallback: parse human output
+                RUNTIME_ID=$(
+                  xcrun simctl list runtimes \
+                    | awk '/iOS/ && /com.apple.CoreSimulator.SimRuntime.iOS-/ {print $NF}' \
+                    | tail -1
+                )
+              fi
+            fi
+
+            if [ -n "$RUNTIME_ID" ] && [[ "$RUNTIME_ID" == com.apple.CoreSimulator.SimRuntime.iOS-* ]]; then
+              echo "✅ Using iOS runtime: $RUNTIME_ID"
+              # Create a new iPhone SE (3rd generation) simulator with the latest available iOS runtime
+              xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" "$RUNTIME_ID" || {
+                echo "❌ Failed to create iPhone SE (3rd generation) simulator"
+                echo "Trying to create any iPhone SE simulator..."
+                xcrun simctl create "iPhone SE" "iPhone SE" "$RUNTIME_ID" || {
+                  echo "❌ Failed to create simulator"
+                  exit 1
+                }
               }
-            }
+            else
+              echo "❌ Could not determine iOS runtime identifier"
+              echo "Available runtimes:"
+              xcrun simctl list runtimes
+              exit 1
+            fi
             AVAILABLE_SIMULATOR=$(xcrun simctl list devices | grep "iPhone SE" | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
           fi
 

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -164,9 +164,11 @@ jobs:
       group: ${{ github.workflow }}-ios-${{ github.ref }}
       cancel-in-progress: true
     env:
-      # iOS project configuration - using same environment variables as mobile-deploy.yml for consistency
+      # iOS project configuration - hardcoded for E2E testing stability
+      # Note: During migration, project name is "Self" but scheme is still "OpenPassport"
+      # mobile-deploy.yml uses secrets for production deployment
       IOS_PROJECT_NAME: "Self"
-      IOS_PROJECT_SCHEME: "Self"
+      IOS_PROJECT_SCHEME: "OpenPassport"
     steps:
       - uses: actions/checkout@v4
       - name: Read and sanitize Node.js version

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -383,12 +383,13 @@ jobs:
 
           # Verify scheme exists by listing available schemes
           echo "Verifying scheme availability..."
-          AVAILABLE_SCHEMES=$(xcodebuild -list -workspace "$WORKSPACE_PATH" 2>/dev/null | grep -A 100 "Schemes:" | grep -v "Schemes:" | head -10 | xargs)
-          echo "Available schemes: $AVAILABLE_SCHEMES"
+          AVAILABLE_SCHEMES=$(xcodebuild -list -workspace "$WORKSPACE_PATH" 2>/dev/null | grep -A 200 "Schemes:" | grep -v "Schemes:" | xargs)
+          echo "Available schemes (first 20): $(echo $AVAILABLE_SCHEMES | cut -d' ' -f1-20)..."
 
           if [[ ! "$AVAILABLE_SCHEMES" =~ ${{ env.IOS_PROJECT_SCHEME }} ]]; then
             echo "❌ Scheme '${{ env.IOS_PROJECT_SCHEME }}' not found"
-            echo "Available schemes: $AVAILABLE_SCHEMES"
+            echo "Full scheme list:"
+            xcodebuild -list -workspace "$WORKSPACE_PATH" 2>/dev/null | grep -A 200 "Schemes:" | grep -v "Schemes:" | head -50
             exit 1
           fi
 

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -7,6 +7,7 @@ env:
   ANDROID_NDK_VERSION: 27.0.11718014
   # Cache versions
   GH_CACHE_VERSION: v1 # Global cache version
+  GH_GEMS_CACHE_VERSION: v1 # Ruby gems cache version
   # Performance optimizations
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4 -Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.caching=true
   CI: true
@@ -183,10 +184,13 @@ jobs:
       - run: corepack enable
       - run: corepack prepare yarn@4.6.0 --activate
       - name: Cache Yarn dependencies
-        uses: ./.github/actions/cache-yarn
+        uses: actions/cache@v4
         with:
-          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.NODE_VERSION_SANITIZED }}
-      - run: yarn workspaces focus @selfxyz/mobile-app
+          path: .yarn/cache
+          key: ${{ runner.os }}-node-${{ env.NODE_VERSION_SANITIZED }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION_SANITIZED }}-yarn-
+      - run: yarn install --immutable --silent
       - name: Cache Maestro
         id: cache-maestro
         uses: actions/cache@v4
@@ -201,7 +205,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          xcode-version: "16.4"
       - name: Cache Node modules
         uses: actions/cache@v4
         with:
@@ -209,6 +213,12 @@ jobs:
           key: ${{ runner.os }}-node-${{ env.NODE_VERSION_SANITIZED }}-${{ hashFiles('app/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE_VERSION_SANITIZED }}-
+      - name: Cache Ruby gems
+        uses: ./.github/actions/cache-bundler
+        with:
+          path: app/vendor/bundle
+          lock-file: app/Gemfile.lock
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-ruby${{ env.RUBY_VERSION }}
       - name: Cache Pods
         uses: ./.github/actions/cache-pods
         with:
@@ -216,6 +226,33 @@ jobs:
             app/ios/Pods
             ~/Library/Caches/CocoaPods
           lock-file: app/ios/Podfile.lock
+      - name: Cache Xcode build
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/ios/build
+            ~/Library/Developer/Xcode/DerivedData
+            ~/Library/Caches/com.apple.dt.Xcode
+          key: ${{ runner.os }}-xcode-${{ hashFiles('app/ios/Podfile.lock') }}-${{ hashFiles('app/ios/OpenPassport.xcworkspace/contents.xcworkspacedata') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ hashFiles('app/ios/Podfile.lock') }}-
+            ${{ runner.os }}-xcode-
+      - name: Cache Xcode Index
+        uses: actions/cache@v4
+        with:
+          path: app/ios/build/Index.noindex
+          key: ${{ runner.os }}-xcode-index-${{ hashFiles('app/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-index-
+      - name: Cache iOS Simulator
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/CoreSimulator/Devices
+            ~/Library/Developer/Xcode/iOS DeviceSupport
+          key: ${{ runner.os }}-simulator-v1
+          restore-keys: |
+            ${{ runner.os }}-simulator-
       - name: Install iOS Runtime
         run: |
           echo "📱 Checking iOS Runtime availability..."

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -7,7 +7,6 @@ env:
   ANDROID_NDK_VERSION: 27.0.11718014
   # Cache versions
   GH_CACHE_VERSION: v1 # Global cache version
-  GH_GEMS_CACHE_VERSION: v1 # Ruby gems cache version
   # Performance optimizations
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4 -Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.caching=true
   CI: true
@@ -184,13 +183,10 @@ jobs:
       - run: corepack enable
       - run: corepack prepare yarn@4.6.0 --activate
       - name: Cache Yarn dependencies
-        uses: actions/cache@v4
+        uses: ./.github/actions/cache-yarn
         with:
-          path: .yarn/cache
-          key: ${{ runner.os }}-node-${{ env.NODE_VERSION_SANITIZED }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE_VERSION_SANITIZED }}-yarn-
-      - run: yarn install --immutable --silent
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.NODE_VERSION_SANITIZED }}
+      - run: yarn workspaces focus @selfxyz/mobile-app --mode=skip-build --silent
       - name: Cache Maestro
         id: cache-maestro
         uses: actions/cache@v4
@@ -202,10 +198,6 @@ jobs:
         run: curl -Ls "https://get.maestro.mobile.dev" | bash
       - name: Add Maestro to path
         run: echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "16.4"
       - name: Cache Node modules
         uses: actions/cache@v4
         with:
@@ -213,12 +205,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ env.NODE_VERSION_SANITIZED }}-${{ hashFiles('app/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE_VERSION_SANITIZED }}-
-      - name: Cache Ruby gems
-        uses: ./.github/actions/cache-bundler
-        with:
-          path: app/vendor/bundle
-          lock-file: app/Gemfile.lock
-          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.GH_GEMS_CACHE_VERSION }}-ruby${{ env.RUBY_VERSION }}
       - name: Cache Pods
         uses: ./.github/actions/cache-pods
         with:
@@ -226,33 +212,6 @@ jobs:
             app/ios/Pods
             ~/Library/Caches/CocoaPods
           lock-file: app/ios/Podfile.lock
-      - name: Cache Xcode build
-        uses: actions/cache@v4
-        with:
-          path: |
-            app/ios/build
-            ~/Library/Developer/Xcode/DerivedData
-            ~/Library/Caches/com.apple.dt.Xcode
-          key: ${{ runner.os }}-xcode-${{ hashFiles('app/ios/Podfile.lock') }}-${{ hashFiles('app/ios/OpenPassport.xcworkspace/contents.xcworkspacedata') }}
-          restore-keys: |
-            ${{ runner.os }}-xcode-${{ hashFiles('app/ios/Podfile.lock') }}-
-            ${{ runner.os }}-xcode-
-      - name: Cache Xcode Index
-        uses: actions/cache@v4
-        with:
-          path: app/ios/build/Index.noindex
-          key: ${{ runner.os }}-xcode-index-${{ hashFiles('app/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-xcode-index-
-      - name: Cache iOS Simulator
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/Library/Developer/CoreSimulator/Devices
-            ~/Library/Developer/Xcode/iOS DeviceSupport
-          key: ${{ runner.os }}-simulator-v1
-          restore-keys: |
-            ${{ runner.os }}-simulator-
       - name: Install iOS Runtime
         run: |
           echo "📱 Checking iOS Runtime availability..."

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.4"
+          xcode-version: "16.2"
       - name: Cache Node modules
         uses: actions/cache@v4
         with:

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -5,7 +5,7 @@ env:
   JAVA_VERSION: 17
   ANDROID_API_LEVEL: 33
   ANDROID_NDK_VERSION: 27.0.11718014
-  XCODE_VERSION: 16.2
+  XCODE_VERSION: 16.4
   # Cache versions
   GH_CACHE_VERSION: v1 # Global cache version
   GH_GEMS_CACHE_VERSION: v1 # Ruby gems cache version

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -277,7 +277,7 @@ jobs:
         run: |
           echo "📱 Verifying iOS Runtime availability..."
           echo "Available iOS runtimes:"
-          xcrun simctl list runtimes | grep iOS || true
+          xcrun simctl list runtimes | grep iOS
       - name: Build dependencies (outside main flow)
         run: |
           echo "Building dependencies..."

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -202,7 +202,20 @@ platform :ios do
 
     target_platform = options[:prod_release] ? "App Store" : "TestFlight"
     should_upload = Fastlane::Helpers.should_upload_app(target_platform)
-    workspace_path = File.expand_path("../ios/#{PROJECT_SCHEME}.xcworkspace", Dir.pwd)
+
+    # Robust workspace path resolution
+    scheme_workspace_path = File.expand_path("../ios/#{PROJECT_SCHEME}.xcworkspace", Dir.pwd)
+    project_workspace_path = File.expand_path("../ios/#{PROJECT_NAME}.xcworkspace", Dir.pwd)
+
+    workspace_path = if File.exist?(scheme_workspace_path)
+        scheme_workspace_path
+      elsif File.exist?(project_workspace_path)
+        project_workspace_path
+      else
+        raise "No workspace found for scheme '#{PROJECT_SCHEME}' or project '#{PROJECT_NAME}'. " \
+              "Checked paths: #{scheme_workspace_path}, #{project_workspace_path}"
+      end
+
     ios_signing_certificate_name = "iPhone Distribution: #{ENV["IOS_TEAM_NAME"]} (#{ENV["IOS_TEAM_ID"]})"
 
     Fastlane::Helpers.verify_env_vars(required_env_vars)

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -202,7 +202,7 @@ platform :ios do
 
     target_platform = options[:prod_release] ? "App Store" : "TestFlight"
     should_upload = Fastlane::Helpers.should_upload_app(target_platform)
-    workspace_path = File.expand_path("../ios/#{PROJECT_NAME}.xcworkspace", Dir.pwd)
+    workspace_path = File.expand_path("../ios/#{PROJECT_SCHEME}.xcworkspace", Dir.pwd)
     ios_signing_certificate_name = "iPhone Distribution: #{ENV["IOS_TEAM_NAME"]} (#{ENV["IOS_TEAM_ID"]})"
 
     Fastlane::Helpers.verify_env_vars(required_env_vars)

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -202,20 +202,7 @@ platform :ios do
 
     target_platform = options[:prod_release] ? "App Store" : "TestFlight"
     should_upload = Fastlane::Helpers.should_upload_app(target_platform)
-
-    # Robust workspace path resolution
-    scheme_workspace_path = File.expand_path("../ios/#{PROJECT_SCHEME}.xcworkspace", Dir.pwd)
-    project_workspace_path = File.expand_path("../ios/#{PROJECT_NAME}.xcworkspace", Dir.pwd)
-
-    workspace_path = if File.exist?(scheme_workspace_path)
-        scheme_workspace_path
-      elsif File.exist?(project_workspace_path)
-        project_workspace_path
-      else
-        raise "No workspace found for scheme '#{PROJECT_SCHEME}' or project '#{PROJECT_NAME}'. " \
-              "Checked paths: #{scheme_workspace_path}, #{project_workspace_path}"
-      end
-
+    workspace_path = File.expand_path("../ios/#{PROJECT_NAME}.xcworkspace", Dir.pwd)
     ios_signing_certificate_name = "iPhone Distribution: #{ENV["IOS_TEAM_NAME"]} (#{ENV["IOS_TEAM_ID"]})"
 
     Fastlane::Helpers.verify_env_vars(required_env_vars)

--- a/common/package.json
+++ b/common/package.json
@@ -362,6 +362,7 @@
   },
   "devDependencies": {
     "@types/js-sha1": "^0.6.3",
+    "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.10",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4933,6 +4933,7 @@ __metadata:
     "@openpassport/zk-kit-lean-imt": "npm:^0.0.6"
     "@openpassport/zk-kit-smt": "npm:^0.0.1"
     "@types/js-sha1": "npm:^0.6.3"
+    "@types/node": "npm:^22.0.0"
     "@types/node-forge": "npm:^1.3.10"
     "@typescript-eslint/eslint-plugin": "npm:^8.0.0"
     "@typescript-eslint/parser": "npm:^8.0.0"


### PR DESCRIPTION
Issue [seems be related to the github runner](https://github.com/actions/runner-images/issues/12758)

## Summary
- trim redundant caches and setup steps from iOS E2E workflow
- focus Yarn install on mobile app workspace

## Testing
- `yarn workspaces foreach -p -v --topological-dev --since=HEAD run nice --if-present`
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Invalid account in Hardhat config)*
- `yarn types`
- `yarn test` *(fails: exit code 37/1 in circuits/contracts)*

------
https://chatgpt.com/codex/tasks/task_b_68a2acabdf8c832db13a667f7eee6d9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized Xcode to 16.4 across CI, E2E, and deploy pipelines and added a Configure Xcode step to address macOS iOS SDK issues.
  - Added Android NDK (27.0.11718014), Java, and Ruby setup, NDK caching, and earlier Ruby dependency install in mobile CI.
  - Moved mobile dependency steps into app subdirectories and improved working-directory handling.
  - Added Node.js type definitions for development.
  - CI/E2E workflows now trigger and gate jobs based on downstream workflow results and per-project change detection.

- New Features
  - Per-project iOS support: dynamic workspace/scheme handling, workspace-aware build flow, pre-build validations, and enhanced build logs.
  - Automated iOS simulator provisioning that creates/boots simulators and exposes simulator identifiers for downstream steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->