### PR TITLE
ci: enable android e2e and config cache

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -158,59 +158,173 @@ jobs:
           (cd android && ./gradlew assembleRelease --quiet --parallel --build-cache --no-configuration-cache) || { echo "❌ Android build failed"; exit 1; }
           echo " Android build succeeded"
 
-      # Run E2E tests on Android emulator
-      - name: Install and Test on Android
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.ANDROID_API_LEVEL }}
-          arch: x86_64
-          target: google_apis
-          force-avd-creation: false
-          emulator-boot-timeout: 900
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -memory 8192 -cores 4 -accel on
-          disable-animations: true
-          script: |
-            echo "Installing app on emulator..."
-            APK_PATH="app/android/app/build/outputs/apk/release/app-release.apk"
-            [ -f "$APK_PATH" ] || { echo "❌ APK not found at $APK_PATH"; exit 1; }
-            adb install -r "$APK_PATH" || { echo "❌ App installation failed"; exit 1; }
-            echo " App installed successfully"
+      # Manual emulator setup for better debugging and control
+      - name: Create Android Virtual Device
+        run: |
+          echo "Creating AVD with manual setup..."
+          echo "Available system images:"
+          sdkmanager --list | grep "system-images;android-${{ env.ANDROID_API_LEVEL }}" | head -5
 
-            echo " Warming up app process..."
-            adb shell pm list packages | grep com.proofofpassportapp || { echo "app not installed"; exit 1; }
-            adb shell monkey -p com.proofofpassportapp -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
-            sleep 3
+          # Create AVD manually with explicit configuration
+          echo "no" | avdmanager create avd \
+            --force \
+            --name ci_emulator \
+            --abi google_apis/x86_64 \
+            --package "system-images;android-${{ env.ANDROID_API_LEVEL }};google_apis;x86_64"
 
-            echo " Clearing logcat..."
-            adb logcat -c || true
+          echo "AVD created successfully"
+          avdmanager list avd
 
-            #  Retry mechanism for flaky tests
-            echo " Running Maestro tests with retry logic..."
-            export MAESTRO_DRIVER_STARTUP_TIMEOUT=240000
+      - name: Start Android Emulator
+        run: |
+          echo "Starting emulator with optimized settings..."
+          echo "Available emulator binaries:"
+          ls -la $ANDROID_HOME/emulator/
 
-            for attempt in 1 2 3; do
-              echo "Test attempt $attempt of 3..."
-              set +e
-              maestro test app/tests/e2e/launch.android.flow.yaml --format junit --output app/maestro-results.xml
-              TEST_EXIT=$?
-              set -e
+          # Start emulator in background with optimized settings for CI
+          nohup $ANDROID_HOME/emulator/emulator \
+            -avd ci_emulator \
+            -no-window \
+            -gpu swiftshader_indirect \
+            -noaudio \
+            -no-boot-anim \
+            -camera-back none \
+            -camera-front none \
+            -memory 6144 \
+            -cores 2 \
+            -accel on \
+            -no-snapshot-save \
+            -partition-size 4096 \
+            -verbose \
+            > emulator.log 2>&1 &
 
-              if [ $TEST_EXIT -eq 0 ]; then
-                echo " Tests passed on attempt $attempt"
-                break
-              elif [ $attempt -eq 3 ]; then
-                echo "❌ Tests failed after 3 attempts"
-              else
-                echo " Attempt $attempt failed, retrying..."
-                sleep 10
-              fi
-            done
+          echo "Emulator started in background, PID: $!"
+          echo "Emulator log location: $(pwd)/emulator.log"
 
-            adb logcat -d > app/maestro-logcat.txt || true
-            maestro hierarchy --app com.proofofpassportapp > app/maestro-hierarchy.txt || true
-            exit $TEST_EXIT
+      - name: Wait for Emulator Boot
+        run: |
+          echo "Waiting for emulator to boot..."
+          boot_timeout=900  # 15 minutes
+          boot_counter=0
+
+          # Wait for device to be detected
+          echo "Waiting for device detection..."
+          while [ $boot_counter -lt $boot_timeout ]; do
+            if adb devices | grep -q "emulator-"; then
+              echo "Device detected after ${boot_counter}s"
+              break
+            fi
+            if [ $((boot_counter % 30)) -eq 0 ]; then
+              echo "Still waiting for device... (${boot_counter}s elapsed)"
+              echo "Current devices:"
+              adb devices
+              echo "Emulator log tail:"
+              tail -10 emulator.log || echo "No emulator log yet"
+            fi
+            sleep 2
+            boot_counter=$((boot_counter + 2))
+          done
+
+          if [ $boot_counter -ge $boot_timeout ]; then
+            echo "❌ Device detection timeout after ${boot_timeout}s"
+            echo "Final emulator log:"
+            cat emulator.log || echo "No emulator log available"
+            exit 1
+          fi
+
+          # Wait for boot completion
+          echo "Device detected, waiting for boot completion..."
+          adb wait-for-device
+
+          boot_counter=0
+          while [ $boot_counter -lt $boot_timeout ]; do
+            boot_completed=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || echo "")
+            if [ "$boot_completed" = "1" ]; then
+              echo "Boot completed after ${boot_counter}s"
+              break
+            fi
+            if [ $((boot_counter % 30)) -eq 0 ]; then
+              echo "Still waiting for boot completion... (${boot_counter}s elapsed)"
+              echo "Boot status: '$boot_completed'"
+            fi
+            sleep 2
+            boot_counter=$((boot_counter + 2))
+          done
+
+          if [ $boot_counter -ge $boot_timeout ]; then
+            echo "❌ Boot completion timeout after ${boot_timeout}s"
+            echo "Final boot status: '$boot_completed'"
+            echo "Final emulator log:"
+            tail -50 emulator.log || echo "No emulator log available"
+            exit 1
+          fi
+
+          # Final readiness check
+          echo "Performing final readiness check..."
+          adb shell input keyevent 82  # Menu key to wake up
+          sleep 2
+
+          echo "✅ Emulator ready!"
+          echo "Final device status:"
+          adb devices
+          echo "System properties:"
+          adb shell getprop | grep -E "(boot|sys|init)" | head -10
+
+      - name: Install and Test App on Emulator
+        run: |
+          echo "Installing app on emulator..."
+          APK_PATH="app/android/app/build/outputs/apk/release/app-release.apk"
+          [ -f "$APK_PATH" ] || { echo "❌ APK not found at $APK_PATH"; exit 1; }
+          adb install -r "$APK_PATH" || { echo "❌ App installation failed"; exit 1; }
+          echo "✅ App installed successfully"
+
+          echo "Warming up app process..."
+          adb shell pm list packages | grep com.proofofpassportapp || { echo "app not installed"; exit 1; }
+          adb shell monkey -p com.proofofpassportapp -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
+          sleep 3
+
+          echo "Clearing logcat..."
+          adb logcat -c || true
+
+          echo "Running Maestro tests with retry logic..."
+          export MAESTRO_DRIVER_STARTUP_TIMEOUT=240000
+
+          for attempt in 1 2 3; do
+            echo "Test attempt $attempt of 3..."
+            set +e
+            maestro test app/tests/e2e/launch.android.flow.yaml --format junit --output app/maestro-results.xml
+            TEST_EXIT=$?
+            set -e
+
+            if [ $TEST_EXIT -eq 0 ]; then
+              echo "✅ Tests passed on attempt $attempt"
+              break
+            elif [ $attempt -eq 3 ]; then
+              echo "❌ Tests failed after 3 attempts"
+            else
+              echo "⚠️ Attempt $attempt failed, retrying..."
+              sleep 10
+            fi
+          done
+
+          # Collect debug information
+          adb logcat -d > app/maestro-logcat.txt || true
+          maestro hierarchy --app com.proofofpassportapp > app/maestro-hierarchy.txt || true
+
+          # Save emulator log for debugging
+          cp emulator.log app/emulator.log || true
+
+          exit $TEST_EXIT
         env:
           E2E_BUILD: "true"
+
+      - name: Cleanup Emulator
+        if: always()
+        run: |
+          echo "Cleaning up emulator..."
+          adb emu kill || true
+          pkill -f "emulator" || true
+          sleep 5
 
       - name: Upload test results
         if: always()
@@ -221,6 +335,7 @@ jobs:
             app/maestro-results.xml
             app/maestro-logcat.txt
             app/maestro-hierarchy.txt
+            app/emulator.log
           if-no-files-found: warn
       - name: Terminate crashpad_handler
         if: always()

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -90,6 +90,13 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           accept-android-sdk-licenses: true
+          packages: |
+            tools
+            platform-tools
+            platforms;android-${{ env.ANDROID_API_LEVEL }}
+            build-tools;35.0.0
+            emulator
+            system-images;android-${{ env.ANDROID_API_LEVEL }};google_apis;x86_64
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -110,6 +117,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ env.ANDROID_API_LEVEL }}
+          arch: x86_64
+          target: google_apis
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: echo "Generated AVD snapshot for caching."
@@ -124,8 +133,8 @@ jobs:
           chmod +x app/android/gradlew
           (cd app/android && ./gradlew assembleDebug --quiet --parallel --build-cache) || { echo "❌ Android build failed"; exit 1; }
           echo "✅ Android build succeeded"
-      - name: Clean Gradle cache
-        run: rm -rf ~/.gradle/caches/*
+      - name: Clean Android/Gradle caches
+        run: rm -rf ~/.gradle/caches/* ~/.android/adb*
       - name: Install and Test on Android
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -136,7 +145,7 @@ jobs:
           ram-size: 2048M
           cores: 2
           disk-size: 4096M
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096
           disable-animations: true
           script: |
             echo "Installing app on emulator..."

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -92,9 +92,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: ${{ env.JAVA_VERSION }}
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
         # Cache Gradle Dependencies
       - name: Cache Gradle dependencies
         uses: actions/cache@v4
@@ -158,7 +155,7 @@ jobs:
         run: |
           echo "Building Android APK..."
           chmod +x android/gradlew
-          (cd android && ./gradlew assembleDebug --quiet --parallel) || { echo "❌ Android build failed"; exit 1; }
+          (cd android && ./gradlew assembleRelease --quiet --parallel --build-cache --no-configuration-cache) || { echo "❌ Android build failed"; exit 1; }
           echo " Android build succeeded"
 
       # Run E2E tests on Android emulator
@@ -169,14 +166,14 @@ jobs:
           arch: x86_64
           target: google_apis
           force-avd-creation: false
-          ram-size: 2048M
-          heap-size: 512M
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          emulator-boot-timeout: 900
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -memory 8192 -cores 4 -accel on
           disable-animations: true
           script: |
             echo "Installing app on emulator..."
-            test -f app/android/app/build/outputs/apk/debug/app-debug.apk || { echo "❌ APK not found at app/android/app/build/outputs/apk/debug/app-debug.apk"; exit 1; }
-            adb install -r app/android/app/build/outputs/apk/debug/app-debug.apk || { echo "❌ App installation failed"; exit 1; }
+            APK_PATH="app/android/app/build/outputs/apk/release/app-release.apk"
+            [ -f "$APK_PATH" ] || { echo "❌ APK not found at $APK_PATH"; exit 1; }
+            adb install -r "$APK_PATH" || { echo "❌ App installation failed"; exit 1; }
             echo " App installed successfully"
 
             echo " Warming up app process..."
@@ -212,6 +209,8 @@ jobs:
             adb logcat -d > app/maestro-logcat.txt || true
             maestro hierarchy --app com.proofofpassportapp > app/maestro-hierarchy.txt || true
             exit $TEST_EXIT
+        env:
+          E2E_BUILD: "true"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -90,13 +90,13 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           accept-android-sdk-licenses: true
-          packages: |
-            tools
-            platform-tools
-            platforms;android-${{ env.ANDROID_API_LEVEL }}
-            build-tools;35.0.0
-            emulator
-            system-images;android-${{ env.ANDROID_API_LEVEL }};google_apis;x86_64
+      - name: Install Android packages
+        run: |
+          sdkmanager "platform-tools" \
+            "platforms;android-${{ env.ANDROID_API_LEVEL }}" \
+            "build-tools;35.0.0" \
+            "emulator" \
+            "system-images;android-${{ env.ANDROID_API_LEVEL }};google_apis;x86_64"
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -153,9 +153,8 @@ jobs:
           disable-animations: true
           script: |
             echo "Installing app on emulator..."
-            APK_PATH="app/android/app/build/outputs/apk/debug/app-debug.apk"
-            [ -f "$APK_PATH" ] || { echo "❌ APK not found at $APK_PATH"; exit 1; }
-            adb install -r "$APK_PATH" || { echo "❌ App installation failed"; exit 1; }
+            test -f app/android/app/build/outputs/apk/debug/app-debug.apk || { echo "❌ APK not found at app/android/app/build/outputs/apk/debug/app-debug.apk"; exit 1; }
+            adb install -r app/android/app/build/outputs/apk/debug/app-debug.apk || { echo "❌ App installation failed"; exit 1; }
             echo "✅ App installed successfully"
 
             echo "⏰ Giving the emulator a moment to settle..."

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -90,6 +90,10 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           accept-android-sdk-licenses: true
+      - name: Free disk space
+        run: |
+          sudo rm -rf "$ANDROID_HOME/system-images" "$ANDROID_HOME/ndk" || true
+          rm -rf ~/.gradle/caches/* ~/.android/avd/* ~/.android/adb* || true
       - name: Install Android packages
         run: |
           sdkmanager "platform-tools" \
@@ -131,7 +135,7 @@ jobs:
         run: |
           echo "Building Android APK..."
           chmod +x app/android/gradlew
-          (cd app/android && ./gradlew assembleDebug --quiet --parallel --build-cache) || { echo "❌ Android build failed"; exit 1; }
+            (cd app/android && ./gradlew assembleDebug --quiet --parallel) || { echo "❌ Android build failed"; exit 1; }
           echo "✅ Android build succeeded"
       - name: Clean Android/Gradle caches
         run: rm -rf ~/.gradle/caches/* ~/.android/adb*

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -28,11 +28,10 @@ on:
 
 jobs:
   e2e-android:
-    if: false # Temporarily disable Android E2E until emulator disk issue resolved
     concurrency:
       group: ${{ github.workflow }}-android-${{ github.ref }}
       cancel-in-progress: true
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -85,14 +84,35 @@ jobs:
         with:
           distribution: "temurin"
           java-version: ${{ env.JAVA_VERSION }}
-      - name: Cache Gradle packages
-        uses: ./.github/actions/cache-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
           accept-android-sdk-licenses: true
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Install NDK
         run: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
+      - name: AVD cache
+        id: avd-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.ANDROID_API_LEVEL }}
+      - name: Create AVD snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.ANDROID_API_LEVEL }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: echo "Generated AVD snapshot for caching."
       - name: Build dependencies (outside emulator)
         run: |
           echo "Building dependencies..."
@@ -102,8 +122,10 @@ jobs:
         run: |
           echo "Building Android APK..."
           chmod +x app/android/gradlew
-          (cd app/android && ./gradlew assembleDebug --quiet --parallel --build-cache --no-configuration-cache) || { echo "❌ Android build failed"; exit 1; }
+          (cd app/android && ./gradlew assembleDebug --quiet --parallel --build-cache) || { echo "❌ Android build failed"; exit 1; }
           echo "✅ Android build succeeded"
+      - name: Clean Gradle cache
+        run: rm -rf ~/.gradle/caches/*
       - name: Install and Test on Android
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -111,7 +133,10 @@ jobs:
           arch: x86_64
           target: google_apis
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -memory 8192 -cores 4 -accel on
+          ram-size: 2048M
+          cores: 2
+          disk-size: 4096M
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           disable-animations: true
           script: |
             echo "Installing app on emulator..."
@@ -133,6 +158,14 @@ jobs:
           name: maestro-results-android
           path: app/maestro-results.xml
           if-no-files-found: warn
+      - name: Terminate crashpad_handler
+        if: always()
+        run: |
+          pkill -f -SIGTERM crashpad_handler || true
+          sleep 5
+          if pgrep -f crashpad_handler > /dev/null; then
+            pkill -f -SIGKILL crashpad_handler || true
+          fi
 
   e2e-ios:
     timeout-minutes: 45

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -161,26 +161,106 @@ jobs:
       # Manual emulator setup for better debugging and control
       - name: Create Android Virtual Device
         run: |
-          echo "Creating AVD with manual setup..."
-          echo "Available system images:"
-          sdkmanager --list | grep "system-images;android-${{ env.ANDROID_API_LEVEL }}" | head -5
+          echo "=== Creating AVD with manual setup ==="
 
-          # Create AVD manually with explicit configuration
+          echo "Android SDK locations:"
+          echo "ANDROID_HOME: $ANDROID_HOME"
+          echo "ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT"
+          echo "HOME: $HOME"
+          ls -la $HOME/.android/ || echo "No .android directory yet"
+
+          echo "Available system images:"
+          sdkmanager --list | grep "system-images;android-${{ env.ANDROID_API_LEVEL }}" | head -10
+
+          echo "Checking if required system image is installed:"
+          SYSTEM_IMAGE="system-images;android-${{ env.ANDROID_API_LEVEL }};google_apis;x86_64"
+          echo "Looking for: $SYSTEM_IMAGE"
+
+          if ! sdkmanager --list | grep -q "^$SYSTEM_IMAGE"; then
+            echo "System image not found in installed packages. Installing..."
+            sdkmanager "$SYSTEM_IMAGE" || { echo "❌ Failed to install system image"; exit 1; }
+          else
+            echo "✅ System image already installed"
+          fi
+
+          echo "Ensuring SDK licenses are accepted..."
+          yes | sdkmanager --licenses || echo "License acceptance completed (some may have been already accepted)"
+
+          echo "Creating AVD directory structure..."
+          mkdir -p "$HOME/.android/avd" || { echo "❌ Failed to create AVD directory"; exit 1; }
+
+          echo "Attempting to create AVD..."
+          set -x  # Enable command tracing
+
+          # Method 1: Standard creation with input
           echo "no" | avdmanager create avd \
             --force \
             --name ci_emulator \
             --abi google_apis/x86_64 \
-            --package "system-images;android-${{ env.ANDROID_API_LEVEL }};google_apis;x86_64"
+            --package "$SYSTEM_IMAGE" || {
+              echo "❌ Method 1 failed, trying method 2..."
 
-          echo "AVD created successfully"
+              # Method 2: Creation with device specification
+              avdmanager create avd \
+                --force \
+                --name ci_emulator \
+                --abi google_apis/x86_64 \
+                --package "$SYSTEM_IMAGE" \
+                --device "pixel" < /dev/null || {
+                echo "❌ Method 2 failed, trying method 3..."
+
+                # Method 3: Accept all prompts automatically
+                yes '' | timeout 30 avdmanager create avd \
+                  --force \
+                  --name ci_emulator \
+                  --abi google_apis/x86_64 \
+                  --package "$SYSTEM_IMAGE" || {
+                  echo "❌ All AVD creation methods failed"
+                  echo "Detailed debugging:"
+                  echo "Java version:"
+                  java -version
+                  echo "Available packages:"
+                  sdkmanager --list | grep -E "(system-images|platforms)" | head -20
+                  echo "SDK manager licenses:"
+                  sdkmanager --licenses
+                  exit 1
+                }
+              }
+            }
+          set +x  # Disable command tracing
+
+          echo "Verifying AVD creation..."
+          if avdmanager list avd | grep -q "ci_emulator"; then
+            echo "✅ AVD created successfully"
+          else
+            echo "❌ AVD creation verification failed"
+            echo "Available AVDs:"
+            avdmanager list avd
+            echo "AVD directory contents:"
+            ls -la "$HOME/.android/avd/" || echo "AVD directory not found"
+            exit 1
+          fi
+
+          echo "Final AVD list:"
           avdmanager list avd
 
       - name: Start Android Emulator
         run: |
-          echo "Starting emulator with optimized settings..."
+          echo "=== Starting emulator with optimized settings ==="
+
+          echo "Verifying AVD exists before starting..."
+          if ! avdmanager list avd | grep -q "ci_emulator"; then
+            echo "❌ AVD 'ci_emulator' not found!"
+            echo "Available AVDs:"
+            avdmanager list avd
+            exit 1
+          fi
+          echo "✅ AVD 'ci_emulator' confirmed to exist"
+
           echo "Available emulator binaries:"
           ls -la $ANDROID_HOME/emulator/
 
+          echo "Starting emulator in background..."
           # Start emulator in background with optimized settings for CI
           nohup $ANDROID_HOME/emulator/emulator \
             -avd ci_emulator \
@@ -190,7 +270,7 @@ jobs:
             -no-boot-anim \
             -camera-back none \
             -camera-front none \
-            -memory 6144 \
+            -memory 4096 \
             -cores 2 \
             -accel on \
             -no-snapshot-save \
@@ -198,8 +278,14 @@ jobs:
             -verbose \
             > emulator.log 2>&1 &
 
-          echo "Emulator started in background, PID: $!"
+          EMULATOR_PID=$!
+          echo "✅ Emulator started in background, PID: $EMULATOR_PID"
           echo "Emulator log location: $(pwd)/emulator.log"
+
+          # Give emulator a moment to start writing to log
+          sleep 5
+          echo "Initial emulator log:"
+          head -20 emulator.log || echo "No log output yet"
 
       - name: Wait for Emulator Boot
         run: |
@@ -308,13 +394,13 @@ jobs:
           done
 
           # Collect debug information
-          adb logcat -d > app/maestro-logcat.txt || true
-          maestro hierarchy --app com.proofofpassportapp > app/maestro-hierarchy.txt || true
+            adb logcat -d > app/maestro-logcat.txt || true
+            maestro hierarchy --app com.proofofpassportapp > app/maestro-hierarchy.txt || true
 
           # Save emulator log for debugging
           cp emulator.log app/emulator.log || true
 
-          exit $TEST_EXIT
+            exit $TEST_EXIT
         env:
           E2E_BUILD: "true"
 
@@ -535,8 +621,8 @@ jobs:
             echo "Creating reliable CI simulator..."
             SIMULATOR_ID=$(xcrun simctl create "CI-iPhone" "iPhone 15" 2>/dev/null || xcrun simctl create "CI-iPhone-SE" "iPhone SE (3rd generation)")
             if [ -z "$SIMULATOR_ID" ]; then
-              echo "❌ Failed to create simulator"
-              exit 1
+                echo "❌ Failed to create simulator"
+                exit 1
             fi
             SIMULATOR_NAME="CI-iPhone"
           fi
@@ -551,7 +637,7 @@ jobs:
             sleep 5
             xcrun simctl boot "$SIMULATOR_ID" || {
               echo "❌ Failed to boot simulator after retry"
-              exit 1
+            exit 1
             }
           }
 

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -143,19 +143,7 @@ jobs:
             ~/.android/adb*
           key: avd-${{ env.ANDROID_API_LEVEL }}
 
-          # Better emulator stability
-      - name: Create AVD snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.ANDROID_API_LEVEL }}
-          arch: x86_64
-          target: google_apis
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -memory 3072 -cores 2 -accel on
-          script: echo "Generated AVD snapshot for caching."
-
-      #  Use cached dependencies (only build if cache miss)
+      # Use cached dependencies (only build if cache miss)
       - name: Build dependencies (cache miss only)
         if: steps.built-deps.outputs.cache-hit != 'true'
         run: |
@@ -173,7 +161,7 @@ jobs:
           (cd android && ./gradlew assembleDebug --quiet --parallel) || { echo "❌ Android build failed"; exit 1; }
           echo " Android build succeeded"
 
-      #  Better emulator configuration and retry logic
+      # Run E2E tests on Android emulator
       - name: Install and Test on Android
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -181,10 +169,9 @@ jobs:
           arch: x86_64
           target: google_apis
           force-avd-creation: false
-          ram-size: 3072M
-          cores: 2
-          disk-size: 4096M
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096 -memory 3072 -cores 2 -accel on
+          ram-size: 2048M
+          heap-size: 512M
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           disable-animations: true
           script: |
             echo "Installing app on emulator..."

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -137,8 +137,8 @@ jobs:
           chmod +x app/android/gradlew
             (cd app/android && ./gradlew assembleDebug --quiet --parallel) || { echo "❌ Android build failed"; exit 1; }
           echo "✅ Android build succeeded"
-      - name: Clean Android/Gradle caches
-        run: rm -rf ~/.gradle/caches/* ~/.android/adb*
+      - name: Clean Android caches
+        run: rm -rf ~/.android/adb*
       - name: Install and Test on Android
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -146,7 +146,7 @@ jobs:
           arch: x86_64
           target: google_apis
           force-avd-creation: false
-          ram-size: 2048M
+          ram-size: 3072M
           cores: 2
           disk-size: 4096M
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096
@@ -157,18 +157,31 @@ jobs:
             adb install -r app/android/app/build/outputs/apk/debug/app-debug.apk || { echo "❌ App installation failed"; exit 1; }
             echo "✅ App installed successfully"
 
-            echo "⏰ Giving the emulator a moment to settle..."
-            sleep 5
+            echo "⏰ Warming up app process..."
+            adb shell pm list packages | grep com.proofofpassportapp || { echo "app not installed"; exit 1; }
+            adb shell monkey -p com.proofofpassportapp -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
+            sleep 3
+
+            echo "🧹 Clearing logcat..."
+            adb logcat -c || true
 
             echo "🎭 Running Maestro tests..."
-            export MAESTRO_DRIVER_STARTUP_TIMEOUT=180000
+            export MAESTRO_DRIVER_STARTUP_TIMEOUT=240000
+            set +e
             maestro test app/tests/e2e/launch.android.flow.yaml --format junit --output app/maestro-results.xml
+            TEST_EXIT=$?
+            adb logcat -d > app/maestro-logcat.txt || true
+            maestro hierarchy --app com.proofofpassportapp > app/maestro-hierarchy.txt || true
+            exit $TEST_EXIT
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-results-android
-          path: app/maestro-results.xml
+          name: maestro-artifacts-android
+          path: |
+            app/maestro-results.xml
+            app/maestro-logcat.txt
+            app/maestro-hierarchy.txt
           if-no-files-found: warn
       - name: Terminate crashpad_handler
         if: always()

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -9,8 +9,8 @@ env:
   # Cache versions
   GH_CACHE_VERSION: v1 # Global cache version
   GH_GEMS_CACHE_VERSION: v1 # Ruby gems cache version
-  # Performance optimizations
-  GRADLE_OPTS: -Dorg.gradle.workers.max=4 -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
+  # Performance optimizations (enhanced)
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4 -Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.caching=true -Dorg.gradle.buildcache=true
   CI: true
   # Disable Maestro analytics in CI
   MAESTRO_CLI_NO_ANALYTICS: true
@@ -65,6 +65,14 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
         run: echo "YARN_ENABLE_HARDENED_MODE=0" >> $GITHUB_ENV
       - run: yarn install --immutable --silent
+
+      # Cache Built Dependencies
+      - name: Cache Built Dependencies
+        id: built-deps
+        uses: ./.github/actions/cache-built-deps
+        with:
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.NODE_VERSION_SANITIZED }}
+
       - name: Validate Maestro test file
         run: |
           [ -f app/tests/e2e/launch.android.flow.yaml ] || { echo "❌ Android E2E test file missing"; exit 1; }
@@ -86,14 +94,32 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+
+        # Cache Gradle Dependencies
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            app/android/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('app/android/**/*.gradle*', 'app/android/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
           accept-android-sdk-licenses: true
-      - name: Free disk space
+
+      # Selective disk space cleanup
+      - name: Free disk space (selective)
         run: |
-          sudo rm -rf "$ANDROID_HOME/system-images" "$ANDROID_HOME/ndk" || true
-          rm -rf ~/.gradle/caches/* ~/.android/avd/* ~/.android/adb* || true
+          sudo rm -rf /opt/ghc* /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          # Avoid breaking system packages
+          rm -rf ~/.android/avd/* || true
+
       - name: Install Android packages
         run: |
           sdkmanager "platform-tools" \
@@ -116,6 +142,8 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-${{ env.ANDROID_API_LEVEL }}
+
+          # Better emulator stability
       - name: Create AVD snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
@@ -124,21 +152,28 @@ jobs:
           arch: x86_64
           target: google_apis
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -memory 3072 -cores 2 -accel on
           script: echo "Generated AVD snapshot for caching."
-      - name: Build dependencies (outside emulator)
+
+      #  Use cached dependencies (only build if cache miss)
+      - name: Build dependencies (cache miss only)
+        if: steps.built-deps.outputs.cache-hit != 'true'
         run: |
-          echo "Building dependencies..."
+          echo "Cache miss for built dependencies. Building now..."
           yarn workspace @selfxyz/mobile-app run build:deps --silent || { echo "❌ Dependency build failed"; exit 1; }
-          echo "✅ Dependencies built successfully"
+          echo " Dependencies built successfully"
+
       - name: Build Android APK
+        working-directory: app
+        env:
+          JAVA_OPTS: -Xmx2g
         run: |
           echo "Building Android APK..."
-          chmod +x app/android/gradlew
-            (cd app/android && ./gradlew assembleDebug --quiet --parallel) || { echo "❌ Android build failed"; exit 1; }
-          echo "✅ Android build succeeded"
-      - name: Clean Android caches
-        run: rm -rf ~/.android/adb*
+          chmod +x android/gradlew
+          (cd android && ./gradlew assembleDebug --quiet --parallel) || { echo "❌ Android build failed"; exit 1; }
+          echo " Android build succeeded"
+
+      #  Better emulator configuration and retry logic
       - name: Install and Test on Android
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -149,30 +184,48 @@ jobs:
           ram-size: 3072M
           cores: 2
           disk-size: 4096M
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096 -memory 3072 -cores 2 -accel on
           disable-animations: true
           script: |
             echo "Installing app on emulator..."
             test -f app/android/app/build/outputs/apk/debug/app-debug.apk || { echo "❌ APK not found at app/android/app/build/outputs/apk/debug/app-debug.apk"; exit 1; }
             adb install -r app/android/app/build/outputs/apk/debug/app-debug.apk || { echo "❌ App installation failed"; exit 1; }
-            echo "✅ App installed successfully"
+            echo " App installed successfully"
 
-            echo "⏰ Warming up app process..."
+            echo " Warming up app process..."
             adb shell pm list packages | grep com.proofofpassportapp || { echo "app not installed"; exit 1; }
             adb shell monkey -p com.proofofpassportapp -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1
             sleep 3
 
-            echo "🧹 Clearing logcat..."
+            echo " Clearing logcat..."
             adb logcat -c || true
 
-            echo "🎭 Running Maestro tests..."
+            #  Retry mechanism for flaky tests
+            echo " Running Maestro tests with retry logic..."
             export MAESTRO_DRIVER_STARTUP_TIMEOUT=240000
-            set +e
-            maestro test app/tests/e2e/launch.android.flow.yaml --format junit --output app/maestro-results.xml
-            TEST_EXIT=$?
+
+            for attempt in 1 2 3; do
+              echo "Test attempt $attempt of 3..."
+              set +e
+              maestro test app/tests/e2e/launch.android.flow.yaml --format junit --output app/maestro-results.xml
+              TEST_EXIT=$?
+              set -e
+
+              if [ $TEST_EXIT -eq 0 ]; then
+                echo " Tests passed on attempt $attempt"
+                break
+              elif [ $attempt -eq 3 ]; then
+                echo "❌ Tests failed after 3 attempts"
+              else
+                echo " Attempt $attempt failed, retrying..."
+                sleep 10
+              fi
+            done
+
             adb logcat -d > app/maestro-logcat.txt || true
             maestro hierarchy --app com.proofofpassportapp > app/maestro-hierarchy.txt || true
             exit $TEST_EXIT
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -193,7 +246,7 @@ jobs:
           fi
 
   e2e-ios:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-latest-large
     concurrency:
       group: ${{ github.workflow }}-ios-${{ github.ref }}
@@ -236,6 +289,14 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
         run: echo "YARN_ENABLE_HARDENED_MODE=0" >> $GITHUB_ENV
       - run: yarn install --immutable --silent
+
+      #  Cache Built Dependencies
+      - name: Cache Built Dependencies
+        id: built-deps
+        uses: ./.github/actions/cache-built-deps
+        with:
+          cache-version: ${{ env.GH_CACHE_VERSION }}-${{ env.NODE_VERSION_SANITIZED }}
+
       - name: Validate Maestro test file
         run: |
           [ -f app/tests/e2e/launch.ios.flow.yaml ] || { echo "❌ iOS E2E test file missing"; exit 1; }
@@ -256,11 +317,11 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
       - name: Configure Xcode path
         run: |
-          echo "🔧 Configuring Xcode path to fix iOS SDK issues..."
+          echo " Configuring Xcode path to fix iOS SDK issues..."
           # Fix for macOS 15 runner iOS SDK issues
           # See: https://github.com/actions/runner-images/issues/12758
           sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
-          echo "✅ Xcode path configured"
+          echo " Xcode path configured"
 
           # Verify Xcode setup
           echo "Xcode version:"
@@ -273,12 +334,22 @@ jobs:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Add ccache to PATH
         run: echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
-      - name: Set up Ruby
+      #  Set up Ruby with enhanced caching
+      - name: Set up Ruby with enhanced caching
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
           bundler-cache: true
           working-directory: app
+      - name: Cache Ruby Gems (additional)
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/vendor/bundle
+            ~/.gem
+          key: ${{ runner.os }}-gems-${{ hashFiles('app/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
       - name: Cache Pods
         uses: ./.github/actions/cache-pods
         with:
@@ -294,93 +365,110 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-derived-data-${{ env.GH_CACHE_VERSION }}-${{ env.XCODE_VERSION }}-
             ${{ runner.os }}-derived-data-${{ env.GH_CACHE_VERSION }}-
+
+      # iOS Simulator caching
+      - name: Cache iOS Simulators
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/CoreSimulator/Devices
+            ~/Library/Caches/com.apple.dt.instruments
+          key: ${{ runner.os }}-ios-simulators-${{ env.XCODE_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-ios-simulators-
+
+      # Cache Xcode build cache
+      - name: Cache Xcode Build Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            ~/Library/Caches/com.apple.dt.Xcode
+          key: ${{ runner.os }}-xcode-cache-${{ env.XCODE_VERSION }}-${{ hashFiles('app/ios/**/*.{swift,m,h}') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-cache-${{ env.XCODE_VERSION }}-
       - name: Verify iOS Runtime
         run: |
-          echo "📱 Verifying iOS Runtime availability..."
+          echo " Verifying iOS Runtime availability..."
           echo "Available iOS runtimes:"
           xcrun simctl list runtimes | grep iOS
-      - name: Build dependencies (outside main flow)
+
+      #  Use cached dependencies (only build if cache miss)
+      - name: Build dependencies (cache miss only)
+        if: steps.built-deps.outputs.cache-hit != 'true'
         run: |
-          echo "Building dependencies..."
+          echo "Cache miss for built dependencies. Building now..."
           yarn workspace @selfxyz/mobile-app run build:deps --silent || { echo "❌ Dependency build failed"; exit 1; }
-          echo "✅ Dependencies built successfully"
+          echo " Dependencies built successfully"
+
       - name: Install iOS dependencies
         run: |
           echo "Installing iOS dependencies..."
           cd app/ios
-          echo "📦 Installing pods via centralized script…"
+          echo " Installing pods via centralized script…"
           BUNDLE_GEMFILE=../Gemfile bundle exec bash scripts/pod-install-with-cache-fix.sh || { echo "❌ Pod install failed"; exit 1; }
         env:
           SELFXYZ_INTERNAL_REPO_PAT: ${{ secrets.SELFXYZ_INTERNAL_REPO_PAT }}
-      - name: Setup iOS Simulator
+      #  Simplified and more reliable simulator setup
+      - name: Setup iOS Simulator (simplified)
         run: |
           echo "Setting up iOS Simulator..."
 
-          # First, check what simulators are actually available
-          echo "Available simulators:"
-          xcrun simctl list devices available || {
-            echo "❌ Failed to list available devices"
-            echo "Trying to list all devices:"
-            xcrun simctl list devices || {
-              echo "❌ Failed to list any devices"
+          # System resource check
+          echo " System resources before simulator setup..."
+          echo "Memory usage: $(top -l 1 | grep PhysMem | head -1)"
+          echo "Available CPU cores: $(sysctl -n hw.ncpu)"
+          echo "Simulator processes: $(ps aux | grep Simulator | wc -l | xargs)"
+
+          # Use a consistent, reliable simulator for CI stability
+          SIMULATOR_NAME="iPhone 15"
+          SIMULATOR_ID=$(xcrun simctl list devices available | grep "$SIMULATOR_NAME" | head -1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
+
+          if [ -z "$SIMULATOR_ID" ]; then
+            echo "$SIMULATOR_NAME not found, trying iPhone SE (3rd generation)..."
+            SIMULATOR_NAME="iPhone SE (3rd generation)"
+            SIMULATOR_ID=$(xcrun simctl list devices available | grep "$SIMULATOR_NAME" | head -1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
+          fi
+
+          if [ -z "$SIMULATOR_ID" ]; then
+            echo "Creating reliable CI simulator..."
+            SIMULATOR_ID=$(xcrun simctl create "CI-iPhone" "iPhone 15" 2>/dev/null || xcrun simctl create "CI-iPhone-SE" "iPhone SE (3rd generation)")
+            if [ -z "$SIMULATOR_ID" ]; then
+              echo "❌ Failed to create simulator"
+              exit 1
+            fi
+            SIMULATOR_NAME="CI-iPhone"
+          fi
+
+          echo " Using simulator: $SIMULATOR_ID ($SIMULATOR_NAME)"
+
+          # Boot simulator with better error handling
+          echo "Booting simulator..."
+          xcrun simctl boot "$SIMULATOR_ID" || {
+            echo "Boot failed, attempting shutdown and retry..."
+            xcrun simctl shutdown "$SIMULATOR_ID" || true
+            sleep 5
+            xcrun simctl boot "$SIMULATOR_ID" || {
+              echo "❌ Failed to boot simulator after retry"
               exit 1
             }
           }
 
-          # Find iPhone SE (3rd generation) simulator
-          echo "Finding iPhone SE (3rd generation) simulator..."
-          AVAILABLE_SIMULATOR=$(xcrun simctl list devices available | grep "iPhone SE (3rd generation)" | head -1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
-
-          if [ -z "$AVAILABLE_SIMULATOR" ]; then
-            echo "iPhone SE (3rd generation) not found, trying any iPhone SE..."
-            AVAILABLE_SIMULATOR=$(xcrun simctl list devices available | grep "iPhone SE" | head -1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
-          fi
-
-          if [ -z "$AVAILABLE_SIMULATOR" ]; then
-            echo "No iPhone SE found, trying any iPhone..."
-            AVAILABLE_SIMULATOR=$(xcrun simctl list devices available | grep "iPhone" | head -1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
-          fi
-
-          if [ -z "$AVAILABLE_SIMULATOR" ]; then
-            echo "❌ No available iPhone simulator found"
-            echo "Creating a new iPhone SE (3rd generation) simulator..."
-            # Create a new iPhone SE (3rd generation) simulator
-            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" || {
-              echo "❌ Failed to create iPhone SE (3rd generation) simulator"
-              echo "Trying to create any iPhone SE simulator..."
-              xcrun simctl create "iPhone SE" "iPhone SE" || {
-                echo "❌ Failed to create simulator"
-                exit 1
-              }
-            }
-            AVAILABLE_SIMULATOR=$(xcrun simctl list devices | grep "iPhone SE" | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
-          fi
-
-          echo "Using simulator: $AVAILABLE_SIMULATOR"
-
-          # Get simulator name for display
-          SIMULATOR_NAME=$(xcrun simctl list devices | grep "$AVAILABLE_SIMULATOR" | sed -E 's/^[[:space:]]*([^(]+).*/\1/' | xargs)
-          echo "Simulator name: $SIMULATOR_NAME"
-
-          # Boot simulator and wait for it to be ready
-          echo "Booting simulator..."
-          xcrun simctl boot "$AVAILABLE_SIMULATOR" || {
-            echo "❌ Failed to boot simulator"
-            exit 1
-          }
-
           echo "Waiting for simulator to be ready..."
-          xcrun simctl bootstatus "$AVAILABLE_SIMULATOR" -b
+          xcrun simctl bootstatus "$SIMULATOR_ID" -b
 
-          # Wait for simulator to be fully ready
-          echo "Waiting for simulator to be fully ready..."
-          sleep 15
-
-          echo "Simulator status:"
-          xcrun simctl list devices | grep "$AVAILABLE_SIMULATOR"
+          # Verify simulator is actually ready
+          for i in {1..10}; do
+            if xcrun simctl get_app_container "$SIMULATOR_ID" "com.apple.mobilesafari" app >/dev/null 2>&1; then
+              echo " Simulator is ready after ${i} checks"
+              break
+            fi
+            echo "Waiting for simulator readiness (attempt $i/10)..."
+            sleep 3
+          done
 
           # Store simulator ID for later use
-          echo "IOS_SIMULATOR_ID=$AVAILABLE_SIMULATOR" >> $GITHUB_ENV
+          echo "IOS_SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
           echo "IOS_SIMULATOR_NAME=$SIMULATOR_NAME" >> $GITHUB_ENV
       - name: Resolve iOS workspace
         run: |
@@ -395,6 +483,20 @@ jobs:
 
           echo "WORKSPACE_PATH=$WORKSPACE_PATH" >> "$GITHUB_ENV"
           echo "Resolved workspace: $WORKSPACE_PATH"
+      #  Configure build environment for optimal performance
+      - name: Configure build environment
+        run: |
+          # Set memory limits and build optimizations
+          echo " Configuring build environment..."
+          echo "Available memory: $(system_profiler SPHardwareDataType | grep Memory)"
+          echo "Available CPU cores: $(sysctl -n hw.ncpu)"
+          echo "Disk space: $(df -h / | tail -1)"
+
+          # Optimize for CI builds
+          echo "Setting build environment variables..."
+        env:
+          XCODE_BUILD_SETTINGS: "CLANG_ENABLE_MODULE_DEBUGGING=NO GCC_GENERATE_DEBUGGING_SYMBOLS=NO"
+
       - name: Build iOS App
         run: |
           echo "Building iOS app..."
@@ -424,15 +526,17 @@ jobs:
             exit 1
           fi
 
-          echo "✅ Using workspace: $WORKSPACE_PATH"
-          echo "✅ Using scheme: ${{ env.IOS_PROJECT_SCHEME }}"
+          echo " Using workspace: $WORKSPACE_PATH"
+          echo " Using scheme: ${{ env.IOS_PROJECT_SCHEME }}"
 
           # Use cached derived data and enable parallel builds for faster compilation
           # Additional flags disable indexing, restrict architecture, and use whole-module Swift compilation
           # Use the simulator that was set up earlier in the workflow
           FORCE_BUNDLING=1 RCT_NO_LAUNCH_PACKAGER=1 \
             xcodebuild -workspace "$WORKSPACE_PATH" -scheme ${{ env.IOS_PROJECT_SCHEME }} -configuration Debug -destination "id=${{ env.IOS_SIMULATOR_ID }}" -derivedDataPath app/ios/build -jobs "$(sysctl -n hw.ncpu)" -parallelizeTargets -quiet COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES SWIFT_COMPILATION_MODE=wholemodule || { echo "❌ iOS build failed"; exit 1; }
-          echo "✅ iOS build succeeded"
+          echo " iOS build succeeded"
+
+      #  Add retry logic for iOS tests too
       - name: Install and Test on iOS
         run: |
           echo "Installing app on simulator..."
@@ -440,10 +544,10 @@ jobs:
           [ -z "$APP_PATH" ] && { echo "❌ Could not find built iOS app"; exit 1; }
           echo "Found app at: $APP_PATH"
 
-          echo "🔍 Determining app bundle ID from built app..."
+          echo " Determining app bundle ID from built app..."
           IOS_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "$APP_PATH/Info.plist")
           [ -z "$IOS_BUNDLE_ID" ] && { echo "❌ Could not determine bundle ID from $APP_PATH/Info.plist"; exit 1; }
-          echo "✅ App Bundle ID: $IOS_BUNDLE_ID"
+          echo " App Bundle ID: $IOS_BUNDLE_ID"
 
           # Use the dynamic simulator ID
           SIMULATOR_ID="${IOS_SIMULATOR_ID:-iPhone SE (3rd generation)}"
@@ -461,28 +565,55 @@ jobs:
 
           echo "Verifying app installation..."
           if xcrun simctl get_app_container "$SIMULATOR_ID" "$IOS_BUNDLE_ID" app >/dev/null 2>&1; then
-            echo "✅ App successfully installed"
+            echo " App successfully installed"
           else
             echo "❌ App installation verification failed"
             exit 1
           fi
 
-          echo "🚀 Testing app launch capability..."
+          echo " Testing app launch capability..."
           xcrun simctl launch "$SIMULATOR_ID" "$IOS_BUNDLE_ID" || {
-            echo "⚠️ Direct app launch test failed - this might be expected."
+            echo " Direct app launch test failed - this might be expected."
           }
 
-          echo "⏰ Checking simulator readiness..."
+          echo " Checking simulator readiness..."
           sleep 10
           # Probe container as readiness check instead of listapps
           xcrun simctl get_app_container "$SIMULATOR_ID" "$IOS_BUNDLE_ID" app >/dev/null 2>&1 || sleep 5
 
-          echo "Running Maestro tests..."
-          echo "Starting test execution..."
-          maestro test app/tests/e2e/launch.ios.flow.yaml --format junit --output app/maestro-results.xml || {
-            echo "Maestro test failed, but continuing to upload results..."
-            exit 1
-          }
+          #  Pre-test system monitoring
+          echo " System resources before testing..."
+          echo "Memory usage: $(top -l 1 | grep PhysMem | head -1)"
+          echo "Simulator processes: $(ps aux | grep Simulator | wc -l | xargs)"
+          echo "Available disk space: $(df -h / | tail -1)"
+
+          #  Consistent retry logic with Android (3 attempts)
+          echo "Running Maestro tests with retry logic..."
+          for attempt in 1 2 3; do
+            echo "Test attempt $attempt of 3..."
+            set +e
+            maestro test app/tests/e2e/launch.ios.flow.yaml --format junit --output app/maestro-results.xml
+            TEST_EXIT=$?
+            set -e
+
+            if [ $TEST_EXIT -eq 0 ]; then
+              echo " Tests passed on attempt $attempt"
+              break
+            elif [ $attempt -eq 3 ]; then
+              echo "❌ Tests failed after 3 attempts"
+              echo " Final system state:"
+              echo "Memory usage: $(top -l 1 | grep PhysMem | head -1)"
+              echo "Simulator status: $(xcrun simctl list devices | grep "$SIMULATOR_ID")"
+            else
+              echo " Attempt $attempt failed, retrying..."
+              echo " System state before retry:"
+              echo "Memory usage: $(top -l 1 | grep PhysMem | head -1)"
+              sleep 10
+            fi
+          done
+
+          exit $TEST_EXIT
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -490,3 +621,21 @@ jobs:
           name: maestro-results-ios
           path: app/maestro-results.xml
           if-no-files-found: warn
+
+      #  iOS process cleanup (matching Android cleanup)
+      - name: Cleanup iOS processes
+        if: always()
+        run: |
+          echo " Cleaning up iOS processes..."
+          # Kill any hanging Xcode processes
+          pkill -f "xcodebuild" || true
+          pkill -f "Simulator" || true
+          pkill -f "CoreSimulatorService" || true
+
+          # Clean up simulator logs and shutdown simulators
+          xcrun simctl shutdown all || true
+
+          # Clean up any stale maestro processes
+          pkill -f "maestro" || true
+
+          echo " iOS cleanup completed"

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -48,6 +48,8 @@ android.jetifier.ignorelist=bcprov-jdk18on
 # Additional Gradle optimizations for better build performance
 org.gradle.caching=true
 org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
 
 # Better dependency caching and offline support
 org.gradle.dependency.verification=off

--- a/app/android/react-native-passport-reader/android/build.gradle
+++ b/app/android/react-native-passport-reader/android/build.gradle
@@ -5,9 +5,9 @@ android {
     namespace "io.tradle.nfc"
     // Use NDK that supports 16k page size
     ndkVersion = "27.1.12297006"
-    compileSdkVersion 33
+    compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig {
-        targetSdkVersion 33
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true

--- a/app/tests/e2e/launch.android.flow.yaml
+++ b/app/tests/e2e/launch.android.flow.yaml
@@ -14,4 +14,3 @@ appId: com.proofofpassportapp
     timeout: 90000
 - tapOn:
     id: launch-get-started-button
-

--- a/app/tests/e2e/launch.android.flow.yaml
+++ b/app/tests/e2e/launch.android.flow.yaml
@@ -4,9 +4,9 @@ appId: com.proofofpassportapp
     clearState: true
     stopApp: true
     permissions:
-      - android.permission.POST_NOTIFICATIONS
-      - android.permission.CAMERA
-      - android.permission.RECORD_AUDIO
+      android.permission.POST_NOTIFICATIONS: allow
+      android.permission.CAMERA: allow
+      android.permission.RECORD_AUDIO: allow
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:

--- a/app/tests/e2e/launch.android.flow.yaml
+++ b/app/tests/e2e/launch.android.flow.yaml
@@ -2,5 +2,5 @@ appId: com.proofofpassportapp
 ---
 - launchApp
 - extendedWaitUntil:
-    visible: "I have a Passport or Biometric ID"
-    timeout: ${LAUNCH_WAIT_MS:60000}
+    id: launch-get-started-button
+    timeout: ${LAUNCH_WAIT_MS:120000}

--- a/app/tests/e2e/launch.android.flow.yaml
+++ b/app/tests/e2e/launch.android.flow.yaml
@@ -2,5 +2,6 @@ appId: com.proofofpassportapp
 ---
 - launchApp
 - extendedWaitUntil:
-    id: launch-get-started-button
+    visible:
+      id: launch-get-started-button
     timeout: ${LAUNCH_WAIT_MS:120000}

--- a/app/tests/e2e/launch.android.flow.yaml
+++ b/app/tests/e2e/launch.android.flow.yaml
@@ -1,18 +1,17 @@
 appId: com.proofofpassportapp
-name: Launch
-onFlowStart:
-  - launchApp:
-      clearState: true
-      stopApp: true
-      permissions:
-        - android.permission.POST_NOTIFICATIONS
-        - android.permission.CAMERA
-        - android.permission.RECORD_AUDIO
-steps:
-  - waitForAnimationToEnd
-  - waitFor:
-      visible:
-        id: launch-get-started-button
-      timeout: 90000
-  - tapOn:
+---
+- launchApp:
+    clearState: true
+    stopApp: true
+    permissions:
+      - android.permission.POST_NOTIFICATIONS
+      - android.permission.CAMERA
+      - android.permission.RECORD_AUDIO
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
       id: launch-get-started-button
+    timeout: 90000
+- tapOn:
+    id: launch-get-started-button
+

--- a/app/tests/e2e/launch.android.flow.yaml
+++ b/app/tests/e2e/launch.android.flow.yaml
@@ -1,7 +1,18 @@
 appId: com.proofofpassportapp
----
-- launchApp
-- extendedWaitUntil:
-    visible:
+name: Launch
+onFlowStart:
+  - launchApp:
+      clearState: true
+      stopApp: true
+      permissions:
+        - android.permission.POST_NOTIFICATIONS
+        - android.permission.CAMERA
+        - android.permission.RECORD_AUDIO
+steps:
+  - waitForAnimationToEnd
+  - waitFor:
+      visible:
+        id: launch-get-started-button
+      timeout: 90000
+  - tapOn:
       id: launch-get-started-button
-    timeout: ${LAUNCH_WAIT_MS:120000}

--- a/app/tests/e2e/launch.android.flow.yaml
+++ b/app/tests/e2e/launch.android.flow.yaml
@@ -7,10 +7,13 @@ appId: com.proofofpassportapp
       android.permission.POST_NOTIFICATIONS: allow
       android.permission.CAMERA: allow
       android.permission.RECORD_AUDIO: allow
+
+# Wait for splash screen animations to complete
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:
       id: launch-get-started-button
-    timeout: 90000
+    timeout: 180000  # Increased from 90s to 3 minutes
+
 - tapOn:
     id: launch-get-started-button

--- a/app/tests/e2e/launch.android.flow.yaml
+++ b/app/tests/e2e/launch.android.flow.yaml
@@ -13,7 +13,7 @@ appId: com.proofofpassportapp
 - extendedWaitUntil:
     visible:
       id: launch-get-started-button
-    timeout: 180000  # Increased from 90s to 3 minutes
+    timeout: 180000 # Increased from 90s to 3 minutes
 
 - tapOn:
     id: launch-get-started-button

--- a/app/tests/e2e/launch.ios.flow.yaml
+++ b/app/tests/e2e/launch.ios.flow.yaml
@@ -2,5 +2,6 @@ appId: com.warroom.proofofpassport
 ---
 - launchApp
 - extendedWaitUntil:
-    id: launch-get-started-button
+    visible:
+      id: launch-get-started-button
     timeout: ${LAUNCH_WAIT_MS:120000}

--- a/app/tests/e2e/launch.ios.flow.yaml
+++ b/app/tests/e2e/launch.ios.flow.yaml
@@ -2,5 +2,5 @@ appId: com.warroom.proofofpassport
 ---
 - launchApp
 - extendedWaitUntil:
-    visible: "I have a Passport or Biometric ID"
-    timeout: ${LAUNCH_WAIT_MS:60000}
+    id: launch-get-started-button
+    timeout: ${LAUNCH_WAIT_MS:120000}


### PR DESCRIPTION
## Summary
- set up Gradle via official action and enable KVM on runners
- cache AVD snapshots and tune emulator resources
- warn on configuration cache issues in Gradle

## Testing
- `yarn workspaces foreach -A -p -v --topological-dev --since=HEAD run nice --if-present` *(fails: Invalid option schema)*
- `yarn workspace @selfxyz/mobile-app run nice` *(errors: Unable to resolve module '@selfxyz/mobile-sdk-alpha/stores')*
- `yarn lint` *(errors: Unable to resolve module '@selfxyz/mobile-sdk-alpha/stores')*
- `yarn build` *(fails: Cannot find module '@anon-aadhaar/core')*
- `yarn workspace @selfxyz/contracts build` *(fails: Couldn't find a script named "hardhat".)*
- `yarn types` *(fails: Cannot find module '@anon-aadhaar/core')*


------
https://chatgpt.com/codex/tasks/task_b_68c60cc7b950832dbf52feb6e72a8a93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Re-enabled Android end-to-end tests with improved emulator reliability and reduced flakiness; iOS flow unchanged.
- Performance
  - Faster and more consistent Android builds via Gradle configuration caching and CI build optimizations.
- Chores
  - Improved mobile CI: longer timeouts, emulator resource tuning, AVD caching, virtualization setup, and automated cleanup to keep runs stable and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->