### PR TITLE
ci: enable android e2e and config cache

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -28,11 +28,10 @@ on:
 
 jobs:
   e2e-android:
-    if: false # Temporarily disable Android E2E until emulator disk issue resolved
     concurrency:
       group: ${{ github.workflow }}-android-${{ github.ref }}
       cancel-in-progress: true
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -87,6 +86,8 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Cache Gradle packages
         uses: ./.github/actions/cache-gradle
+        with:
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ hashFiles('app/android/gradle.properties') }}
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
@@ -102,8 +103,11 @@ jobs:
         run: |
           echo "Building Android APK..."
           chmod +x app/android/gradlew
-          (cd app/android && ./gradlew assembleDebug --quiet --parallel --build-cache --no-configuration-cache) || { echo "❌ Android build failed"; exit 1; }
+          (cd app/android && ./gradlew assembleDebug --quiet --parallel --build-cache) || { echo "❌ Android build failed"; exit 1; }
           echo "✅ Android build succeeded"
+      - name: Clean Android caches
+        run: |
+          rm -rf ~/.android/avd/* ~/.gradle/caches/*
       - name: Install and Test on Android
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -111,7 +115,7 @@ jobs:
           arch: x86_64
           target: google_apis
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -memory 8192 -cores 4 -accel on
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -memory 8192 -cores 4 -accel on -partition-size 4096
           disable-animations: true
           script: |
             echo "Installing app on emulator..."

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -48,6 +48,7 @@ android.jetifier.ignorelist=bcprov-jdk18on
 # Additional Gradle optimizations for better build performance
 org.gradle.caching=true
 org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
 
 # Better dependency caching and offline support
 org.gradle.dependency.verification=off


### PR DESCRIPTION
## Summary
- reenable android E2E workflow with 60m timeout
- clean emulator caches and increase disk partition
- enable Gradle configuration caching

## Testing
- `yarn workspaces foreach -A -p -v --topological-dev --since=HEAD run nice --if-present` *(fails: Invalid option schema)*
- `yarn workspace @selfxyz/mobile-app run nice` *(fails: write EPIPE)*
- `yarn lint` *(fails: exit code 129)*
- `yarn build` *(fails: exit code 129)*
- `yarn workspace @selfxyz/contracts build` *(fails: Couldn't find a script named "hardhat".)*
- `yarn types` *(fails: Cannot find module '@anon-aadhaar/core')*
- `yarn workspace @selfxyz/mobile-app test` *(fails: exit code 129)*

------
https://chatgpt.com/codex/tasks/task_b_68c60cc7b950832dbf52feb6e72a8a93