### PR TITLE
chore: speed up ios e2e builds

### DIFF
--- a/.github/actions/cache-built-deps/action.yml
+++ b/.github/actions/cache-built-deps/action.yml
@@ -18,7 +18,7 @@ runs:
         path: |
           common/dist
           packages/mobile-sdk-alpha/dist
-        key: built-deps-${{ inputs.cache-version }}-${{ hashFiles('common/**/*', 'packages/mobile-sdk-alpha/**/*', '!common/dist/**', '!packages/mobile-sdk-alpha/dist/**') }}
+        key: built-deps-${{ inputs.cache-version }}-${{ hashFiles('common/**/*', 'packages/mobile-sdk-alpha/**/*', '!common/dist/**', '!packages/mobile-sdk-alpha/dist/**', '!common/**/__tests__/**', '!common/**/*.test.*', '!common/**/*.spec.*', '!packages/mobile-sdk-alpha/**/__tests__/**', '!packages/mobile-sdk-alpha/**/*.test.*', '!packages/mobile-sdk-alpha/**/*.spec.*') }}
         fail-on-cache-miss: false
     - name: Save Built Dependencies
       if: steps.restore.outputs.cache-hit != 'true'
@@ -27,4 +27,4 @@ runs:
         path: |
           common/dist
           packages/mobile-sdk-alpha/dist
-        key: built-deps-${{ inputs.cache-version }}-${{ hashFiles('common/**/*', 'packages/mobile-sdk-alpha/**/*', '!common/dist/**', '!packages/mobile-sdk-alpha/dist/**') }}
+        key: built-deps-${{ inputs.cache-version }}-${{ hashFiles('common/**/*', 'packages/mobile-sdk-alpha/**/*', '!common/dist/**', '!packages/mobile-sdk-alpha/dist/**', '!common/**/__tests__/**', '!common/**/*.test.*', '!common/**/*.spec.*', '!packages/mobile-sdk-alpha/**/__tests__/**', '!packages/mobile-sdk-alpha/**/*.test.*', '!packages/mobile-sdk-alpha/**/*.spec.*') }}

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -241,9 +241,15 @@ jobs:
           echo "📱 Verifying iOS Runtime availability..."
           echo "Available iOS runtimes:"
           xcrun simctl list runtimes | grep iOS
-      - name: Build dependencies (outside main flow)
+      - name: Cache Built Dependencies
+        id: built-deps
+        uses: ./.github/actions/cache-built-deps
+        with:
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.NODE_VERSION_SANITIZED }}
+      - name: Build dependencies (cache miss)
+        if: steps.built-deps.outputs.cache-hit != 'true'
         run: |
-          echo "Building dependencies..."
+          echo "Cache miss for built dependencies. Building now..."
           yarn workspace @selfxyz/mobile-app run build:deps --silent || { echo "❌ Dependency build failed"; exit 1; }
           echo "✅ Dependencies built successfully"
       - name: Install iOS dependencies

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "analyze:tree-shaking:web": "yarn web:build && node ./scripts/analyze-tree-shaking.cjs web",
     "android": "yarn build:deps && react-native run-android",
     "android:ci": "./scripts/mobile-ci-build-android.sh",
-    "build:deps": "yarn workspaces foreach --from @selfxyz/mobile-app --topological --recursive run build",
+    "build:deps": "node ../scripts/build-deps-if-changed.mjs @selfxyz/mobile-app",
     "bump-version:major": "npm version major && yarn sync-versions",
     "bump-version:minor": "npm version minor && yarn sync-versions",
     "bump-version:patch": "npm version patch && yarn sync-versions",

--- a/packages/mobile-sdk-alpha/package.json
+++ b/packages/mobile-sdk-alpha/package.json
@@ -47,6 +47,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && tsup && yarn postbuild",
+    "build:deps": "node ../../scripts/build-deps-if-changed.mjs @selfxyz/mobile-sdk-alpha",
     "postbuild": "node ./scripts/postBuild.mjs",
     "demo:android": "yarn workspace demo-app android",
     "demo:ios": "yarn workspace demo-app ios",

--- a/scripts/build-deps-if-changed.mjs
+++ b/scripts/build-deps-if-changed.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+const workspace = process.argv[2];
+if (!workspace) {
+  console.error('Usage: build-deps-if-changed <workspace>');
+  process.exit(1);
+}
+
+const baseRef = process.env.GITHUB_BASE_REF
+  ? `origin/${process.env.GITHUB_BASE_REF}`
+  : 'origin/dev';
+let diff;
+try {
+  diff = execSync(`git diff --name-only ${baseRef}...HEAD`, {
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter(Boolean);
+} catch {
+  diff = [];
+}
+
+const deps =
+  {
+    '@selfxyz/mobile-app': [
+      ['@selfxyz/common', 'common/'],
+      ['@selfxyz/mobile-sdk-alpha', 'packages/mobile-sdk-alpha/'],
+    ],
+    '@selfxyz/mobile-sdk-alpha': [['@selfxyz/common', 'common/']],
+  }[workspace] || [];
+
+for (const [pkg, dir] of deps) {
+  const changed = diff.some(f => f.startsWith(dir));
+  if (changed) {
+    console.log(`Building ${pkg}...`);
+    execSync(`yarn workspace ${pkg} build`, { stdio: 'inherit' });
+  } else {
+    console.log(`Skipping ${pkg}; no changes`);
+  }
+}


### PR DESCRIPTION
## Summary
- avoid cache busts on test changes
- cache and reuse built deps in iOS E2E workflow
- add incremental dependency build helper

## Testing
- `yarn workspaces foreach -p -v --topological-dev --since=HEAD run nice --if-present` *(fails: Unable to resolve path to module '@selfxyz/mobile-sdk-alpha/constants/analytics')*
- `yarn lint` *(fails: Unable to resolve path to module '@selfxyz/mobile-sdk-alpha/constants/analytics')*
- `yarn build`
- `yarn workspace @selfxyz/contracts build` *(fails: Couldn't find a script named "hardhat")*
- `yarn types` *(fails: Cannot find module 'dompurify' or its corresponding type declarations)*
- `yarn workspace @selfxyz/mobile-sdk-alpha test`
- `yarn workspace @selfxyz/mobile-app test`


------
https://chatgpt.com/codex/tasks/task_b_68c06de14878832db6a58c29144c55e4