### PR TITLE
Connect mobile SDK demo mock generation to document store

### DIFF
--- a/packages/mobile-sdk-demo/App.tsx
+++ b/packages/mobile-sdk-demo/App.tsx
@@ -2,24 +2,52 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
+import type {
+  DocumentCatalog,
+  DocumentMetadata,
+} from '@selfxyz/common/dist/esm/src/utils/types.js';
 import type { IDDocument } from '@selfxyz/common/dist/esm/src/utils/types.js';
+import { loadSelectedDocument, useSelfClient } from '@selfxyz/mobile-sdk-alpha';
 
 import HomeScreen from './src/screens/HomeScreen';
 import { screenMap, type ScreenContext, type ScreenRoute } from './src/screens';
+import SelfClientProvider from './src/providers/SelfClientProvider';
 
-function App() {
+type SelectedDocumentState = {
+  data: IDDocument;
+  metadata: DocumentMetadata;
+};
+
+function DemoApp() {
+  const selfClient = useSelfClient();
+
   const [screen, setScreen] = useState<ScreenRoute>('home');
-  const [mockDocument, setMockDocument] = useState<IDDocument | null>(null);
+  const [catalog, setCatalog] = useState<DocumentCatalog>({ documents: [] });
+  const [selectedDocument, setSelectedDocument] = useState<SelectedDocumentState | null>(null);
+
+  const refreshDocuments = useCallback(async () => {
+    try {
+      const selected = await loadSelectedDocument(selfClient);
+      const nextCatalog = await selfClient.loadDocumentCatalog();
+      setCatalog(nextCatalog);
+      setSelectedDocument(selected);
+    } catch (error) {
+      console.warn('Failed to refresh documents', error);
+      setCatalog({ documents: [] });
+      setSelectedDocument(null);
+    }
+  }, [selfClient]);
 
   const navigate = (next: ScreenRoute) => setScreen(next);
 
   const screenContext: ScreenContext = {
     navigate,
     goHome: () => setScreen('home'),
-    mockDocument,
-    setMockDocument,
+    documentCatalog: catalog,
+    selectedDocument,
+    refreshDocuments,
   };
 
   useEffect(() => {
@@ -27,6 +55,10 @@ function App() {
       setScreen('home');
     }
   }, [screen]);
+
+  useEffect(() => {
+    refreshDocuments();
+  }, [refreshDocuments]);
 
   if (screen === 'home') {
     return <HomeScreen screenContext={screenContext} />;
@@ -42,6 +74,14 @@ function App() {
   const props = descriptor.getProps?.(screenContext) ?? {};
 
   return <ScreenComponent {...props} />;
+}
+
+function App() {
+  return (
+    <SelfClientProvider>
+      <DemoApp />
+    </SelfClientProvider>
+  );
 }
 
 export default App;

--- a/packages/mobile-sdk-demo/src/providers/SelfClientProvider.tsx
+++ b/packages/mobile-sdk-demo/src/providers/SelfClientProvider.tsx
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { sha256 } from '@noble/hashes/sha256';
+import type { PropsWithChildren } from 'react';
+import React, { useMemo } from 'react';
+
+import {
+  SelfMobileSdk,
+  createListenersMap,
+  type Adapters,
+  type TrackEventParams,
+  type WsConn,
+  webScannerShim,
+} from '@selfxyz/mobile-sdk-alpha';
+
+import { inMemoryDocumentsAdapter } from '../utils/documentStore';
+
+const createFetch = () => {
+  const fetchImpl = globalThis.fetch;
+  if (!fetchImpl) {
+    return async () => {
+      throw new Error('Fetch is not available in this environment. Provide a fetch polyfill.');
+    };
+  }
+
+  return (input: RequestInfo | URL, init?: RequestInit) => fetchImpl(input, init);
+};
+
+const createWsAdapter = () => ({
+  connect: (_url: string): WsConn => {
+    return {
+      send: () => {
+        throw new Error('WebSocket send is not implemented in the demo environment.');
+      },
+      close: () => {},
+      onMessage: () => {},
+      onError: () => {},
+      onClose: () => {},
+    };
+  },
+});
+
+const hash = (data: Uint8Array): Uint8Array => sha256(data);
+
+export function SelfClientProvider({ children }: PropsWithChildren) {
+  const config = useMemo(() => ({}), []);
+
+  const adapters: Adapters = useMemo(
+    () => ({
+      scanner: webScannerShim,
+      network: {
+        http: {
+          fetch: createFetch(),
+        },
+        ws: createWsAdapter(),
+      },
+      documents: inMemoryDocumentsAdapter,
+      crypto: {
+        async hash(data: Uint8Array): Promise<Uint8Array> {
+          return hash(data);
+        },
+        async sign(_data: Uint8Array, keyRef: string): Promise<Uint8Array> {
+          throw new Error(`Signing is not supported in the demo client (keyRef: ${keyRef}).`);
+        },
+      },
+      analytics: {
+        trackEvent: (_event: string, _payload?: TrackEventParams) => {
+          // No-op analytics for the demo application
+        },
+      },
+      auth: {
+        async getPrivateKey(): Promise<string | null> {
+          return null;
+        },
+      },
+    }),
+    [],
+  );
+
+  const listeners = useMemo(() => {
+    const { map } = createListenersMap();
+    return map;
+  }, []);
+
+  return (
+    <SelfMobileSdk config={config} adapters={adapters} listeners={listeners}>
+      {children}
+    </SelfMobileSdk>
+  );
+}
+
+export default SelfClientProvider;

--- a/packages/mobile-sdk-demo/src/providers/SelfClientProvider.tsx
+++ b/packages/mobile-sdk-demo/src/providers/SelfClientProvider.tsx
@@ -7,7 +7,7 @@ import type { PropsWithChildren } from 'react';
 import React, { useMemo } from 'react';
 
 import {
-  SelfMobileSdk,
+  SelfClientProvider as SdkSelfClientProvider,
   createListenersMap,
   type Adapters,
   type TrackEventParams,
@@ -85,9 +85,9 @@ export function SelfClientProvider({ children }: PropsWithChildren) {
   }, []);
 
   return (
-    <SelfMobileSdk config={config} adapters={adapters} listeners={listeners}>
+    <SdkSelfClientProvider config={config} adapters={adapters} listeners={listeners}>
       {children}
-    </SelfMobileSdk>
+    </SdkSelfClientProvider>
   );
 }
 

--- a/packages/mobile-sdk-demo/src/screens/DocumentsList.tsx
+++ b/packages/mobile-sdk-demo/src/screens/DocumentsList.tsx
@@ -2,81 +2,143 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+
+import type { DocumentCatalog, DocumentMetadata, IDDocument } from '@selfxyz/common/dist/esm/src/utils/types.js';
+import { getAllDocuments, useSelfClient } from '@selfxyz/mobile-sdk-alpha';
 
 import SafeAreaScrollView from '../components/SafeAreaScrollView';
 import StandardHeader from '../components/StandardHeader';
 
 type Props = {
   onBack: () => void;
+  catalog: DocumentCatalog;
 };
 
-export default function DocumentsList({ onBack }: Props) {
-  const mockDocuments = [
-    {
-      id: 'abc123def456',
-      documentType: 'mock_passport',
-      documentCategory: 'PASSPORT',
-      nationality: 'USA',
-      isRegistered: true,
-      mock: true,
-      createdAt: '2024-03-20T14:30:00Z',
-      name: 'JANE DOE',
-      birthDate: '1990-05-15',
-      documentNumber: 'N1234567890',
-    },
-  ];
+type DocumentEntry = {
+  metadata: DocumentMetadata;
+  data: IDDocument;
+};
 
-  const DocumentCard = ({ document }: { document: (typeof mockDocuments)[0] }) => {
-    const getDocumentTypeDisplay = () => {
-      if (document.mock) {
-        return `Mock ${document.documentCategory.charAt(0) + document.documentCategory.slice(1).toLowerCase()}`;
+const humanizeDocumentType = (documentType: string) => {
+  if (documentType.startsWith('mock_')) {
+    const base = documentType.replace('mock_', '');
+    return `Mock ${base.replace('_', ' ')}`.replace(/\b\w/g, char => char.toUpperCase());
+  }
+  return documentType.replace(/_/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
+};
+
+const formatDataPreview = (metadata: DocumentMetadata) => {
+  if (!metadata.data) {
+    return 'No preview available';
+  }
+
+  const lines = metadata.data.split(/\r?\n/).filter(Boolean);
+  const preview = lines.slice(0, 2).join('\n');
+
+  return preview.length > 120 ? `${preview.slice(0, 117)}…` : preview;
+};
+
+export default function DocumentsList({ onBack, catalog }: Props) {
+  const selfClient = useSelfClient();
+  const [documents, setDocuments] = useState<DocumentEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const allDocuments = await getAllDocuments(selfClient);
+        if (!active) {
+          return;
+        }
+        setDocuments(Object.values(allDocuments));
+      } catch (err) {
+        if (!active) {
+          return;
+        }
+        setDocuments([]);
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
       }
-      return document.documentCategory.charAt(0) + document.documentCategory.slice(1).toLowerCase();
     };
 
-    const formatDate = (dateString: string) => {
-      return new Date(dateString).toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-      });
-    };
+    load();
 
-    return (
-      <View style={styles.documentCard}>
-        <View style={styles.documentHeader}>
-          <Text style={styles.documentType}>{getDocumentTypeDisplay()}</Text>
-          <View style={[styles.statusBadge, document.isRegistered ? styles.verified : styles.pending]}>
-            <Text style={styles.statusText}>{document.isRegistered ? 'Registered' : 'Pending'}</Text>
-          </View>
+    return () => {
+      active = false;
+    };
+  }, [selfClient, catalog]);
+
+  const content = useMemo(() => {
+    if (loading) {
+      return (
+        <View style={styles.loadingState}>
+          <ActivityIndicator size="small" color="#0550ae" />
+          <Text style={styles.loadingText}>Loading your documents…</Text>
         </View>
-        <Text style={styles.documentCountry}>
-          {document.nationality} • {document.name}
-        </Text>
-        <Text style={styles.documentNumber}>Document: {document.documentNumber}</Text>
-        <Text style={styles.documentDate}>Created: {formatDate(document.createdAt)}</Text>
-      </View>
-    );
-  };
+      );
+    }
+
+    if (error) {
+      return (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>We hit a snag fetching documents</Text>
+          <Text style={styles.emptySubtext}>{error}</Text>
+        </View>
+      );
+    }
+
+    if (documents.length === 0) {
+      return (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>No documents yet</Text>
+          <Text style={styles.emptySubtext}>
+            Generate a mock document to see it appear here. The demo document store keeps everything locally on your device.
+          </Text>
+        </View>
+      );
+    }
+
+    return documents.map(({ metadata }) => {
+      const statusLabel = metadata.isRegistered ? 'Registered' : 'Not registered';
+      const badgeStyle = metadata.isRegistered ? styles.verified : styles.pending;
+      const preview = formatDataPreview(metadata);
+      const documentId = `${metadata.id.slice(0, 8)}…${metadata.id.slice(-6)}`;
+
+      return (
+        <View key={metadata.id} style={styles.documentCard}>
+          <View style={styles.documentHeader}>
+            <Text style={styles.documentType}>{humanizeDocumentType(metadata.documentType)}</Text>
+            <View style={[styles.statusBadge, badgeStyle]}>
+              <Text style={styles.statusText}>{statusLabel}</Text>
+            </View>
+          </View>
+          <Text style={styles.documentMeta}>{metadata.documentCategory.toUpperCase()}</Text>
+          <Text style={styles.documentMeta}>{metadata.mock ? 'Mock data' : 'Live data'}</Text>
+          <Text style={styles.documentPreview} selectable>
+            {preview}
+          </Text>
+          <Text style={styles.documentIdLabel}>Document ID</Text>
+          <Text style={styles.documentId}>{documentId}</Text>
+        </View>
+      );
+    });
+  }, [documents, error, loading]);
 
   return (
     <SafeAreaScrollView contentContainerStyle={styles.container} backgroundColor="#fafbfc">
-      <StandardHeader title="My Documents" subtitle="Your registered identity documents" onBack={onBack} />
+      <StandardHeader title="My Documents" subtitle="Documents stored in this demo app" onBack={onBack} />
 
-      <View style={styles.content}>
-        {mockDocuments.map(document => (
-          <DocumentCard key={document.id} document={document} />
-        ))}
-
-        <View style={styles.emptyState}>
-          <Text style={styles.emptyText}>✨ Demo Document Registry</Text>
-          <Text style={styles.emptySubtext}>
-            This shows your mock passport that was generated and registered through the demo flow
-          </Text>
-        </View>
-      </View>
+      <View style={styles.content}>{content}</View>
     </SafeAreaScrollView>
   );
 }
@@ -131,19 +193,34 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: '#333',
   },
-  documentCountry: {
-    fontSize: 16,
+  documentMeta: {
+    fontSize: 14,
     color: '#666',
     marginBottom: 4,
   },
-  documentNumber: {
-    fontSize: 14,
-    color: '#777',
-    marginBottom: 4,
+  documentPreview: {
+    marginTop: 12,
+    padding: 12,
+    backgroundColor: '#f6f8fa',
+    borderRadius: 8,
+    fontFamily: 'monospace',
+    fontSize: 12,
+    color: '#0d1117',
+    borderWidth: 1,
+    borderColor: '#e1e5e9',
+    lineHeight: 16,
   },
-  documentDate: {
+  documentIdLabel: {
+    marginTop: 12,
+    fontSize: 12,
+    color: '#57606a',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  documentId: {
     fontSize: 14,
-    color: '#777',
+    color: '#0d1117',
+    fontFamily: 'monospace',
   },
   emptyState: {
     marginTop: 32,
@@ -165,5 +242,19 @@ const styles = StyleSheet.create({
     color: '#777',
     textAlign: 'center',
     lineHeight: 20,
+  },
+  loadingState: {
+    marginTop: 32,
+    padding: 24,
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#e1e5e9',
+    alignItems: 'center',
+    gap: 12,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: '#57606a',
   },
 });

--- a/packages/mobile-sdk-demo/src/screens/GenerateMock.tsx
+++ b/packages/mobile-sdk-demo/src/screens/GenerateMock.tsx
@@ -5,9 +5,13 @@
 import React, { useState } from 'react';
 import { ActivityIndicator, Button, StyleSheet, Switch, Text, TextInput, View } from 'react-native';
 
-import { countryCodes } from '@selfxyz/common';
-import type { IDDocument } from '@selfxyz/common/dist/esm/src/utils/types.js';
-import { generateMockDocument, signatureAlgorithmToStrictSignatureAlgorithm } from '@selfxyz/mobile-sdk-alpha';
+import { calculateContentHash, countryCodes, inferDocumentCategory, isMRZDocument } from '@selfxyz/common';
+import type { DocumentMetadata, IDDocument } from '@selfxyz/common/dist/esm/src/utils/types.js';
+import {
+  generateMockDocument,
+  signatureAlgorithmToStrictSignatureAlgorithm,
+  useSelfClient,
+} from '@selfxyz/mobile-sdk-alpha';
 
 import { Picker } from '@react-native-picker/picker';
 import SafeAreaScrollView from '../components/SafeAreaScrollView';
@@ -25,12 +29,13 @@ const defaultDocumentType = 'mock_passport';
 const defaultOfac = true;
 
 type Props = {
-  onGenerate?: (doc: IDDocument) => void;
+  onDocumentStored?: () => Promise<void> | void;
   onNavigate: (screen: 'home' | 'register' | 'prove') => void;
   onBack: () => void;
 };
 
-export default function GenerateMock({ onGenerate, onNavigate, onBack }: Props) {
+export default function GenerateMock({ onDocumentStored, onNavigate, onBack }: Props) {
+  const selfClient = useSelfClient();
   const [age, setAge] = useState(defaultAge);
   const [expiryYears, setExpiryYears] = useState(defaultExpiryYears);
   const [isInOfacList, setIsInOfacList] = useState(defaultOfac);
@@ -73,8 +78,28 @@ export default function GenerateMock({ onGenerate, onNavigate, onBack }: Props) 
         selectedCountry: country,
         selectedDocumentType: documentType,
       });
+      const documentId = calculateContentHash(doc);
+      const catalog = await selfClient.loadDocumentCatalog();
+      const existing = catalog.documents.find(entry => entry.id === documentId);
+
+      await selfClient.saveDocument(documentId, doc);
+
+      if (!existing) {
+        const metadata: DocumentMetadata = {
+          id: documentId,
+          documentType: doc.documentType,
+          documentCategory: doc.documentCategory || inferDocumentCategory(doc.documentType),
+          data: isMRZDocument(doc) ? doc.mrz : 'qrData' in doc ? doc.qrData : '',
+          mock: doc.mock ?? false,
+          isRegistered: false,
+        };
+        catalog.documents.push(metadata);
+      }
+
+      catalog.selectedDocumentId = documentId;
+      await selfClient.saveDocumentCatalog(catalog);
+      await onDocumentStored?.();
       setResult(doc);
-      onGenerate?.(doc);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/packages/mobile-sdk-demo/src/screens/index.ts
+++ b/packages/mobile-sdk-demo/src/screens/index.ts
@@ -4,15 +4,20 @@
 
 import type { ComponentType } from 'react';
 
-import type { IDDocument } from '@selfxyz/common/dist/esm/src/utils/types.js';
+import type {
+  DocumentCatalog,
+  DocumentMetadata,
+  IDDocument,
+} from '@selfxyz/common/dist/esm/src/utils/types.js';
 
 export type ScreenId = 'generate' | 'register' | 'prove' | 'camera' | 'nfc' | 'qr' | 'documents' | 'activity';
 
 export type ScreenContext = {
   navigate: (next: ScreenRoute) => void;
   goHome: () => void;
-  mockDocument: IDDocument | null;
-  setMockDocument: (document: IDDocument | null) => void;
+  documentCatalog: DocumentCatalog;
+  selectedDocument: { data: IDDocument; metadata: DocumentMetadata } | null;
+  refreshDocuments: () => Promise<void>;
 };
 
 export type ScreenStatus = 'working' | 'placeholder';
@@ -39,8 +44,8 @@ export const screenDescriptors: ScreenDescriptor[] = [
     sectionTitle: '⭐ Core Features',
     status: 'working',
     load: () => require('./GenerateMock').default,
-    getProps: ({ setMockDocument, navigate }) => ({
-      onGenerate: setMockDocument,
+    getProps: ({ refreshDocuments, navigate }) => ({
+      onDocumentStored: refreshDocuments,
       onNavigate: navigate,
       onBack: () => navigate('home'),
     }),
@@ -50,13 +55,15 @@ export const screenDescriptors: ScreenDescriptor[] = [
     title: 'Register Document',
     sectionTitle: '⭐ Core Features',
     status: 'placeholder',
-    subtitle: ({ mockDocument }) =>
-      mockDocument ? 'View the mock document registration flow' : 'Generate mock data to unlock this demo',
-    getStatus: ({ mockDocument }) => (mockDocument ? 'working' : 'placeholder'),
-    isDisabled: ({ mockDocument }) => !mockDocument,
+    subtitle: ({ selectedDocument }) =>
+      selectedDocument
+        ? 'View the most recently generated mock document'
+        : 'Generate mock data to unlock this demo',
+    getStatus: ({ selectedDocument }) => (selectedDocument ? 'working' : 'placeholder'),
+    isDisabled: ({ selectedDocument }) => !selectedDocument,
     load: () => require('./RegisterDocument').default,
-    getProps: ({ mockDocument, navigate }) => ({
-      document: mockDocument,
+    getProps: ({ selectedDocument, navigate }) => ({
+      document: selectedDocument?.data ?? null,
       onBack: () => navigate('home'),
     }),
   },
@@ -91,10 +98,22 @@ export const screenDescriptors: ScreenDescriptor[] = [
     id: 'documents',
     title: 'Document List',
     sectionTitle: '📋 Your Data',
-    status: 'placeholder',
-    subtitle: 'View all registered identity documents',
+    status: 'working',
+    subtitle: ({ documentCatalog }) => {
+      const count = documentCatalog.documents.length;
+      if (count === 0) {
+        return 'No documents stored yet';
+      }
+      if (count === 1) {
+        return '1 document in your demo vault';
+      }
+      return `${count} documents in your demo vault`;
+    },
     load: () => require('./DocumentsList').default,
-    getProps: ({ navigate }) => ({ onBack: () => navigate('home') }),
+    getProps: ({ navigate, documentCatalog }) => ({
+      onBack: () => navigate('home'),
+      catalog: documentCatalog,
+    }),
   },
   {
     id: 'activity',

--- a/packages/mobile-sdk-demo/src/utils/documentStore.ts
+++ b/packages/mobile-sdk-demo/src/utils/documentStore.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { DocumentsAdapter } from '@selfxyz/mobile-sdk-alpha';
+import type { DocumentCatalog, IDDocument } from '@selfxyz/common/dist/esm/src/utils/types.js';
+
+const documentStore = new Map<string, IDDocument>();
+
+let catalogState: DocumentCatalog = { documents: [] };
+
+const cloneCatalog = (value: DocumentCatalog): DocumentCatalog => {
+  return JSON.parse(JSON.stringify(value)) as DocumentCatalog;
+};
+
+const cloneDocument = (value: IDDocument): IDDocument => {
+  return JSON.parse(JSON.stringify(value)) as IDDocument;
+};
+
+export const inMemoryDocumentsAdapter: DocumentsAdapter = {
+  async loadDocumentCatalog(): Promise<DocumentCatalog> {
+    return cloneCatalog(catalogState);
+  },
+  async saveDocumentCatalog(nextCatalog: DocumentCatalog): Promise<void> {
+    catalogState = cloneCatalog(nextCatalog);
+  },
+  async loadDocumentById(id: string): Promise<IDDocument | null> {
+    const document = documentStore.get(id);
+    return document ? cloneDocument(document) : null;
+  },
+  async saveDocument(id: string, passportData: IDDocument): Promise<void> {
+    documentStore.set(id, cloneDocument(passportData));
+  },
+  async deleteDocument(id: string): Promise<void> {
+    documentStore.delete(id);
+  },
+};
+
+export function resetDocumentStore() {
+  catalogState = { documents: [] };
+  documentStore.clear();
+}


### PR DESCRIPTION
## Summary
- add an in-memory documents adapter and SDK provider around the demo app
- persist generated mock documents through the Self client and refresh navigation state
- render the live document catalog on the "My Documents" screen instead of static placeholders

## Testing
- yarn workspace mobile-sdk-demo test *(fails: Cannot find module '@react-native-picker/picker' from 'jest.setup.js')*


------
https://chatgpt.com/codex/tasks/task_b_68dc2c26cd64832d8591f09e02c02e57