### PR TITLE
chore: map common paths in mobile sdk

### DIFF
--- a/packages/mobile-sdk-alpha/tsconfig.json
+++ b/packages/mobile-sdk-alpha/tsconfig.json
@@ -16,7 +16,13 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "verbatimModuleSyntax": false,
-    "types": ["vitest/globals", "react"]
+    "types": ["vitest/globals", "react"],
+    "baseUrl": ".",
+    "paths": {
+      "@selfxyz/common": ["../../common"],
+      "@selfxyz/common/*": ["../../common/*"],
+      "@selfxyz/common/utils/passports/*": ["../../common/utils/passports/*"]
+    }
   },
   "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary
- add baseUrl and common path mappings to mobile-sdk-alpha tsconfig

## Testing
- `yarn workspace @selfxyz/mobile-sdk-alpha format`
- `yarn workspaces foreach -p -v --topological-dev --since=HEAD run nice` *(passes for mobile-sdk-alpha)*
- `yarn lint` *(fails: Unable to resolve module paths in @selfxyz/mobile-app)*
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Couldn't find a script named "hardhat")*
- `yarn types` *(fails: Cannot find module 'react-native-svg-circle-country-flags' in @selfxyz/mobile-app)*
- `yarn workspace @selfxyz/mobile-sdk-alpha test`


------
https://chatgpt.com/codex/tasks/task_b_68bd15b42600832da69f631949352eed