### PR TITLE
chore: update to macos latest large runner

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   build-deps:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v4
       - name: Read and sanitize Node.js version
@@ -98,7 +98,7 @@ jobs:
         working-directory: ./
 
   test:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     needs: build-deps
     steps:
       - uses: actions/checkout@v4
@@ -159,7 +159,7 @@ jobs:
         run: yarn test
         working-directory: ./app
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     needs: build-deps
     env:
       # iOS project configuration - hardcoded for CI stability

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: ./
 
   test:
-    runs-on: macos-latest-large
+    runs-on: macos-latest
     needs: build-deps
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -95,7 +95,7 @@ concurrency:
 
 jobs:
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     if: (inputs.platform == 'ios' || inputs.platform == 'both')
     steps:
       - name: Mobile deployment status

--- a/app/fastlane/DEV.md
+++ b/app/fastlane/DEV.md
@@ -396,7 +396,7 @@ The workflow consists of parallel jobs for each platform:
 
 #### `build-ios` Job
 
-Runs on `macos-latest` and performs the following steps:
+Runs on `macos-latest-large` and performs the following steps:
 1. Sets up the environment (Node.js, Ruby, CocoaPods)
 2. Processes iOS secrets and certificates
 3. Runs appropriate Fastlane lane based on branch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI and deployment workflows now run build-deps and the iOS build on larger macOS runners (macos-latest-large) to improve reliability and throughput; test jobs unchanged.

* **Documentation**
  * Updated CI/CD docs to reflect the move to larger macOS runners for the iOS build job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->