### PR TITLE
test: verify provider memoization and add jsdoc

### DIFF
--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -20,6 +20,11 @@ import type {
   ValidationResult,
 } from './types/public';
 
+/**
+ * Optional adapter implementations used when a consumer does not provide their
+ * own. These defaults are intentionally minimal no-ops suitable for tests and
+ * non-production environments.
+ */
 const optionalDefaults: Partial<Adapters> = {
   storage: {
     get: async () => null,
@@ -37,6 +42,13 @@ const optionalDefaults: Partial<Adapters> = {
   },
 };
 
+/**
+ * Creates a fully configured {@link SelfClient} instance.
+ *
+ * The function validates that all required adapters are supplied and merges the
+ * provided configuration with sensible defaults. Missing optional adapters are
+ * filled with benign no-op implementations.
+ */
 export function createSelfClient({ config, adapters }: { config: Config; adapters: Partial<Adapters> }): SelfClient {
   const cfg = mergeConfig(defaultConfig, config);
   const required: (keyof Adapters)[] = ['scanner', 'network', 'crypto'];

--- a/packages/mobile-sdk-alpha/src/context.tsx
+++ b/packages/mobile-sdk-alpha/src/context.tsx
@@ -3,21 +3,50 @@ import { createContext, type PropsWithChildren, useContext, useMemo } from 'reac
 import { createSelfClient } from './client';
 import type { Adapters, Config, SelfClient } from './types/public';
 
+/**
+ * React context holding a {@link SelfClient} instance.
+ *
+ * The context is intentionally initialised with `null` so that consumers
+ * outside of a {@link SelfClientProvider} can be detected and an informative
+ * error can be thrown.
+ */
 const SelfClientContext = createContext<SelfClient | null>(null);
 
+/**
+ * Props for {@link SelfClientProvider}.
+ *
+ * @public
+ */
 export interface SelfClientProviderProps {
+  /** SDK configuration options. */
   config: Config;
+  /**
+   * Partial set of adapter implementations. Any missing optional adapters will
+   * be replaced with default no-op implementations.
+   */
   adapters?: Partial<Adapters>;
 }
 
 export { SelfClientContext };
 
+/**
+ * Provides a memoised {@link SelfClient} instance to all descendant components
+ * via {@link SelfClientContext}.
+ *
+ * Consumers should ensure that `config` and `adapters` are referentially stable
+ * (e.g. wrapped in `useMemo`) to avoid recreating the client on every render.
+ */
 export function SelfClientProvider({ config, adapters = {}, children }: PropsWithChildren<SelfClientProviderProps>) {
   const client = useMemo(() => createSelfClient({ config, adapters }), [config, adapters]);
 
   return <SelfClientContext.Provider value={client}>{children}</SelfClientContext.Provider>;
 }
 
+/**
+ * Retrieves the current {@link SelfClient} from context.
+ *
+ * @throws If used outside of a {@link SelfClientProvider}.
+ */
 export function useSelfClient(): SelfClient {
   const ctx = useContext(SelfClientContext);
   if (!ctx) throw new Error('useSelfClient must be used within a SelfClientProvider');

--- a/packages/mobile-sdk-alpha/tests/provider.test.tsx
+++ b/packages/mobile-sdk-alpha/tests/provider.test.tsx
@@ -1,7 +1,8 @@
 /* @vitest-environment jsdom */
 import type { ReactNode } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
+import * as clientModule from '../src/client';
 import { SelfClientProvider, useSelfClient } from '../src/index';
 import { expectedMRZResult, mockAdapters, sampleMRZ } from './utils/testHelpers';
 
@@ -26,5 +27,23 @@ describe('SelfClientProvider Context', () => {
     expect(() => {
       renderHook(() => useSelfClient());
     }).toThrow('useSelfClient must be used within a SelfClientProvider');
+  });
+
+  it('memoises the client instance across re-renders', () => {
+    const spy = vi.spyOn(clientModule, 'createSelfClient');
+    const config = {};
+    const adapters = mockAdapters;
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SelfClientProvider config={config} adapters={adapters}>
+        {children}
+      </SelfClientProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useSelfClient(), { wrapper });
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- document SelfClient context utilities
- document SelfClient factory
- test SelfClientProvider memoization

## Testing
- `yarn workspaces foreach -A -p -v --topological-dev run nice` *(fails: lint errors in @selfxyz/common)*
- `yarn lint`
- `yarn build` *(fails: type error in @selfxyz/common)*
- `yarn workspace @selfxyz/contracts build` *(fails: Hardhat config error)*
- `yarn types` *(fails: type error in @selfxyz/common)*
- `yarn workspace @selfxyz/mobile-sdk-alpha nice`
- `yarn workspace @selfxyz/mobile-sdk-alpha build`
- `yarn workspace @selfxyz/mobile-sdk-alpha types`
- `yarn workspace @selfxyz/mobile-sdk-alpha test` *(fails: window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_68a523cb2964832db09472c5f5211366