### PR TITLE
docs: document mobile sdk APIs using JSDoc

### DIFF
--- a/packages/mobile-sdk-alpha/src/adapters/index.ts
+++ b/packages/mobile-sdk-alpha/src/adapters/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Re-exports of adapter interfaces used by the SDK.
+ * Consumers implement these to integrate with platform-specific
+ * capabilities such as networking, storage, or scanning hardware.
+ */
 export type {
   Adapters,
   ClockAdapter,

--- a/packages/mobile-sdk-alpha/src/bridge/nativeEvents.native.ts
+++ b/packages/mobile-sdk-alpha/src/bridge/nativeEvents.native.ts
@@ -5,6 +5,9 @@ import type { NativeEventBridge } from './nativeEvents';
 
 const emitters: Record<string, NativeEventEmitter> = {};
 
+/**
+ * Retrieve or create an event emitter for the specified native module.
+ */
 function getEmitter(moduleName: string): NativeEventEmitter {
   if (!emitters[moduleName]) {
     const mod = (NativeModules as Record<string, any>)[moduleName];
@@ -26,12 +29,18 @@ function getEmitter(moduleName: string): NativeEventEmitter {
   return emitters[moduleName];
 }
 
+/**
+ * Subscribe to a native module event using React Native's event emitters.
+ */
 export const addListener: NativeEventBridge['addListener'] = (moduleName, eventName, handler) => {
   const emitter = getEmitter(moduleName);
   const sub: NativeEventSubscription = emitter.addListener(eventName, handler);
   return () => sub.remove();
 };
 
+/**
+ * Remove a previously registered native module event handler.
+ */
 export const removeListener: NativeEventBridge['removeListener'] = (moduleName, eventName, handler) => {
   const emitter = emitters[moduleName];
   if (emitter) {

--- a/packages/mobile-sdk-alpha/src/bridge/nativeEvents.ts
+++ b/packages/mobile-sdk-alpha/src/bridge/nativeEvents.ts
@@ -1,13 +1,37 @@
 import type { Unsubscribe } from '../types/public';
 
+/**
+ * Generic function signature for handlers of native events.
+ */
 export type EventHandler = (...args: unknown[]) => void;
 
+/**
+ * Minimal interface for bridging native platform event emitters.
+ * Implementations may wrap React Native, Capacitor, or other layers.
+ */
 export interface NativeEventBridge {
+  /**
+   * Subscribe to a named event on a given native module.
+   *
+   * @param moduleName - Name of the native module exposing events.
+   * @param eventName - Event identifier within the module.
+   * @param handler - Callback invoked when the event fires.
+   * @returns Function that unsubscribes the listener.
+   */
   addListener(moduleName: string, eventName: string, handler: EventHandler): Unsubscribe;
+  /**
+   * Remove a previously registered event handler.
+   */
   removeListener(moduleName: string, eventName: string, handler: EventHandler): void;
 }
 
+/**
+ * Default no-op bridge for non-native environments.
+ */
 export const addListener: NativeEventBridge['addListener'] = (moduleName, eventName, handler) => () =>
   removeListener(moduleName, eventName, handler);
 
+/**
+ * Placeholder removal function used in browser builds.
+ */
 export const removeListener: NativeEventBridge['removeListener'] = () => {};

--- a/packages/mobile-sdk-alpha/src/browser.ts
+++ b/packages/mobile-sdk-alpha/src/browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser-focused entry point that only exposes APIs safe for web
+ * environments. Using this module enables better tree-shaking and avoids
+ * bundling native-specific code.
+ */
 // Browser-safe exports with explicit tree-shaking friendly imports
 
 // Types

--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -36,6 +36,14 @@ const optionalDefaults: Partial<Adapters> = {
   },
 };
 
+/**
+ * Create a {@link SelfClient} instance using provided configuration and adapter implementations.
+ *
+ * @param param0 - Object containing partial configuration and platform-specific adapters.
+ * @param param0.config - Configuration values to override {@link defaultConfig}.
+ * @param param0.adapters - Implementations of required SDK adapters.
+ * @returns Initialized client exposing document scanning, validation, and proof APIs.
+ */
 export function createSelfClient({ config, adapters }: { config: Config; adapters: Partial<Adapters> }): SelfClient {
   const cfg = mergeConfig(defaultConfig, config);
   const required: (keyof Adapters)[] = ['scanner', 'network', 'crypto'];
@@ -46,6 +54,13 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
   const _adapters = { ...optionalDefaults, ...adapters } as Adapters;
   const listeners = new Map<SDKEvent, Set<(p: any) => void>>();
 
+  /**
+   * Register a callback for a specific SDK event.
+   *
+   * @param event - Name of the event to subscribe to.
+   * @param cb - Handler invoked when the event is emitted.
+   * @returns Function that removes the listener when called.
+   */
   function on<E extends SDKEvent>(event: E, cb: (payload: SDKEventMap[E]) => void): Unsubscribe {
     const set = listeners.get(event) ?? new Set();
     set.add(cb as any);
@@ -53,6 +68,12 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
     return () => set.delete(cb as any);
   }
 
+  /**
+   * Emit an SDK event to all registered listeners.
+   *
+   * @param event - Event identifier.
+   * @param payload - Data associated with the event.
+   */
   function emit<E extends SDKEvent>(event: E, payload: SDKEventMap[E]): void {
     const set = listeners.get(event);
     if (!set) return;
@@ -65,18 +86,43 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
     }
   }
 
+  /**
+   * Scan a document using the configured {@link ScannerAdapter}.
+   *
+   * @param opts - Scan options and optional abort signal.
+   * @returns Result of the scan operation.
+   */
   async function scanDocument(opts: ScanOpts & { signal?: AbortSignal }): Promise<ScanResult> {
     return _adapters.scanner.scan(opts);
   }
 
+  /**
+   * Perform client-side validation of a previously scanned document.
+   *
+   * @param _input - Validation input produced from a scan.
+   * @returns Result of validation.
+   */
   async function validateDocument(_input: ValidationInput): Promise<ValidationResult> {
     return { ok: false, reason: 'SELF_ERR_VALIDATION_STUB' };
   }
 
+  /**
+   * Check whether a document has already been registered with the backend.
+   *
+   * @param _input - Registration query parameters.
+   * @returns Registration status information.
+   */
   async function checkRegistration(_input: RegistrationInput): Promise<RegistrationStatus> {
     return { registered: false, reason: 'SELF_REG_STATUS_STUB' };
   }
 
+  /**
+   * Generate a cryptographic proof according to the provided request.
+   *
+   * @param _req - Proof parameters describing the type and payload.
+   * @param opts - Optional controls for progress updates, timeouts and cancellation.
+   * @returns Handle that can be used to monitor and cancel the proof process.
+   */
   async function generateProof(
     _req: ProofRequest,
     opts: {

--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -1,6 +1,6 @@
 import { defaultConfig } from './config/defaults';
 import { mergeConfig } from './config/merge';
-import { notImplemented } from './errors';
+import { notImplemented, sdkError } from './errors';
 import type {
   Adapters,
   Config,
@@ -44,7 +44,13 @@ const optionalDefaults: Partial<Adapters> = {
  * @param param0.adapters - Implementations of required SDK adapters.
  * @returns Initialized client exposing document scanning, validation, and proof APIs.
  */
-export function createSelfClient({ config, adapters }: { config: Config; adapters: Partial<Adapters> }): SelfClient {
+export function createSelfClient({
+  config,
+  adapters,
+}: {
+  config: Partial<Config>;
+  adapters: Partial<Adapters>;
+}): SelfClient {
   const cfg = mergeConfig(defaultConfig, config);
   const required: (keyof Adapters)[] = ['scanner', 'network', 'crypto'];
   for (const name of required) {
@@ -134,7 +140,9 @@ export function createSelfClient({ config, adapters }: { config: Config; adapter
     if (!adapters.network) throw notImplemented('network');
     if (!adapters.crypto) throw notImplemented('crypto');
     const timeoutMs = opts.timeoutMs ?? cfg.timeouts?.proofMs ?? defaultConfig.timeouts.proofMs;
-    void _adapters.clock.sleep(timeoutMs!, opts.signal).then(() => emit('error', new Error('timeout')));
+    void _adapters.clock
+      .sleep(timeoutMs!, opts.signal)
+      .then(() => emit('error', sdkError('timeout', 'SELF_ERR_PROOF_TIMEOUT', 'proof', true)));
     return {
       id: 'stub',
       status: 'pending',

--- a/packages/mobile-sdk-alpha/src/config/defaults.ts
+++ b/packages/mobile-sdk-alpha/src/config/defaults.ts
@@ -1,5 +1,9 @@
 import type { Config } from '../types/public';
 
+/**
+ * Baseline configuration used when creating a {@link SelfClient}.
+ * Values here can be overridden by user-provided configuration.
+ */
 export const defaultConfig: Required<Config> = {
   endpoints: { api: '', teeWs: '', artifactsCdn: '' },
   timeouts: { httpMs: 30000, wsMs: 60000, scanMs: 60000, proofMs: 120000 },

--- a/packages/mobile-sdk-alpha/src/config/merge.ts
+++ b/packages/mobile-sdk-alpha/src/config/merge.ts
@@ -1,5 +1,14 @@
 import type { Config } from '../types/public';
 
+/**
+ * Merge a base configuration with override values.
+ *
+ * Nested objects such as `endpoints`, `timeouts`, `features` and `tlsPinning`
+ * are merged shallowly, giving precedence to values in the override object.
+ *
+ * @param base - Fully populated default configuration.
+ * @param override - Partial configuration supplied by the consumer.
+ */
 export function mergeConfig(base: Required<Config>, override: Config): Required<Config> {
   return {
     ...base,

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Main entry point for the mobile SDK. This module re-exports all public
+ * types and functions for use in native or cross-platform environments.
+ */
 // Types
 export type {
   Adapters,

--- a/packages/mobile-sdk-alpha/src/types/public.ts
+++ b/packages/mobile-sdk-alpha/src/types/public.ts
@@ -1,5 +1,8 @@
 export type { PassportData } from '@selfxyz/common/utils/types';
 export type { PassportValidationCallbacks } from '../validation/document';
+/**
+ * Runtime configuration options for the SDK.
+ */
 export interface Config {
   endpoints?: { api?: string; teeWs?: string; artifactsCdn?: string };
   timeouts?: {
@@ -11,14 +14,22 @@ export interface Config {
   features?: Record<string, boolean>;
   tlsPinning?: { enabled: boolean; pins?: string[] };
 }
+/**
+ * Provides cryptographic primitives used by the SDK.
+ */
 export interface CryptoAdapter {
   hash(input: Uint8Array, algo?: 'sha256'): Promise<Uint8Array>;
   sign(data: Uint8Array, keyRef: string): Promise<Uint8Array>;
 }
-
+/**
+ * Minimal wrapper around `fetch` used for HTTP requests.
+ */
 export interface HttpAdapter {
   fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 }
+/**
+ * Parsed machine-readable zone (MRZ) details from a passport.
+ */
 export interface MRZInfo {
   passportNumber: string;
   dateOfBirth: string;
@@ -31,12 +42,16 @@ export interface MRZInfo {
   documentType: string;
   validation: MRZValidation;
 }
-
+/**
+ * Abstraction over timing operations used for timeouts and delays.
+ */
 export interface ClockAdapter {
   now(): number;
   sleep(ms: number, signal?: AbortSignal): Promise<void>;
 }
-
+/**
+ * Result of validating fields within the MRZ.
+ */
 export interface MRZValidation {
   format: boolean;
   passportNumberChecksum: boolean;
@@ -45,13 +60,21 @@ export interface MRZValidation {
   compositeChecksum: boolean;
   overall: boolean;
 }
-
+/**
+ * Supported log levels for {@link LoggerAdapter}.
+ */
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+/**
+ * Progress update emitted during long-running operations.
+ */
 export interface Progress {
   step: string;
   percent?: number;
 }
+/**
+ * Collection of platform-specific adapters required by the SDK.
+ */
 export interface Adapters {
   storage: StorageAdapter;
   scanner: ScannerAdapter;
@@ -60,47 +83,75 @@ export interface Adapters {
   clock: ClockAdapter;
   logger: LoggerAdapter;
 }
-
+/**
+ * Represents a proof generation task that can be monitored or cancelled.
+ */
 export interface ProofHandle {
   id: string;
   status: 'pending' | 'completed' | 'failed';
   result: () => Promise<{ ok: boolean; reason?: string }>;
   cancel: () => void;
 }
+/**
+ * Logging interface consumed by the SDK for diagnostics.
+ */
 export interface LoggerAdapter {
   log(level: LogLevel, message: string, fields?: Record<string, unknown>): void;
 }
-
+/**
+ * Parameters for requesting a cryptographic proof.
+ */
 export interface ProofRequest {
   type: 'register' | 'dsc' | 'disclose';
   payload: unknown;
 }
+/**
+ * Networking capabilities including HTTP and WebSocket transports.
+ */
 export interface NetworkAdapter {
   http: HttpAdapter;
   ws: WsAdapter;
 }
-
+/**
+ * Input used when querying registration status for a document.
+ */
 export interface RegistrationInput {
   docId?: string;
   scan: ScanResult;
 }
-
+/**
+ * Response indicating whether a document is registered.
+ */
 export interface RegistrationStatus {
   registered: boolean;
   reason?: string;
 }
-
+/**
+ * Mapping of SDK event names to their payload types.
+ */
 export interface SDKEventMap {
   progress: Progress;
   state: string;
   error: Error;
 }
+/**
+ * Names of events emitted by {@link SelfClient}.
+ */
 export type SDKEvent = keyof SDKEventMap;
 
+/**
+ * Supported scanning modes.
+ */
 export type ScanMode = 'mrz' | 'nfc' | 'qr';
+/**
+ * Options passed to the scanning adapter.
+ */
 export interface ScanOpts {
   mode: ScanMode;
 }
+/**
+ * Result returned from a scan operation.
+ */
 export type ScanResult =
   | {
       mode: 'mrz';
@@ -113,9 +164,15 @@ export type ScanResult =
     }
   | { mode: 'nfc'; raw: unknown }
   | { mode: 'qr'; data: string };
+/**
+ * Adapter interface for document scanning implementations.
+ */
 export interface ScannerAdapter {
   scan(opts: ScanOpts & { signal?: AbortSignal }): Promise<ScanResult>;
 }
+/**
+ * Public client interface exposed to SDK consumers.
+ */
 export interface SelfClient {
   scanDocument(opts: ScanOpts & { signal?: AbortSignal }): Promise<ScanResult>;
   validateDocument(input: ValidationInput): Promise<ValidationResult>;
@@ -131,23 +188,40 @@ export interface SelfClient {
   on<E extends SDKEvent>(event: E, cb: (payload: SDKEventMap[E]) => void): Unsubscribe;
   emit<E extends SDKEvent>(event: E, payload: SDKEventMap[E]): void;
 }
+/**
+ * Function returned to remove an event listener.
+ */
 export type Unsubscribe = () => void;
+/**
+ * Simple async key-value storage used by the SDK.
+ */
 export interface StorageAdapter {
   get(key: string): Promise<string | null>;
   set(key: string, value: string): Promise<void>;
   remove(key: string): Promise<void>;
 }
+/**
+ * Input for document validation operations.
+ */
 export interface ValidationInput {
   scan: ScanResult;
 }
+/**
+ * Result of document validation.
+ */
 export interface ValidationResult {
   ok: boolean;
   reason?: string;
 }
+/**
+ * WebSocket adapter used for real-time communication.
+ */
 export interface WsAdapter {
   connect(url: string, opts?: { signal?: AbortSignal; headers?: Record<string, string> }): WsConn;
 }
-
+/**
+ * Handle representing an active WebSocket connection.
+ */
 export interface WsConn {
   send: (data: string | ArrayBufferView | ArrayBuffer) => void;
   close: () => void;

--- a/packages/mobile-sdk-alpha/src/types/public.ts
+++ b/packages/mobile-sdk-alpha/src/types/public.ts
@@ -1,5 +1,23 @@
+import type { SdkError } from '../errors';
+
 export type { PassportData } from '@selfxyz/common/utils/types';
 export type { PassportValidationCallbacks } from '../validation/document';
+
+// Platform-neutral HTTP shapes
+export type RequestLike = string | URL;
+export interface RequestInitLike {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | ArrayBuffer | ArrayBufferView | Uint8Array;
+}
+export interface HttpResponseLike {
+  status: number;
+  headers: Record<string, string>;
+  text(): Promise<string>;
+  json<T = unknown>(): Promise<T>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
 /**
  * Runtime configuration options for the SDK.
  */
@@ -25,7 +43,7 @@ export interface CryptoAdapter {
  * Minimal wrapper around `fetch` used for HTTP requests.
  */
 export interface HttpAdapter {
-  fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+  fetch(input: RequestLike, init?: RequestInitLike): Promise<HttpResponseLike>;
 }
 /**
  * Parsed machine-readable zone (MRZ) details from a passport.
@@ -132,7 +150,7 @@ export interface RegistrationStatus {
 export interface SDKEventMap {
   progress: Progress;
   state: string;
-  error: Error;
+  error: SdkError;
 }
 /**
  * Names of events emitted by {@link SelfClient}.

--- a/packages/mobile-sdk-alpha/tests/client.test.ts
+++ b/packages/mobile-sdk-alpha/tests/client.test.ts
@@ -84,7 +84,15 @@ const scanner: ScannerAdapter = {
 };
 
 const network: NetworkAdapter = {
-  http: { fetch: async () => new Response(null) },
+  http: {
+    fetch: async () => ({
+      status: 200,
+      headers: {},
+      text: async () => '',
+      json: async () => ({}),
+      arrayBuffer: async () => new ArrayBuffer(0),
+    }),
+  },
   ws: {
     connect: () => ({
       send: () => {},

--- a/packages/mobile-sdk-alpha/tests/client.test.ts
+++ b/packages/mobile-sdk-alpha/tests/client.test.ts
@@ -89,7 +89,7 @@ const network: NetworkAdapter = {
       status: 200,
       headers: {},
       text: async () => '',
-      json: async () => ({}),
+      json: async <T = unknown>() => ({}) as T,
       arrayBuffer: async () => new ArrayBuffer(0),
     }),
   },


### PR DESCRIPTION
## Summary
- add JSDoc for mobile SDK client, errors, config utilities and bridges
- document public types and entry modules for clarity

## Testing
- `yarn workspaces foreach -p -v --topological-dev --since=HEAD run nice --if-present`
- `yarn lint`
- `yarn build`
- `yarn workspace @selfxyz/contracts build` (fails: Invalid account config)
- `yarn types`
- `yarn test` (fails: workspace build errors)
- `yarn workspace @selfxyz/mobile-sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_68a47bf92098832d90948a3680a84b31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Expanded public API: added event system (on/emit), proof/registration types, MRZ info/validation, networking/crypto/logging/clock adapters, WebSocket interfaces, and cross-environment HTTP shapes.
  - createSelfClient now accepts partial config; generateProof supports timeoutMs with structured progress and timeout handling.
  - Introduced bridge helpers to add/remove native event listeners with safe fallbacks.
- Documentation
  - Added JSDoc across SDK modules and browser entry to clarify usage and surfaces.
- Tests
  - Updated HTTP fetch mocks to the new cross-environment response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->