### PR TITLE
moves ofac and protocol store

### DIFF
--- a/app/metro.config.cjs
+++ b/app/metro.config.cjs
@@ -28,6 +28,10 @@ const extraNodeModules = {
     sdkAlphaPath,
     'dist/esm/constants/analytics.js',
   ),
+  '@selfxyz/mobile-sdk-alpha/stores': path.resolve(
+    sdkAlphaPath,
+    'dist/esm/stores.js',
+  ),
   // Main exports
   '@selfxyz/common/utils': path.resolve(
     commonPath,

--- a/app/metro.config.cjs
+++ b/app/metro.config.cjs
@@ -163,6 +163,10 @@ const extraNodeModules = {
     commonPath,
     'dist/esm/src/utils/csca.js',
   ),
+  '@selfxyz/common/utils/ofac': path.resolve(
+    commonPath,
+    'dist/esm/src/utils/ofac.js',
+  ),
   // Types subpaths
   '@selfxyz/common/types/passport': path.resolve(
     commonPath,

--- a/app/src/screens/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/recovery/AccountRecoveryChoiceScreen.tsx
@@ -9,6 +9,7 @@ import { useNavigation } from '@react-navigation/native';
 import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
 import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
 import { BackupEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+import { useProtocolStore } from '@selfxyz/mobile-sdk-alpha/stores';
 
 import { PrimaryButton } from '@/components/buttons/PrimaryButton';
 import { SecondaryButton } from '@/components/buttons/SecondaryButton';
@@ -24,7 +25,6 @@ import {
   loadPassportDataAndSecret,
   reStorePassportDataWithRightCSCA,
 } from '@/providers/passportDataProvider';
-import { useProtocolStore } from '@/stores/protocolStore';
 import { useSettingStore } from '@/stores/settingStore';
 import { STORAGE_NAME, useBackupMnemonic } from '@/utils/cloudBackup';
 import { black, slate500, slate600, white } from '@/utils/colors';

--- a/app/src/screens/recovery/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/recovery/RecoverWithPhraseScreen.tsx
@@ -12,6 +12,7 @@ import { useNavigation } from '@react-navigation/native';
 import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
 import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
 import { BackupEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+import { useProtocolStore } from '@selfxyz/mobile-sdk-alpha/stores';
 
 import { SecondaryButton } from '@/components/buttons/SecondaryButton';
 import Description from '@/components/typography/Description';
@@ -21,7 +22,6 @@ import {
   loadPassportDataAndSecret,
   reStorePassportDataWithRightCSCA,
 } from '@/providers/passportDataProvider';
-import { useProtocolStore } from '@/stores/protocolStore';
 import {
   black,
   slate300,

--- a/app/src/stores/protocolStore.ts
+++ b/app/src/stores/protocolStore.ts
@@ -22,7 +22,7 @@ import {
 } from '@selfxyz/common/constants';
 import type { DeployedCircuits, OfacTree } from '@selfxyz/common/utils/types';
 
-import { fetchOfacTrees } from '@/utils/ofac';
+import { fetchOfacTrees } from '@selfxyz/common/utils/ofac';
 
 interface ProtocolState {
   passport: {

--- a/app/src/utils/proving/provingInputs.ts
+++ b/app/src/utils/proving/provingInputs.ts
@@ -4,20 +4,10 @@
 
 import type { DocumentCategory, PassportData } from '@selfxyz/common/types';
 import type { SelfApp } from '@selfxyz/common/utils';
-import {
-  generateCircuitInputsRegister,
-  generateTEEInputsDiscloseStateless,
-  generateTEEInputsDSC,
-  generateTEEInputsRegister,
-} from '@selfxyz/common/utils/circuits/registerInputs';
+import { generateTEEInputsDiscloseStateless } from '@selfxyz/common/utils/circuits/registerInputs';
 
 import { useProtocolStore } from '@/stores/protocolStore';
 
-export {
-  generateCircuitInputsRegister,
-  generateTEEInputsDSC,
-  generateTEEInputsRegister,
-};
 export function generateTEEInputsDisclose(
   secret: string,
   passportData: PassportData,

--- a/app/src/utils/proving/provingInputs.ts
+++ b/app/src/utils/proving/provingInputs.ts
@@ -5,8 +5,7 @@
 import type { DocumentCategory, PassportData } from '@selfxyz/common/types';
 import type { SelfApp } from '@selfxyz/common/utils';
 import { generateTEEInputsDiscloseStateless } from '@selfxyz/common/utils/circuits/registerInputs';
-
-import { useProtocolStore } from '@/stores/protocolStore';
+import { useProtocolStore } from '@selfxyz/mobile-sdk-alpha/stores';
 
 export function generateTEEInputsDisclose(
   secret: string,

--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -45,6 +45,7 @@ import {
   PassportEvents,
   ProofEvents,
 } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+import { useProtocolStore } from '@selfxyz/mobile-sdk-alpha/stores';
 
 import { navigationRef } from '@/navigation';
 // will need to be passed in from selfClient
@@ -53,7 +54,6 @@ import {
   markCurrentDocumentAsRegistered,
   reStorePassportDataWithRightCSCA,
 } from '@/providers/passportDataProvider';
-import { useProtocolStore } from '@/stores/protocolStore';
 import { useSelfAppStore } from '@/stores/selfAppStore';
 import analytics from '@/utils/analytics';
 import { generateTEEInputsDisclose } from '@/utils/proving/provingInputs';

--- a/app/src/utils/proving/provingMachine.ts
+++ b/app/src/utils/proving/provingMachine.ts
@@ -18,6 +18,10 @@ import {
 } from '@selfxyz/common/utils';
 import { getPublicKey, verifyAttestation } from '@selfxyz/common/utils/attest';
 import {
+  generateTEEInputsDSC,
+  generateTEEInputsRegister,
+} from '@selfxyz/common/utils/circuits/registerInputs';
+import {
   checkDocumentSupported,
   checkIfPassportDscIsInTree,
   isDocumentNullified,
@@ -52,11 +56,7 @@ import {
 import { useProtocolStore } from '@/stores/protocolStore';
 import { useSelfAppStore } from '@/stores/selfAppStore';
 import analytics from '@/utils/analytics';
-import {
-  generateTEEInputsDisclose,
-  generateTEEInputsDSC,
-  generateTEEInputsRegister,
-} from '@/utils/proving/provingInputs';
+import { generateTEEInputsDisclose } from '@/utils/proving/provingInputs';
 
 const { trackEvent } = analytics();
 

--- a/app/src/utils/proving/validateDocument.ts
+++ b/app/src/utils/proving/validateDocument.ts
@@ -7,6 +7,7 @@ import { isUserRegistered } from '@selfxyz/common/utils/passports/validate';
 import type { PassportValidationCallbacks } from '@selfxyz/mobile-sdk-alpha';
 import { isPassportDataValid } from '@selfxyz/mobile-sdk-alpha';
 import { DocumentEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+import { useProtocolStore } from '@selfxyz/mobile-sdk-alpha/stores';
 
 import {
   getAllDocumentsDirectlyFromKeychain,
@@ -16,7 +17,6 @@ import {
   storePassportData,
   updateDocumentRegistrationState,
 } from '@/providers/passportDataProvider';
-import { useProtocolStore } from '@/stores/protocolStore';
 import analytics from '@/utils/analytics';
 
 const { trackEvent } = analytics();

--- a/app/tests/src/utils/proving/validateDocument.test.ts
+++ b/app/tests/src/utils/proving/validateDocument.test.ts
@@ -25,7 +25,7 @@ jest.mock('@/providers/passportDataProvider', () => ({
 }));
 
 // Mock the protocol store to avoid complex state management
-jest.mock('@/stores/protocolStore', () => ({
+jest.mock('@selfxyz/mobile-sdk-alpha/stores', () => ({
   useProtocolStore: {
     getState: jest.fn(() => ({
       passport: {

--- a/app/tests/utils/proving/provingMachine.generatePayload.test.ts
+++ b/app/tests/utils/proving/provingMachine.generatePayload.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import { useProtocolStore } from '@/stores/protocolStore';
+import { useProtocolStore } from '@selfxyz/mobile-sdk-alpha/stores';
+
 import { useSelfAppStore } from '@/stores/selfAppStore';
 import { useProvingStore } from '@/utils/proving/provingMachine';
 

--- a/app/tests/utils/proving/provingMachine.startFetchingData.test.ts
+++ b/app/tests/utils/proving/provingMachine.startFetchingData.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
 import type { SelfClient } from '@selfxyz/mobile-sdk-alpha';
+import { useProtocolStore } from '@selfxyz/mobile-sdk-alpha/stores';
 
-import { useProtocolStore } from '@/stores/protocolStore';
 import { useProvingStore } from '@/utils/proving/provingMachine';
 
 import { actorMock } from './actorMock';

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -17,6 +17,9 @@
       "@selfxyz/mobile-sdk-alpha/constants/analytics": [
         "../packages/mobile-sdk-alpha/dist/esm/constants/analytics.js"
       ],
+      "@selfxyz/mobile-sdk-alpha/stores": [
+        "../packages/mobile-sdk-alpha/dist/esm/stores.js"
+      ],
       "@/*": ["./src/*"]
     }
   },

--- a/common/package.json
+++ b/common/package.json
@@ -320,6 +320,11 @@
       "types": "./dist/esm/src/utils/passports/format.d.ts",
       "import": "./dist/esm/src/utils/passports/format.js",
       "require": "./dist/cjs/src/utils/passports/format.cjs"
+    },
+    "./utils/ofac": {
+      "types": "./dist/esm/src/utils/ofac.d.ts",
+      "import": "./dist/esm/src/utils/ofac.js",
+      "require": "./dist/cjs/src/utils/ofac.cjs"
     }
   },
   "main": "./dist/cjs/index.cjs",

--- a/common/scripts/shimConfigs.js
+++ b/common/scripts/shimConfigs.js
@@ -184,6 +184,11 @@ export const shimConfigs = [
     targetPath: '../../esm/src/utils/certificate_parsing/oids.js',
     name: 'utils/oids',
   },
+    {
+    shimPath: 'utils/ofac',
+    targetPath: '../../esm/src/utils/ofac.js',
+    name: 'utils/ofac',
+  },
   {
     shimPath: 'utils/passportDg1',
     targetPath: '../../esm/src/utils/passports/dg1.js',

--- a/common/scripts/shimConfigs.js
+++ b/common/scripts/shimConfigs.js
@@ -184,7 +184,7 @@ export const shimConfigs = [
     targetPath: '../../esm/src/utils/certificate_parsing/oids.js',
     name: 'utils/oids',
   },
-    {
+  {
     shimPath: 'utils/ofac',
     targetPath: '../../esm/src/utils/ofac.js',
     name: 'utils/ofac',

--- a/common/src/utils/index.ts
+++ b/common/src/utils/index.ts
@@ -6,6 +6,7 @@ export type {
 export type { DocumentCategory, PassportData } from './types.js';
 export type { IdDocInput } from './passports/genMockIdDoc.js';
 export type { PassportMetadata } from './passports/passport_parsing/parsePassportData.js';
+export type { TEEPayload, TEEPayloadBase, TEEPayloadDisclose } from './proving.js';
 export type { UserIdType } from './circuits/uuid.js';
 export {
   EndpointType,
@@ -41,7 +42,6 @@ export {
   generateNullifier,
   initPassportDataParsing,
 } from './passports/passport.js';
-export type { TEEPayload, TEEPayloadBase, TEEPayloadDisclose } from './proving.js';
 export { formatMrz } from './passports/format.js';
 export { genAndInitMockPassportData } from './passports/genMockPassportData.js';
 export {

--- a/common/src/utils/ofac.ts
+++ b/common/src/utils/ofac.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import { TREE_URL, TREE_URL_STAGING } from '@selfxyz/common/constants';
-import type { OfacTree } from '@selfxyz/common/utils/types';
+import { TREE_URL, TREE_URL_STAGING } from '../constants/constants.js';
+import type { OfacTree } from './types.js';
 
 export type OfacVariant = 'passport' | 'id_card';
 
@@ -16,9 +16,7 @@ const fetchTree = async (url: string): Promise<any> => {
   const responseData = await res.json();
   if (responseData.status !== 'success' || !responseData.data) {
     throw new Error(
-      `Failed to fetch tree from ${url}: ${
-        responseData.message || 'Invalid response format'
-      }`,
+      `Failed to fetch tree from ${url}: ${responseData.message || 'Invalid response format'}`
     );
   }
   return responseData.data;
@@ -27,17 +25,13 @@ const fetchTree = async (url: string): Promise<any> => {
 // Main public helper that retrieves the three OFAC trees depending on the variant (passport vs id_card).
 export const fetchOfacTrees = async (
   environment: 'prod' | 'stg',
-  variant: OfacVariant = 'passport',
+  variant: OfacVariant = 'passport'
 ): Promise<OfacTree> => {
   const baseUrl = environment === 'prod' ? TREE_URL : TREE_URL_STAGING;
 
   const ppNoNatUrl = `${baseUrl}/ofac/passport-no-nationality`;
-  const nameDobUrl = `${baseUrl}/ofac/name-dob${
-    variant === 'id_card' ? '-id' : ''
-  }`;
-  const nameYobUrl = `${baseUrl}/ofac/name-yob${
-    variant === 'id_card' ? '-id' : ''
-  }`;
+  const nameDobUrl = `${baseUrl}/ofac/name-dob${variant === 'id_card' ? '-id' : ''}`;
+  const nameYobUrl = `${baseUrl}/ofac/name-yob${variant === 'id_card' ? '-id' : ''}`;
 
   // For ID cards, we intentionally skip fetching the (large) passport-number-tree.
   if (variant === 'id_card') {

--- a/common/src/utils/passportData.ts
+++ b/common/src/utils/passportData.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 import type { PassportData } from './types.js';
 
 const fs = require('fs');

--- a/common/tsup.config.ts
+++ b/common/tsup.config.ts
@@ -52,6 +52,7 @@ const entry = {
   'src/utils/contracts/index': 'src/utils/contracts/index.ts',
   'src/utils/contracts/forbiddenCountries': 'src/utils/contracts/forbiddenCountries.ts',
   'src/utils/csca': 'src/utils/csca.ts',
+  'src/utils/ofac': 'src/utils/ofac.ts',
   // Level 3 Hash Function Exports
   'src/utils/hash/poseidon': 'src/utils/hash/poseidon.ts',
   'src/utils/hash/sha': 'src/utils/hash/sha.ts',

--- a/packages/mobile-sdk-alpha/package.json
+++ b/packages/mobile-sdk-alpha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/mobile-sdk-alpha",
-  "version": "2.6.4",
+  "version": "0.0.1",
   "description": "Self SDK (alpha) for registering and proving. Adapters-first, RN-first with web shims.",
   "keywords": [
     "self",
@@ -23,6 +23,11 @@
       "types": "./dist/esm/browser.d.ts",
       "import": "./dist/esm/browser.js",
       "require": "./dist/cjs/browser.cjs"
+    },
+    "./stores": {
+      "types": "./dist/esm/stores.d.ts",
+      "import": "./dist/esm/stores.js",
+      "require": "./dist/cjs/stores.cjs"
     },
     "./constants/analytics": {
       "types": "./dist/esm/constants/analytics.d.ts",
@@ -64,10 +69,11 @@
     "validate:pkg": "node ./scripts/verify-conditions.mjs"
   },
   "dependencies": {
-    "tslib": "^2.6.2"
+    "@selfxyz/common": "workspace:^",
+    "tslib": "^2.6.2",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
-    "@selfxyz/common": "workspace:^",
     "@testing-library/react": "^14.1.2",
     "@types/react": "^18.3.4",
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/packages/mobile-sdk-alpha/scripts/postBuild.mjs
+++ b/packages/mobile-sdk-alpha/scripts/postBuild.mjs
@@ -41,6 +41,7 @@ const distPackageJson = {
     '.': './esm/index.js',
     './browser': './esm/browser.js',
     './constants/analytics': './esm/constants/analytics.js',
+    './stores': './esm/stores.js',
   },
 };
 try {

--- a/packages/mobile-sdk-alpha/scripts/shimConfigs.js
+++ b/packages/mobile-sdk-alpha/scripts/shimConfigs.js
@@ -6,4 +6,5 @@
 export const shimConfigs = [
   { shimPath: 'browser', targetPath: '../esm/browser.js', name: 'browser' },
   { shimPath: 'constants/analytics', targetPath: '../../esm/constants/analytics.js', name: 'constants/analytics' },
+  { shimPath: 'stores', targetPath: '../esm/stores.js', name: 'stores' },
 ];

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -103,5 +103,7 @@ export { reactNativeScannerAdapter } from './adapters/react-native/scanner';
 
 export { scanQRProof } from './qr';
 
+export { useProtocolStore } from './stores/protocolStore';
+
 // Error handling
 export { webScannerShim } from './adapters/web/shims';

--- a/packages/mobile-sdk-alpha/src/stores/index.ts
+++ b/packages/mobile-sdk-alpha/src/stores/index.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+export { useProtocolStore } from './protocolStore';

--- a/packages/mobile-sdk-alpha/src/stores/protocolStore.ts
+++ b/packages/mobile-sdk-alpha/src/stores/protocolStore.ts
@@ -20,9 +20,8 @@ import {
   IDENTITY_TREE_URL_STAGING,
   IDENTITY_TREE_URL_STAGING_ID_CARD,
 } from '@selfxyz/common/constants';
-import type { DeployedCircuits, OfacTree } from '@selfxyz/common/utils/types';
-
 import { fetchOfacTrees } from '@selfxyz/common/utils/ofac';
+import type { DeployedCircuits, OfacTree } from '@selfxyz/common/utils/types';
 
 interface ProtocolState {
   passport: {
@@ -38,10 +37,7 @@ interface ProtocolState {
     fetch_csca_tree: (environment: 'prod' | 'stg') => Promise<void>;
     fetch_dsc_tree: (environment: 'prod' | 'stg') => Promise<void>;
     fetch_identity_tree: (environment: 'prod' | 'stg') => Promise<void>;
-    fetch_alternative_csca: (
-      environment: 'prod' | 'stg',
-      ski: string,
-    ) => Promise<void>;
+    fetch_alternative_csca: (environment: 'prod' | 'stg', ski: string) => Promise<void>;
     fetch_all: (environment: 'prod' | 'stg', ski: string) => Promise<void>;
     fetch_ofac_trees: (environment: 'prod' | 'stg') => Promise<void>;
   };
@@ -58,10 +54,7 @@ interface ProtocolState {
     fetch_csca_tree: (environment: 'prod' | 'stg') => Promise<void>;
     fetch_dsc_tree: (environment: 'prod' | 'stg') => Promise<void>;
     fetch_identity_tree: (environment: 'prod' | 'stg') => Promise<void>;
-    fetch_alternative_csca: (
-      environment: 'prod' | 'stg',
-      ski: string,
-    ) => Promise<void>;
+    fetch_alternative_csca: (environment: 'prod' | 'stg', ski: string) => Promise<void>;
     fetch_all: (environment: 'prod' | 'stg', ski: string) => Promise<void>;
     fetch_ofac_trees: (environment: 'prod' | 'stg') => Promise<void>;
   };
@@ -87,19 +80,14 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
         get().passport.fetch_alternative_csca(environment, ski),
       ]);
     },
-    fetch_alternative_csca: async (
-      environment: 'prod' | 'stg',
-      ski: string,
-    ) => {
+    fetch_alternative_csca: async (environment: 'prod' | 'stg', ski: string) => {
       const url = `${environment === 'prod' ? API_URL : API_URL_STAGING}/ski-pems/${ski.toLowerCase()}`; // TODO: remove false once we have the endpoint in production
       try {
         const response = await fetch(url, {
           method: 'GET',
         });
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -114,9 +102,7 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -130,9 +116,7 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -140,31 +124,22 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
           passport: { ...get().passport, circuits_dns_mapping: data.data },
         });
       } catch (error) {
-        console.error(
-          `Failed fetching circuit DNS mapping from ${url}:`,
-          error,
-        );
+        console.error(`Failed fetching circuit DNS mapping from ${url}:`, error);
       }
     },
     fetch_csca_tree: async (environment: 'prod' | 'stg') => {
-      const url =
-        environment === 'prod' ? CSCA_TREE_URL : CSCA_TREE_URL_STAGING;
+      const url = environment === 'prod' ? CSCA_TREE_URL : CSCA_TREE_URL_STAGING;
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const rawData = JSON.parse(responseText);
 
         let treeData: any;
         if (rawData && rawData.data) {
-          treeData =
-            typeof rawData.data === 'string'
-              ? JSON.parse(rawData.data)
-              : rawData.data;
+          treeData = typeof rawData.data === 'string' ? JSON.parse(rawData.data) : rawData.data;
         } else {
           treeData = rawData; // Assume rawData is the tree if no .data field
         }
@@ -179,9 +154,7 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -192,14 +165,11 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
       }
     },
     fetch_identity_tree: async (environment: 'prod' | 'stg') => {
-      const url =
-        environment === 'prod' ? IDENTITY_TREE_URL : IDENTITY_TREE_URL_STAGING;
+      const url = environment === 'prod' ? IDENTITY_TREE_URL : IDENTITY_TREE_URL_STAGING;
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -242,9 +212,7 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -259,9 +227,7 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -269,34 +235,23 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
           id_card: { ...get().id_card, circuits_dns_mapping: data.data },
         });
       } catch (error) {
-        console.error(
-          `Failed fetching circuit DNS mapping from ${url}:`,
-          error,
-        );
+        console.error(`Failed fetching circuit DNS mapping from ${url}:`, error);
         // Optionally handle error state
       }
     },
     fetch_csca_tree: async (environment: 'prod' | 'stg') => {
-      const url =
-        environment === 'prod'
-          ? CSCA_TREE_URL_ID_CARD
-          : CSCA_TREE_URL_STAGING_ID_CARD;
+      const url = environment === 'prod' ? CSCA_TREE_URL_ID_CARD : CSCA_TREE_URL_STAGING_ID_CARD;
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const rawData = JSON.parse(responseText);
 
         let treeData: any;
         if (rawData && rawData.data) {
-          treeData =
-            typeof rawData.data === 'string'
-              ? JSON.parse(rawData.data)
-              : rawData.data;
+          treeData = typeof rawData.data === 'string' ? JSON.parse(rawData.data) : rawData.data;
         } else {
           treeData = rawData; // Assume rawData is the tree if no .data field
         }
@@ -307,16 +262,11 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
       }
     },
     fetch_dsc_tree: async (environment: 'prod' | 'stg') => {
-      const url =
-        environment === 'prod'
-          ? DSC_TREE_URL_ID_CARD
-          : DSC_TREE_URL_STAGING_ID_CARD;
+      const url = environment === 'prod' ? DSC_TREE_URL_ID_CARD : DSC_TREE_URL_STAGING_ID_CARD;
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -327,16 +277,11 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
       }
     },
     fetch_identity_tree: async (environment: 'prod' | 'stg') => {
-      const url =
-        environment === 'prod'
-          ? IDENTITY_TREE_URL_ID_CARD
-          : IDENTITY_TREE_URL_STAGING_ID_CARD;
+      const url = environment === 'prod' ? IDENTITY_TREE_URL_ID_CARD : IDENTITY_TREE_URL_STAGING_ID_CARD;
       try {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);
@@ -346,19 +291,14 @@ export const useProtocolStore = create<ProtocolState>((set, get) => ({
         // Optionally handle error state
       }
     },
-    fetch_alternative_csca: async (
-      environment: 'prod' | 'stg',
-      ski: string,
-    ) => {
+    fetch_alternative_csca: async (environment: 'prod' | 'stg', ski: string) => {
       const url = `${environment === 'prod' ? API_URL : API_URL_STAGING}/ski-pems/${ski.toLowerCase()}`; // TODO: remove false once we have the endpoint in production
       try {
         const response = await fetch(url, {
           method: 'GET',
         });
         if (!response.ok) {
-          throw new Error(
-            `HTTP error fetching ${url}! status: ${response.status}`,
-          );
+          throw new Error(`HTTP error fetching ${url}! status: ${response.status}`);
         }
         const responseText = await response.text();
         const data = JSON.parse(responseText);

--- a/packages/mobile-sdk-alpha/tsup.config.ts
+++ b/packages/mobile-sdk-alpha/tsup.config.ts
@@ -10,6 +10,7 @@ const entry = {
   index: 'src/index.ts',
   browser: 'src/browser.ts',
   'constants/analytics': 'src/constants/analytics.ts',
+  stores: 'src/stores/index.ts',
 };
 
 export default defineConfig([

--- a/yarn.lock
+++ b/yarn.lock
@@ -4936,6 +4936,7 @@ __metadata:
     tsup: "npm:^8.0.1"
     typescript: "npm:^5.9.2"
     vitest: "npm:^1.6.0"
+    zustand: "npm:^4.5.2"
   peerDependencies:
     react: ^18.3.1
     react-native: ^0.76.9


### PR DESCRIPTION
ofac moves to common since its types were already there and its move of a util than an sdk piece (based on vibes) 

protoclstore moves to msdk since it is needed by the proving machine. 


msdk was missing some of its dependencies. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Protocol store exposed via the mobile SDK for easier app integration.
  - OFAC utility added and exported for downstream use.

- Refactor
  - App screens and proving logic updated to consume the shared SDK store.
  - Utility imports reorganized with no behavioral changes.

- Tests
  - Mocks and test imports updated to reflect the new shared store.

- Chores
  - Added module aliases, build entries, and package export entries to support new modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->