### PR TITLE
SDK: minimize amount of data sent through PROVING_PASSPORT_NOT_SUPPORTED event

### DIFF
--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -135,7 +135,8 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
       ({ passportData }) => {
         if (navigationRef.isReady()) {
           navigationRef.navigate('UnsupportedDocument', {
-            passportData,
+            countryCode: passportData.passportMetadata?.countryCode,
+            documentCategory: passportData.documentCategory,
           } as any);
         }
       },

--- a/app/src/screens/document/UnsupportedDocumentScreen.tsx
+++ b/app/src/screens/document/UnsupportedDocumentScreen.tsx
@@ -10,7 +10,7 @@ import { XStack, YStack } from 'tamagui';
 import type { RouteProp } from '@react-navigation/native';
 
 import { countryCodes } from '@selfxyz/common/constants';
-import type { PassportData } from '@selfxyz/common/types';
+import type { DocumentCategory } from '@selfxyz/common/types';
 import {
   hasAnyValidRegisteredDocument,
   useSelfClient,
@@ -39,7 +39,8 @@ type CountryFlagsRecord = Record<string, CountryFlagComponent>;
 type UnsupportedDocumentScreenRouteProp = RouteProp<
   {
     UnsupportedDocument: {
-      passportData: PassportData | null;
+      countryCode: string;
+      documentCategory: DocumentCategory;
     };
   },
   'UnsupportedDocument'
@@ -55,11 +56,10 @@ const UnsupportedDocumentScreen: React.FC<UnsupportedDocumentScreenProps> = ({
   const selfClient = useSelfClient();
   const navigateToLaunch = useHapticNavigation('Launch');
   const navigateToHome = useHapticNavigation('Home');
-  const passportData = route.params?.passportData;
 
   const { countryName, country2AlphaCode, documentTypeText } = useMemo(() => {
     try {
-      const countryCode = passportData?.passportMetadata?.countryCode;
+      const countryCode = route.params?.countryCode;
       if (countryCode) {
         // Handle Germany corner case where country code is "D<<" instead of "DEU"
         let normalizedCountryCode = countryCode;
@@ -74,7 +74,7 @@ const UnsupportedDocumentScreen: React.FC<UnsupportedDocumentScreenProps> = ({
         const name =
           countryCodes[normalizedCountryCode as keyof typeof countryCodes];
         const docType =
-          passportData?.documentCategory === 'id_card'
+          route.params?.documentCategory === 'id_card'
             ? 'ID Cards'
             : 'Passports';
         return {
@@ -87,13 +87,13 @@ const UnsupportedDocumentScreen: React.FC<UnsupportedDocumentScreenProps> = ({
       console.error('Error extracting country from passport data:', error);
     }
     const docType =
-      passportData?.documentCategory === 'id_card' ? 'ID Cards' : 'Passports';
+      route.params?.documentCategory === 'id_card' ? 'ID Cards' : 'Passports';
     return {
       countryName: 'Unknown',
       country2AlphaCode: 'Unknown',
       documentTypeText: docType,
     };
-  }, [passportData]);
+  }, [route.params?.documentCategory, route.params?.countryCode]);
 
   // Get country flag component dynamically
   const getCountryFlag = (code: string) => {
@@ -127,7 +127,7 @@ const UnsupportedDocumentScreen: React.FC<UnsupportedDocumentScreenProps> = ({
         countryName,
         countryCode:
           country2AlphaCode !== 'Unknown' ? country2AlphaCode : undefined,
-        documentCategory: passportData?.documentCategory,
+        documentCategory: route.params?.documentCategory,
       });
     } catch (error) {
       console.error('Failed to open email client:', error);

--- a/app/tests/utils/proving/provingMachine.test.ts
+++ b/app/tests/utils/proving/provingMachine.test.ts
@@ -81,7 +81,8 @@ describe('events', () => {
     expect(emitMock).toHaveBeenCalledWith(
       SdkEvents.PROVING_PASSPORT_NOT_SUPPORTED,
       {
-        passportData: mockPassportData,
+        countryCode: mockPassportData.passportMetadata?.countryCode,
+        documentCategory: mockPassportData.documentCategory,
       },
     );
   });


### PR DESCRIPTION
**Description**

As per [suggestion](https://github.com/selfxyz/self/pull/1011/files#r2333661129) this fix minimizes amount of data being sent over the event in question.

**Tested**

Adapted unit tests.