### PR TITLE
feat: use Self SDK hook for MRZ parsing

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -12,6 +12,7 @@ import { DatabaseProvider } from './src/providers/databaseProvider';
 import { LoggerProvider } from './src/providers/loggerProvider';
 import { NotificationTrackingProvider } from './src/providers/notificationTrackingProvider';
 import { PassportProvider } from './src/providers/passportDataProvider';
+import { SelfClientProvider } from './src/providers/selfClientProvider';
 import { RemoteConfigProvider } from './src/providers/remoteConfigProvider';
 import { initSentry, wrapWithSentry } from './src/Sentry';
 
@@ -25,15 +26,17 @@ function App(): React.JSX.Element {
       <YStack flex={1} height="100%" width="100%">
         <RemoteConfigProvider>
           <LoggerProvider>
-            <AuthProvider>
-              <PassportProvider>
-                <DatabaseProvider>
-                  <NotificationTrackingProvider>
-                    <AppNavigation />
-                  </NotificationTrackingProvider>
-                </DatabaseProvider>
-              </PassportProvider>
-            </AuthProvider>
+            <SelfClientProvider>
+              <AuthProvider>
+                <PassportProvider>
+                  <DatabaseProvider>
+                    <NotificationTrackingProvider>
+                      <AppNavigation />
+                    </NotificationTrackingProvider>
+                  </DatabaseProvider>
+                </PassportProvider>
+              </AuthProvider>
+            </SelfClientProvider>
           </LoggerProvider>
         </RemoteConfigProvider>
       </YStack>

--- a/app/src/components/native/PassportCamera.tsx
+++ b/app/src/components/native/PassportCamera.tsx
@@ -4,9 +4,8 @@ import React, { useCallback } from 'react';
 import type { NativeSyntheticEvent, StyleProp, ViewStyle } from 'react-native';
 import { PixelRatio, Platform, requireNativeComponent } from 'react-native';
 
-import { extractMRZInfo } from '@selfxyz/mobile-sdk-alpha';
-
 import { RCTFragment } from '@/components/native/RCTFragment';
+import { useSelfClient, type SelfClient } from '@selfxyz/mobile-sdk-alpha';
 
 interface NativePassportOCRViewProps {
   onPassportRead: (
@@ -47,7 +46,7 @@ export interface PassportCameraProps {
   isMounted: boolean;
   onPassportRead: (
     error: Error | null,
-    mrzData?: ReturnType<typeof extractMRZInfo>,
+    mrzData?: ReturnType<SelfClient['extractMRZInfo']>,
   ) => void;
 }
 
@@ -55,6 +54,7 @@ export const PassportCamera: React.FC<PassportCameraProps> = ({
   onPassportRead,
   isMounted,
 }) => {
+  const selfClient = useSelfClient();
   const _onError = useCallback(
     (
       event: NativeSyntheticEvent<{
@@ -93,7 +93,7 @@ export const PassportCamera: React.FC<PassportCameraProps> = ({
         return;
       }
       if (typeof event.nativeEvent.data === 'string') {
-        onPassportRead(null, extractMRZInfo(event.nativeEvent.data));
+        onPassportRead(null, selfClient.extractMRZInfo(event.nativeEvent.data));
       } else {
         onPassportRead(null, {
           passportNumber: event.nativeEvent.data.documentNumber,

--- a/app/src/components/native/PassportCamera.web.tsx
+++ b/app/src/components/native/PassportCamera.web.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect } from 'react';
 
-import type { extractMRZInfo } from '@selfxyz/mobile-sdk-alpha';
+import { useSelfClient, type SelfClient } from '@selfxyz/mobile-sdk-alpha';
 
 // TODO: Web find a lightweight ocr or mrz scanner.
 
@@ -10,7 +10,7 @@ export interface PassportCameraProps {
   isMounted: boolean;
   onPassportRead: (
     error: Error | null,
-    mrzData?: ReturnType<typeof extractMRZInfo>,
+    mrzData?: ReturnType<SelfClient['extractMRZInfo']>,
   ) => void;
 }
 
@@ -18,6 +18,16 @@ export const PassportCamera: React.FC<PassportCameraProps> = ({
   onPassportRead,
   isMounted,
 }) => {
+  const selfClient = useSelfClient();
+  const _onPassportRead = useCallback(
+    (mrz: string) => {
+      if (!isMounted) {
+        return;
+      }
+      onPassportRead(null, selfClient.extractMRZInfo(mrz));
+    },
+    [onPassportRead, isMounted],
+  );
   const handleError = useCallback(() => {
     if (!isMounted) {
       return;
@@ -28,6 +38,7 @@ export const PassportCamera: React.FC<PassportCameraProps> = ({
 
   // Web stub - no functionality yet
   useEffect(() => {
+    void _onPassportRead; // noop until web implementation exists
     // Simulate that the component is not ready for web
     if (isMounted) {
       console.warn('PassportCamera: Web implementation not yet available');
@@ -37,7 +48,7 @@ export const PassportCamera: React.FC<PassportCameraProps> = ({
       }, 100);
       return () => clearTimeout(timer);
     }
-  }, [isMounted, handleError]);
+  }, [isMounted, handleError, _onPassportRead]);
 
   return (
     <div

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+import type { PropsWithChildren } from 'react';
+import {
+  SelfClientProvider as SDKSelfClientProvider,
+  webScannerShim,
+  type WsConn,
+} from '@selfxyz/mobile-sdk-alpha';
+
+/**
+ * Provides a configured Self SDK client instance to all descendants.
+ *
+ * Adapters:
+ * - `webScannerShim` for basic MRZ/QR scanning stubs
+ * - `fetch`/`WebSocket` for network communication
+ * - Web Crypto hashing with a stub signer
+ */
+export const SelfClientProvider = ({ children }: PropsWithChildren) => (
+  <SDKSelfClientProvider
+    config={{}}
+    adapters={{
+      scanner: webScannerShim,
+      network: {
+        http: { fetch: (input: RequestInfo, init?: RequestInit) => fetch(input, init) },
+        ws: {
+          connect: (url: string): WsConn => {
+            const socket = new WebSocket(url);
+            return {
+              send: (data: string | ArrayBufferView | ArrayBuffer) => socket.send(data),
+              close: () => socket.close(),
+              onMessage: cb => {
+                socket.addEventListener('message', ev => cb((ev as MessageEvent).data));
+              },
+              onError: cb => {
+                socket.addEventListener('error', e => cb(e));
+              },
+              onClose: cb => {
+                socket.addEventListener('close', () => cb());
+              },
+            };
+          },
+        },
+      },
+      crypto: {
+        async hash(data: Uint8Array, algo: 'sha256' = 'sha256'): Promise<Uint8Array> {
+          const buf = await crypto.subtle.digest(algo, data as BufferSource);
+          return new Uint8Array(buf);
+        },
+        async sign(_data: Uint8Array, _keyRef: string): Promise<Uint8Array> {
+          return new Uint8Array();
+        },
+      },
+    }}
+  >
+    {children}
+  </SDKSelfClientProvider>
+);
+
+export default SelfClientProvider;

--- a/app/tests/src/utils/proving/validateDocument.test.ts
+++ b/app/tests/src/utils/proving/validateDocument.test.ts
@@ -51,6 +51,35 @@ jest.mock('@/stores/protocolStore', () => ({
   },
 }));
 
+/**
+ * Creates a Self SDK client with minimal mock adapters for tests.
+ */
+function createTestClient() {
+  const { createSelfClient } = require('@selfxyz/mobile-sdk-alpha');
+  return createSelfClient({
+    config: {},
+    adapters: {
+      scanner: { scan: jest.fn() },
+      network: {
+        http: { fetch: jest.fn() },
+        ws: {
+          connect: jest.fn(() => ({
+            send: jest.fn(),
+            close: jest.fn(),
+            onMessage: jest.fn(),
+            onError: jest.fn(),
+            onClose: jest.fn(),
+          })),
+        },
+      },
+      crypto: {
+        hash: jest.fn(),
+        sign: jest.fn(),
+      },
+    },
+  });
+}
+
 describe('validateDocument - Real mobile-sdk-alpha Integration (PII-safe)', () => {
   it('should use the real isPassportDataValid function with synthetic passport data', () => {
     // This test verifies that we're using the real function, not a mock
@@ -132,16 +161,8 @@ describe('validateDocument - Real mobile-sdk-alpha Integration (PII-safe)', () =
     expect(callbacks.onPassportMetadataNull).toHaveBeenCalled();
   });
 
-  it('should import and use real mobile-sdk-alpha exports', () => {
-    // Verify that we can import other exports from the real package (using synthetic data)
-    const {
-      createSelfClient,
-      defaultConfig,
-      extractMRZInfo,
-    } = require('@selfxyz/mobile-sdk-alpha');
-
-    expect(typeof createSelfClient).toBe('function');
-    expect(typeof defaultConfig).toBe('object');
-    expect(typeof extractMRZInfo).toBe('function');
+  it('should expose extractMRZInfo via a self client instance', () => {
+    const client = createTestClient();
+    expect(typeof client.extractMRZInfo).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary
- wrap app with SelfClientProvider to configure SDK adapters
- parse MRZ data via useSelfClient hook in native and web passport cameras

## Testing
- `yarn install` *(fails: network errors)*
- `yarn workspace @selfxyz/mobile-app nice` *(fails: Couldn't find the node_modules state file)*
- `yarn workspace @selfxyz/mobile-app lint` *(fails: Couldn't find the node_modules state file)*
- `yarn workspace @selfxyz/mobile-app types` *(fails: Couldn't find the node_modules state file)*
- `yarn workspace @selfxyz/mobile-app test` *(fails: Couldn't find the node_modules state file)*
- `yarn workspace @selfxyz/mobile-app build` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_b_68a531b0f6d4832d8e8f99633c7c08a5