### PR TITLE
fix metro resolver for monorepo

### DIFF
--- a/app/metro.config.cjs
+++ b/app/metro.config.cjs
@@ -210,6 +210,8 @@ const config = {
       trueMonorepoNodeModules,
       // Add paths to other package workspaces if needed
     ],
+    unstable_enableSymlinks: true,
+    disableHierarchicalLookup: true,
     assetExts: assetExts.filter(ext => ext !== 'svg'),
     sourceExts: [...sourceExts, 'svg'],
   },

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+module.exports = {
+  presets: ['module:@react-native/babel-preset'],
+};

--- a/package.json
+++ b/package.json
@@ -1,16 +1,28 @@
 {
   "name": "self-workspace-root",
-  "workspaces": [
-    "app",
-    "circuits",
-    "common",
-    "contracts",
-    "packages/*",
-    "prover/tests",
-    "sdk/*",
-    "scripts/tests",
-    "packages/mobile-sdk-alpha/demo-app"
-  ],
+  "workspaces": {
+    "packages": [
+      "app",
+      "circuits",
+      "common",
+      "contracts",
+      "packages/*",
+      "prover/tests",
+      "sdk/*",
+      "scripts/tests",
+      "packages/mobile-sdk-alpha/demo-app"
+    ],
+    "nohoist": [
+      "**/react-native",
+      "**/react-native/**",
+      "**/@react-native-*",
+      "**/@react-native-*/**",
+      "**/@babel/runtime",
+      "**/@babel/runtime/**",
+      "**/metro-*",
+      "**/metro-*/**"
+    ]
+  },
   "scripts": {
     "build": "yarn workspaces foreach --topological-dev --parallel --exclude @selfxyz/contracts -i --all run build",
     "check:versions": "node scripts/check-package-versions.mjs",
@@ -39,6 +51,7 @@
     "react-native": "0.76.9"
   },
   "dependencies": {
+    "@babel/runtime": "^7.28.3",
     "react": "^18.3.1",
     "react-native": "0.76.9"
   },

--- a/packages/mobile-sdk-alpha/demo-app/metro.config.cjs
+++ b/packages/mobile-sdk-alpha/demo-app/metro.config.cjs
@@ -18,7 +18,12 @@ const config = {
       react: path.resolve(__dirname, '../../../node_modules/react'),
       'react-native': path.resolve(__dirname, '../../../node_modules/react-native'),
     },
-    nodeModulesPaths: [path.resolve(__dirname, 'node_modules'), path.resolve(__dirname, '../../../node_modules')],
+    nodeModulesPaths: [
+      path.resolve(__dirname, 'node_modules'),
+      path.resolve(__dirname, '../../../node_modules'),
+    ],
+    unstable_enableSymlinks: true,
+    disableHierarchicalLookup: true,
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23492,6 +23492,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "self-workspace-root@workspace:."
   dependencies:
+    "@babel/runtime": "npm:^7.28.3"
     "@types/node": "npm:^22.0.0"
     gitleaks: "npm:1.0.0"
     husky: "npm:9.1.7"


### PR DESCRIPTION
## Summary
- add root babel config and @babel/runtime dependency
- enable Metro symlink resolution in app and demo app
- configure Yarn workspaces with nohoist to keep RN deps local

## Testing
- `yarn workspaces foreach -p -v --topological-dev --since=HEAD run nice --if-present` *(fails: Cannot find module '@react-native-picker/picker')*
- `yarn lint` *(fails: Unable to resolve module 'react-native-svg-circle-country-flags')*
- `yarn build` *(fails: build failed in @selfxyz/mobile-sdk-alpha)*
- `yarn workspace @selfxyz/contracts build` *(fails: Hardhat config error)*
- `yarn types` *(fails: Cannot find module 'react-native-svg-circle-country-flags')*
- `yarn workspace @selfxyz/mobile-app test` *(fails: Cannot find module '@react-native-picker/picker')*
- `yarn workspace demo-app test` *(fails: renders menu buttons)
- `yarn workspace demo-app build` *(fails: Cannot find module '@react-native-picker/picker')*


------
https://chatgpt.com/codex/tasks/task_b_68b9dd8390f0832db7acf96700d85dd0