### PR TITLE
chore: bump v2.6.6 (aadhaar) for release

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -121,8 +121,8 @@ android {
         applicationId "com.proofofpassportapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 99
-        versionName "2.6.5"
+        versionCode 101
+        versionName "2.6.6"
         manifestPlaceholders = [appAuthRedirectScheme: 'com.proofofpassportapp']
         externalNativeBuild {
             cmake {

--- a/app/ios/OpenPassport/Info.plist
+++ b/app/ios/OpenPassport/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.5</string>
+	<string>2.6.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 				CODE_SIGN_ENTITLEMENTS = OpenPassport/OpenPassportDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 172;
+				CURRENT_PROJECT_VERSION = 173;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 5B29R5LYHQ;
 				ENABLE_BITCODE = NO;
@@ -542,7 +542,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.6.5;
+				MARKETING_VERSION = 2.6.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -568,7 +568,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = OpenPassport/OpenPassport.entitlements;
-				CURRENT_PROJECT_VERSION = 172;
+				CURRENT_PROJECT_VERSION = 173;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 5B29R5LYHQ;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -682,7 +682,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.6.5;
+				MARKETING_VERSION = 2.6.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/mobile-app",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/tests/utils/proving/loadingScreenStateText.test.ts
+++ b/app/tests/utils/proving/loadingScreenStateText.test.ts
@@ -85,11 +85,15 @@ describe('stateLoadingScreenText', () => {
   describe('getLoadingScreenText with passport metadata', () => {
     const rsaMetadata: PassportMetadata = {
       signatureAlgorithm: 'RSA',
-      curveOrExponent: '',
+      curveOrExponent: '65537',
     };
 
     it('should use algorithm information to estimate proving time', () => {
-      const result = getLoadingScreenText('proving', rsaMetadata);
+      const result = getLoadingScreenText(
+        'proving',
+        rsaMetadata.signatureAlgorithm,
+        rsaMetadata.curveOrExponent,
+      );
 
       // Should use RSA (4 SECONDS)
       expect(result.estimatedTime).toBe('4 SECONDS');
@@ -97,8 +101,8 @@ describe('stateLoadingScreenText', () => {
   });
 
   describe('getProvingTimeEstimate', () => {
-    it('should return default time when metadata is undefined', () => {
-      const result = getProvingTimeEstimate(undefined, 'register');
+    it('should return default time when parameters are undefined', () => {
+      const result = getProvingTimeEstimate('', '', 'register');
       expect(result).toBe('30 - 90 SECONDS');
     });
 
@@ -117,7 +121,8 @@ describe('stateLoadingScreenText', () => {
           };
 
           const result = getProvingTimeEstimate(
-            metadata,
+            metadata.signatureAlgorithm,
+            metadata.curveOrExponent,
             type as 'dsc' | 'register',
           );
           expect(result).toBe(expectedTime);
@@ -138,7 +143,8 @@ describe('stateLoadingScreenText', () => {
           };
 
           const result = getProvingTimeEstimate(
-            metadata,
+            metadata.signatureAlgorithm,
+            metadata.curveOrExponent,
             type as 'dsc' | 'register',
           );
           expect(result).toBe(expectedTime);
@@ -161,7 +167,8 @@ describe('stateLoadingScreenText', () => {
           };
 
           const result = getProvingTimeEstimate(
-            metadata,
+            metadata.signatureAlgorithm,
+            metadata.curveOrExponent,
             type as 'dsc' | 'register',
           );
           expect(result).toBe(expectedTime);
@@ -182,7 +189,8 @@ describe('stateLoadingScreenText', () => {
           };
 
           const result = getProvingTimeEstimate(
-            metadata,
+            metadata.signatureAlgorithm,
+            metadata.curveOrExponent,
             type as 'dsc' | 'register',
           );
           expect(result).toBe(expectedTime);
@@ -203,7 +211,8 @@ describe('stateLoadingScreenText', () => {
           };
 
           const result = getProvingTimeEstimate(
-            metadata,
+            metadata.signatureAlgorithm,
+            metadata.curveOrExponent,
             type as 'dsc' | 'register',
           );
           expect(result).toBe(expectedTime);
@@ -224,7 +233,8 @@ describe('stateLoadingScreenText', () => {
           };
 
           const result = getProvingTimeEstimate(
-            metadata,
+            metadata.signatureAlgorithm,
+            metadata.curveOrExponent,
             type as 'dsc' | 'register',
           );
           expect(result).toBe(expectedTime);
@@ -238,7 +248,11 @@ describe('stateLoadingScreenText', () => {
         curveOrExponent: '',
       };
 
-      const result = getProvingTimeEstimate(metadata, 'register');
+      const result = getProvingTimeEstimate(
+        metadata.signatureAlgorithm,
+        metadata.curveOrExponent,
+        'register',
+      );
       expect(result).toBe('30 - 90 SECONDS');
     });
   });

--- a/app/version.json
+++ b/app/version.json
@@ -1,10 +1,10 @@
 {
   "ios": {
-    "build": 172,
-    "lastDeployed": "2025-09-13T16:35:10Z"
+    "build": 173,
+    "lastDeployed": "2025-09-20T16:35:10Z"
   },
   "android": {
-    "build": 99,
-    "lastDeployed": "2025-09-13T10:59:07Z"
+    "build": 101,
+    "lastDeployed": "2025-09-20T10:59:07Z"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Bumped app version to 2.6.6 across iOS and Android.
  - Updated Android build info (versionCode → 101; versionName → 2.6.6).
  - Updated iOS build info (build number → 173; marketing/version to 2.6.6).
  - Updated internal package/version metadata.
- Tests
  - Adjusted tests for proving-related utilities to reflect a move from metadata objects to explicit parameters.
- Notes
  - No user-facing feature or behavior changes; metadata and build identifiers only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->