### PR TITLE
Move proving inputs to the common package

### DIFF
--- a/app/src/stores/protocolStore.ts
+++ b/app/src/stores/protocolStore.ts
@@ -18,6 +18,7 @@ import {
   IDENTITY_TREE_URL_STAGING,
   IDENTITY_TREE_URL_STAGING_ID_CARD,
 } from '@selfxyz/common/constants';
+import type { OfacTree } from '@selfxyz/common/utils/types';
 
 import { fetchOfacTrees } from '@/utils/ofac';
 
@@ -29,11 +30,7 @@ interface ProtocolState {
     deployed_circuits: any;
     circuits_dns_mapping: any;
     alternative_csca: Record<string, string>;
-    ofac_trees: {
-      passportNoAndNationality: any;
-      nameAndDob: any;
-      nameAndYob: any;
-    } | null;
+    ofac_trees: OfacTree | null;
     fetch_deployed_circuits: (environment: 'prod' | 'stg') => Promise<void>;
     fetch_circuits_dns_mapping: (environment: 'prod' | 'stg') => Promise<void>;
     fetch_csca_tree: (environment: 'prod' | 'stg') => Promise<void>;
@@ -53,11 +50,7 @@ interface ProtocolState {
     deployed_circuits: any;
     circuits_dns_mapping: any;
     alternative_csca: Record<string, string>;
-    ofac_trees: {
-      passportNoAndNationality: any;
-      nameAndDob: any;
-      nameAndYob: any;
-    } | null;
+    ofac_trees: OfacTree | null;
     fetch_deployed_circuits: (environment: 'prod' | 'stg') => Promise<void>;
     fetch_circuits_dns_mapping: (environment: 'prod' | 'stg') => Promise<void>;
     fetch_csca_tree: (environment: 'prod' | 'stg') => Promise<void>;

--- a/app/src/utils/ofac.ts
+++ b/app/src/utils/ofac.ts
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import { TREE_URL, TREE_URL_STAGING } from '@selfxyz/common/constants';
-
-export interface OfacTrees {
-  passportNoAndNationality: any;
-  nameAndDob: any;
-  nameAndYob: any;
-}
+import type { OfacTree } from '@selfxyz/common/utils/types';
 
 export type OfacVariant = 'passport' | 'id_card';
 
@@ -31,7 +26,7 @@ const fetchTree = async (url: string): Promise<any> => {
 export const fetchOfacTrees = async (
   environment: 'prod' | 'stg',
   variant: OfacVariant = 'passport',
-): Promise<OfacTrees> => {
+): Promise<OfacTree> => {
   const baseUrl = environment === 'prod' ? TREE_URL : TREE_URL_STAGING;
 
   const ppNoNatUrl = `${baseUrl}/ofac/passport-no-nationality`;

--- a/app/src/utils/proving/provingInputs.ts
+++ b/app/src/utils/proving/provingInputs.ts
@@ -5,11 +5,16 @@ import {
   generateCircuitInputsRegister,
   generateTEEInputsDiscloseStateless,
   generateTEEInputsDSC,
+  generateTEEInputsRegister,
 } from '@selfxyz/common/utils/circuits/registerInputs';
 
 import { useProtocolStore } from '@/stores/protocolStore';
 
-export { generateCircuitInputsRegister, generateTEEInputsDSC };
+export {
+  generateCircuitInputsRegister,
+  generateTEEInputsDSC,
+  generateTEEInputsRegister,
+};
 export function generateTEEInputsDisclose(
   secret: string,
   passportData: PassportData,

--- a/app/src/utils/proving/provingInputs.ts
+++ b/app/src/utils/proving/provingInputs.ts
@@ -1,163 +1,34 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
-
-import { poseidon2 } from 'poseidon-lite';
-import { LeanIMT } from '@openpassport/zk-kit-lean-imt';
-import { SMT } from '@openpassport/zk-kit-smt';
-
-import {
-  attributeToPosition,
-  attributeToPosition_ID,
-  DEFAULT_MAJORITY,
-  ID_CARD_ATTESTATION_ID,
-  PASSPORT_ATTESTATION_ID,
-} from '@selfxyz/common/constants';
 import type { DocumentCategory, PassportData } from '@selfxyz/common/types';
-import type { SelfApp, SelfAppDisclosureConfig } from '@selfxyz/common/utils';
+import type { SelfApp } from '@selfxyz/common/utils';
 import {
-  calculateUserIdentifierHash,
-  generateCircuitInputsDSC,
   generateCircuitInputsRegister,
-  generateCircuitInputsVCandDisclose,
-  getCircuitNameFromPassportData,
-  hashEndpointWithScope,
-} from '@selfxyz/common/utils';
+  generateTEEInputsDiscloseStateless,
+  generateTEEInputsDSC,
+} from '@selfxyz/common/utils/circuits/registerInputs';
 
 import { useProtocolStore } from '@/stores/protocolStore';
 
-export function generateTEEInputsDSC(
-  passportData: PassportData,
-  cscaTree: string[][],
-  env: 'prod' | 'stg',
-) {
-  const inputs = generateCircuitInputsDSC(passportData, cscaTree);
-  const circuitName = getCircuitNameFromPassportData(passportData, 'dsc');
-  const endpointType = env === 'stg' ? 'staging_celo' : 'celo';
-  const endpoint = 'https://self.xyz';
-  return { inputs, circuitName, endpointType, endpoint };
-}
-
+export { generateCircuitInputsRegister, generateTEEInputsDSC };
 export function generateTEEInputsDisclose(
   secret: string,
   passportData: PassportData,
   selfApp: SelfApp,
 ) {
-  const { scope, disclosures, endpoint, userId, userDefinedData, chainID } =
-    selfApp;
-  const userIdentifierHash = calculateUserIdentifierHash(
-    chainID,
-    userId,
-    userDefinedData,
-  );
-  const scope_hash = hashEndpointWithScope(endpoint, scope);
-  const document: DocumentCategory = passportData.documentCategory;
-
-  const selector_dg1 = getSelectorDg1(document, disclosures);
-
-  const majority = disclosures.minimumAge
-    ? disclosures.minimumAge.toString()
-    : DEFAULT_MAJORITY;
-  const selector_older_than = disclosures.minimumAge ? '1' : '0';
-
-  const selector_ofac = disclosures.ofac ? 1 : 0;
-
-  const ofac_trees = useProtocolStore.getState()[document].ofac_trees;
-  if (!ofac_trees) {
-    throw new Error('OFAC trees not loaded');
-  }
-  let passportNoAndNationalitySMT: SMT | null = null;
-  const nameAndDobSMT = new SMT(poseidon2, true);
-  const nameAndYobSMT = new SMT(poseidon2, true);
-  if (document === 'passport') {
-    passportNoAndNationalitySMT = new SMT(poseidon2, true);
-    passportNoAndNationalitySMT.import(ofac_trees.passportNoAndNationality);
-  }
-  nameAndDobSMT.import(ofac_trees.nameAndDob);
-  nameAndYobSMT.import(ofac_trees.nameAndYob);
-
-  const serialized_tree = useProtocolStore.getState()[document].commitment_tree;
-  const tree = LeanIMT.import((a, b) => poseidon2([a, b]), serialized_tree);
-  const inputs = generateCircuitInputsVCandDisclose(
+  return generateTEEInputsDiscloseStateless(
     secret,
-    document === 'passport' ? PASSPORT_ATTESTATION_ID : ID_CARD_ATTESTATION_ID,
     passportData,
-    scope_hash,
-    selector_dg1,
-    selector_older_than,
-    tree,
-    majority,
-    passportNoAndNationalitySMT,
-    nameAndDobSMT,
-    nameAndYobSMT,
-    selector_ofac,
-    disclosures.excludedCountries ?? [],
-    userIdentifierHash.toString(),
+    selfApp,
+    (document: DocumentCategory, tree) => {
+      const protocolStore = useProtocolStore.getState();
+      switch (tree) {
+        case 'ofac':
+          return protocolStore[document].ofac_trees;
+        case 'commitment':
+          return protocolStore[document].commitment_tree;
+        default:
+          throw new Error('Unknown tree type');
+      }
+    },
   );
-  return {
-    inputs,
-    circuitName:
-      passportData.documentCategory === 'passport'
-        ? 'vc_and_disclose'
-        : 'vc_and_disclose_id',
-    endpointType: selfApp.endpointType,
-    endpoint: selfApp.endpoint,
-  };
-}
-
-export function generateTEEInputsRegister(
-  secret: string,
-  passportData: PassportData,
-  dscTree: string,
-  env: 'prod' | 'stg',
-) {
-  const inputs = generateCircuitInputsRegister(secret, passportData, dscTree);
-  const circuitName = getCircuitNameFromPassportData(passportData, 'register');
-  const endpointType = env === 'stg' ? 'staging_celo' : 'celo';
-  const endpoint = 'https://self.xyz';
-  return { inputs, circuitName, endpointType, endpoint };
-}
-
-/*** DISCLOSURE ***/
-
-function getSelectorDg1(
-  document: DocumentCategory,
-  disclosures: SelfAppDisclosureConfig,
-) {
-  switch (document) {
-    case 'passport':
-      return getSelectorDg1Passport(disclosures);
-    case 'id_card':
-      return getSelectorDg1IdCard(disclosures);
-  }
-}
-
-function getSelectorDg1Passport(disclosures: SelfAppDisclosureConfig) {
-  const selector_dg1 = Array(88).fill('0');
-  Object.entries(disclosures).forEach(([attribute, reveal]) => {
-    if (['ofac', 'excludedCountries', 'minimumAge'].includes(attribute)) {
-      return;
-    }
-    if (reveal) {
-      const [start, end] =
-        attributeToPosition[attribute as keyof typeof attributeToPosition];
-      selector_dg1.fill('1', start, end + 1);
-    }
-  });
-  return selector_dg1;
-}
-
-function getSelectorDg1IdCard(disclosures: SelfAppDisclosureConfig) {
-  const selector_dg1 = Array(90).fill('0');
-  Object.entries(disclosures).forEach(([attribute, reveal]) => {
-    if (['ofac', 'excludedCountries', 'minimumAge'].includes(attribute)) {
-      return;
-    }
-    if (reveal) {
-      const [start, end] =
-        attributeToPosition_ID[
-          attribute as keyof typeof attributeToPosition_ID
-        ];
-      selector_dg1.fill('1', start, end + 1);
-    }
-  });
-  return selector_dg1;
 }

--- a/app/src/utils/proving/provingInputs.ts
+++ b/app/src/utils/proving/provingInputs.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
 import type { DocumentCategory, PassportData } from '@selfxyz/common/types';
 import type { SelfApp } from '@selfxyz/common/utils';
 import {

--- a/common/src/utils/circuits/registerInputs.ts
+++ b/common/src/utils/circuits/registerInputs.ts
@@ -1,1 +1,153 @@
+// SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
+
+import { poseidon2 } from 'poseidon-lite';
+
+import {
+  attributeToPosition,
+  attributeToPosition_ID,
+  DEFAULT_MAJORITY,
+  ID_CARD_ATTESTATION_ID,
+  PASSPORT_ATTESTATION_ID,
+} from '../../constants/constants.js';
+import type { DocumentCategory, PassportData } from '../../types/index.js';
+import type { SelfApp, SelfAppDisclosureConfig } from '../../utils/appType.js';
+import {
+  calculateUserIdentifierHash,
+  generateCircuitInputsDSC,
+  generateCircuitInputsRegister,
+  generateCircuitInputsVCandDisclose,
+  getCircuitNameFromPassportData,
+  hashEndpointWithScope,
+} from '../../utils/index.js';
+import type { OfacTree } from '../../utils/types.js';
+
+import { LeanIMT } from '@openpassport/zk-kit-lean-imt';
+import { SMT } from '@openpassport/zk-kit-smt';
+
 export { generateCircuitInputsRegister } from './generateInputs.js';
+
+export function generateTEEInputsDSC(
+  passportData: PassportData,
+  cscaTree: string[][],
+  env: 'prod' | 'stg'
+) {
+  const inputs = generateCircuitInputsDSC(passportData, cscaTree);
+  const circuitName = getCircuitNameFromPassportData(passportData, 'dsc');
+  const endpointType = env === 'stg' ? 'staging_celo' : 'celo';
+  const endpoint = 'https://self.xyz';
+  return { inputs, circuitName, endpointType, endpoint };
+}
+
+export function generateTEEInputsDiscloseStateless(
+  secret: string,
+  passportData: PassportData,
+  selfApp: SelfApp,
+  getTree: <T extends 'ofac' | 'commitment'>(
+    doc: DocumentCategory,
+    tree: T
+  ) => T extends 'ofac' ? OfacTree : any
+) {
+  const { scope, disclosures, endpoint, userId, userDefinedData, chainID } = selfApp;
+  const userIdentifierHash = calculateUserIdentifierHash(chainID, userId, userDefinedData);
+  const scope_hash = hashEndpointWithScope(endpoint, scope);
+  const document: DocumentCategory = passportData.documentCategory;
+
+  const selector_dg1 = getSelectorDg1(document, disclosures);
+
+  const majority = disclosures.minimumAge ? disclosures.minimumAge.toString() : DEFAULT_MAJORITY;
+  const selector_older_than = disclosures.minimumAge ? '1' : '0';
+
+  const selector_ofac = disclosures.ofac ? 1 : 0;
+
+  const ofac_trees = getTree(document, 'ofac');
+  if (!ofac_trees) {
+    throw new Error('OFAC trees not loaded');
+  }
+  let passportNoAndNationalitySMT: SMT | null = null;
+  const nameAndDobSMT = new SMT(poseidon2, true);
+  const nameAndYobSMT = new SMT(poseidon2, true);
+  if (document === 'passport') {
+    passportNoAndNationalitySMT = new SMT(poseidon2, true);
+    passportNoAndNationalitySMT.import(ofac_trees.passportNoAndNationality);
+  }
+  nameAndDobSMT.import(ofac_trees.nameAndDob);
+  nameAndYobSMT.import(ofac_trees.nameAndYob);
+
+  const serialized_tree = getTree(document, 'commitment');
+  const tree = LeanIMT.import((a, b) => poseidon2([a, b]), serialized_tree);
+  const inputs = generateCircuitInputsVCandDisclose(
+    secret,
+    document === 'passport' ? PASSPORT_ATTESTATION_ID : ID_CARD_ATTESTATION_ID,
+    passportData,
+    scope_hash,
+    selector_dg1,
+    selector_older_than,
+    tree,
+    majority,
+    passportNoAndNationalitySMT,
+    nameAndDobSMT,
+    nameAndYobSMT,
+    selector_ofac,
+    disclosures.excludedCountries ?? [],
+    userIdentifierHash.toString()
+  );
+  return {
+    inputs,
+    circuitName:
+      passportData.documentCategory === 'passport' ? 'vc_and_disclose' : 'vc_and_disclose_id',
+    endpointType: selfApp.endpointType,
+    endpoint: selfApp.endpoint,
+  };
+}
+
+export function generateTEEInputsRegister(
+  secret: string,
+  passportData: PassportData,
+  dscTree: string,
+  env: 'prod' | 'stg'
+) {
+  const inputs = generateCircuitInputsRegister(secret, passportData, dscTree);
+  const circuitName = getCircuitNameFromPassportData(passportData, 'register');
+  const endpointType = env === 'stg' ? 'staging_celo' : 'celo';
+  const endpoint = 'https://self.xyz';
+  return { inputs, circuitName, endpointType, endpoint };
+}
+
+/*** DISCLOSURE ***/
+
+function getSelectorDg1(document: DocumentCategory, disclosures: SelfAppDisclosureConfig) {
+  switch (document) {
+    case 'passport':
+      return getSelectorDg1Passport(disclosures);
+    case 'id_card':
+      return getSelectorDg1IdCard(disclosures);
+  }
+}
+
+function getSelectorDg1Passport(disclosures: SelfAppDisclosureConfig) {
+  const selector_dg1 = Array(88).fill('0');
+  Object.entries(disclosures).forEach(([attribute, reveal]) => {
+    if (['ofac', 'excludedCountries', 'minimumAge'].includes(attribute)) {
+      return;
+    }
+    if (reveal) {
+      const [start, end] = attributeToPosition[attribute as keyof typeof attributeToPosition];
+      selector_dg1.fill('1', start, end + 1);
+    }
+  });
+  return selector_dg1;
+}
+
+function getSelectorDg1IdCard(disclosures: SelfAppDisclosureConfig) {
+  const selector_dg1 = Array(90).fill('0');
+  Object.entries(disclosures).forEach(([attribute, reveal]) => {
+    if (['ofac', 'excludedCountries', 'minimumAge'].includes(attribute)) {
+      return;
+    }
+    if (reveal) {
+      const [start, end] = attributeToPosition_ID[attribute as keyof typeof attributeToPosition_ID];
+      selector_dg1.fill('1', start, end + 1);
+    }
+  });
+  return selector_dg1;
+}

--- a/common/src/utils/circuits/registerInputs.ts
+++ b/common/src/utils/circuits/registerInputs.ts
@@ -63,6 +63,15 @@ export function generateTEEInputsDiscloseStateless(
   if (!ofac_trees) {
     throw new Error('OFAC trees not loaded');
   }
+
+  // Validate OFAC tree structure
+  if (!ofac_trees.nameAndDob || !ofac_trees.nameAndYob) {
+    throw new Error('Invalid OFAC tree structure: missing required fields');
+  }
+  if (document === 'passport' && !ofac_trees.passportNoAndNationality) {
+    throw new Error('Invalid OFAC tree structure: missing passportNoAndNationality for passport');
+  }
+
   let passportNoAndNationalitySMT: SMT | null = null;
   const nameAndDobSMT = new SMT(poseidon2, true);
   const nameAndYobSMT = new SMT(poseidon2, true);

--- a/common/src/utils/types.ts
+++ b/common/src/utils/types.ts
@@ -4,6 +4,13 @@ import type { PassportMetadata } from './passports/passport_parsing/parsePasspor
 export type DocumentCategory = 'passport' | 'id_card';
 
 export type DocumentType = 'passport' | 'id_card' | 'mock_passport' | 'mock_id_card';
+
+export type OfacTree = {
+  passportNoAndNationality: any;
+  nameAndDob: any;
+  nameAndYob: any;
+};
+
 export type PassportData = {
   mrz: string;
   dg1Hash?: number[];


### PR DESCRIPTION
fullfills part 3 of migration prompts. 

1. create an OfacTree type
2. create a version of generateTEEInputsDisclose which doesnt depend on protocolStore.
3. moving all functions from proving-inputs in app to the register-inputs folder in common/circuits. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - End-to-end TEE input generation added for DSC, disclose, and register flows with consistent selector encoding for passport and ID card.
  - Disclosure flow now supports a stateless processing variant for more reliable runtime behavior.

- Refactor
  - Input-generation logic consolidated into shared utilities, simplifying and centralizing flows.
  - OFAC and commitment tree retrieval moved to a dynamic callback approach to decouple state access.

- Chores
  - Introduced a shared OFAC data type and updated store usage for consistent OFAC handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->