### PR TITLE
feat: show feedback widget on NFC scan issues

### DIFF
--- a/app/src/hooks/useFeedbackModal.ts
+++ b/app/src/hooks/useFeedbackModal.ts
@@ -10,7 +10,7 @@ import {
 import type { FeedbackModalScreenParams } from '@/components/FeedbackModalScreen';
 import { captureFeedback } from '@/Sentry';
 
-export type FeedbackType = 'button' | 'widget' | 'custom' | 'modal';
+export type FeedbackType = 'button' | 'widget' | 'custom';
 
 export const useFeedbackModal = () => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -34,8 +34,6 @@ export const useFeedbackModal = () => {
         break;
       case 'custom':
         setIsVisible(true);
-        break;
-      case 'modal':
         break;
       default:
         showFeedbackButton();

--- a/app/src/screens/passport/PassportNFCScanScreen.tsx
+++ b/app/src/screens/passport/PassportNFCScanScreen.tsx
@@ -33,6 +33,7 @@ import TextsContainer from '@/components/TextsContainer';
 import { BodyText } from '@/components/typography/BodyText';
 import { Title } from '@/components/typography/Title';
 import { PassportEvents } from '@/consts/analytics';
+import { useFeedbackAutoHide } from '@/hooks/useFeedbackAutoHide';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import NFC_IMAGE from '@/images/nfc.png';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
@@ -79,7 +80,8 @@ type PassportNFCScanRoute = RouteProp<
 const PassportNFCScanScreen: React.FC = () => {
   const navigation = useNavigation();
   const route = useRoute<PassportNFCScanRoute>();
-  const { showModal } = useFeedback();
+  const { showModal, showFeedbackModal } = useFeedback();
+  useFeedbackAutoHide();
   const {
     passportNumber,
     dateOfBirth,
@@ -93,6 +95,7 @@ const PassportNFCScanScreen: React.FC = () => {
   const [isNfcSheetOpen, setIsNfcSheetOpen] = useState(false);
   const [dialogMessage, setDialogMessage] = useState('');
   const [nfcMessage, setNfcMessage] = useState<string | null>(null);
+  const scanTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const animationRef = useRef<LottieView>(null);
 
@@ -140,6 +143,10 @@ ${deviceInfo.map(([k, v]) => `${k}=${v}`).join('\n')}
       )}&body=${encodeURIComponent(body)}`,
     );
   }, []);
+
+  const onReportIssue = useCallback(() => {
+    showFeedbackModal('widget');
+  }, [showFeedbackModal]);
 
   const openErrorModal = useCallback(
     (message: string) => {
@@ -198,6 +205,16 @@ ${deviceInfo.map(([k, v]) => `${k}=${v}`).join('\n')}
       setIsNfcSheetOpen(true);
       // Add timestamp when scan starts
       const scanStartTime = Date.now();
+      if (scanTimeoutRef.current) {
+        clearTimeout(scanTimeoutRef.current);
+        scanTimeoutRef.current = null;
+      }
+      scanTimeoutRef.current = setTimeout(() => {
+        trackEvent(PassportEvents.NFC_SCAN_FAILED, { error: 'timeout' });
+        openErrorModal('Scan timed out. Please try again.');
+        showFeedbackModal('widget');
+        setIsNfcSheetOpen(false);
+      }, 30000);
 
       try {
         const { canNumber, useCan, skipPACE, skipCA, extendedMode } =
@@ -307,7 +324,12 @@ ${deviceInfo.map(([k, v]) => `${k}=${v}`).join('\n')}
           duration_seconds: parseFloat(scanDurationSeconds),
         });
         openErrorModal(message);
+        showFeedbackModal('widget');
       } finally {
+        if (scanTimeoutRef.current) {
+          clearTimeout(scanTimeoutRef.current);
+          scanTimeoutRef.current = null;
+        }
         setIsNfcSheetOpen(false);
       }
     } else if (isNfcSupported) {
@@ -327,6 +349,7 @@ ${deviceInfo.map(([k, v]) => `${k}=${v}`).join('\n')}
     isPacePolling,
     navigation,
     openErrorModal,
+    showFeedbackModal,
   ]);
 
   const navigateToLaunch = useHapticNavigation('Launch', {
@@ -448,12 +471,21 @@ ${deviceInfo.map(([k, v]) => `${k}=${v}`).join('\n')}
                   gap="$1.5"
                 >
                   <Title>Verify your ID</Title>
-                  <Button
-                    unstyled
-                    onPress={goToNFCTrouble}
-                    icon={<CircleHelp size={28} color={slate500} />}
-                    aria-label="Help"
-                  />
+                  <XStack alignItems="center" gap="$2">
+                    <Button
+                      unstyled
+                      onPress={goToNFCTrouble}
+                      icon={<CircleHelp size={28} color={slate500} />}
+                      aria-label="Help"
+                    />
+                    <Button
+                      unstyled
+                      onPress={onReportIssue}
+                      aria-label="Report issue"
+                    >
+                      <BodyText color={slate500}>Report issue</BodyText>
+                    </Button>
+                  </XStack>
                 </XStack>
               </GestureDetector>
               {isNfcEnabled ? (

--- a/app/src/screens/passport/PassportNFCTroubleScreen.tsx
+++ b/app/src/screens/passport/PassportNFCTroubleScreen.tsx
@@ -2,13 +2,15 @@
 
 import React, { useEffect } from 'react';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { YStack } from 'tamagui';
+import { Button, YStack } from 'tamagui';
 
 import type { TipProps } from '@/components/Tips';
 import Tips from '@/components/Tips';
 import { Caption } from '@/components/typography/Caption';
+import { useFeedbackAutoHide } from '@/hooks/useFeedbackAutoHide';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import SimpleScrolledTitleLayout from '@/layouts/SimpleScrolledTitleLayout';
+import { useFeedback } from '@/providers/feedbackProvider';
 import analytics from '@/utils/analytics';
 import { slate500 } from '@/utils/colors';
 
@@ -46,6 +48,8 @@ const PassportNFCTrouble: React.FC = () => {
   const goToNFCMethodSelection = useHapticNavigation(
     'PassportNFCMethodSelection',
   );
+  const { showFeedbackModal } = useFeedback();
+  useFeedbackAutoHide();
 
   // error screen, flush analytics
   useEffect(() => {
@@ -84,6 +88,9 @@ const PassportNFCTrouble: React.FC = () => {
           device supports NFC and that your passport's RFID is functioning
           properly.
         </Caption>
+        <Button onPress={() => showFeedbackModal('widget')}>
+          Report issue
+        </Button>
       </YStack>
     </SimpleScrolledTitleLayout>
   );


### PR DESCRIPTION
## Summary
- remove unused modal feedback type
- show feedback widget for NFC scan errors, timeouts, and user reports
- add report issue button on NFC scan and trouble screens

## Testing
- `yarn workspaces foreach -p -v --topological-dev --since=HEAD run nice --if-present` *(failed: Unexpected any, no-console, import errors)*
- `yarn lint` *(failed: 321 problems)*
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(failed: Hardhat config errors)*
- `yarn types`
- `yarn test` *(failed: workspace build errors)*

------
https://chatgpt.com/codex/tasks/task_b_68abc614f510832d9ef04f283dd88d21