### PR TITLE
ease ofac check in go-sdk similar to ts-sdk

### DIFF
--- a/sdk/sdk-go/verifier.go
+++ b/sdk/sdk-go/verifier.go
@@ -469,8 +469,7 @@ func (s *BackendVerifier) Verify(
 		}
 	}
 
-	// OFAC validation: if config requires OFAC, then cumulative OFAC must be true
-	isOfacValid := true
+	isOfacValid := false
 	if configErr == nil && verificationConfig.Ofac {
 		isOfacValid = cumulativeOfac
 	}

--- a/sdk/sdk-go/verifier.go
+++ b/sdk/sdk-go/verifier.go
@@ -460,14 +460,19 @@ func (s *BackendVerifier) Verify(
 		}
 	}
 
+	// Calculate cumulative OFAC: true if any OFAC check is enabled
+	cumulativeOfac := false
+	for _, ofacCheck := range genericDiscloseOutput.Ofac {
+		if ofacCheck {
+			cumulativeOfac = true
+			break
+		}
+	}
+
+	// OFAC validation: if config requires OFAC, then cumulative OFAC must be true
 	isOfacValid := true
 	if configErr == nil && verificationConfig.Ofac {
-		for _, ofacCheck := range genericDiscloseOutput.Ofac {
-			if !ofacCheck {
-				isOfacValid = false
-				break
-			}
-		}
+		isOfacValid = cumulativeOfac
 	}
 
 	return &VerificationResult{
@@ -547,28 +552,6 @@ func (s *BackendVerifier) validateWithConfig(
 	}
 
 	s.validateTimestamp(attestationId, publicSignals, discloseIndices, issues)
-
-	if !verificationConfig.Ofac {
-		for i, ofacCheck := range genericDiscloseOutput.Ofac {
-			if ofacCheck {
-				var ofacType string
-				switch i {
-				case 0:
-					ofacType = "Passport number OFAC check"
-				case 1:
-					ofacType = "Name and DOB OFAC check"
-				case 2:
-					ofacType = "Name and YOB OFAC check"
-				default:
-					ofacType = fmt.Sprintf("OFAC check %d", i)
-				}
-				*issues = append(*issues, ConfigIssue{
-					Type:    InvalidOfac,
-					Message: fmt.Sprintf("%s is not allowed", ofacType),
-				})
-			}
-		}
-	}
 
 	return forbiddenCountriesList, genericDiscloseOutput, nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Go verifier to mark OFAC valid if any check passes and stops flagging OFAC issues when OFAC is disabled in config.
> 
> - **Go SDK (`sdk/sdk-go/verifier.go`)**:
>   - **OFAC verification**:
>     - Compute `cumulativeOfac` (true if any `Ofac` check is true) and set `IsOfacValid` from it when `verificationConfig.Ofac` is enabled.
>     - Remove config validation that appended `InvalidOfac` issues when `Ofac` is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a01df3844d9d87a7c12ed4fa3508669a122440c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OFAC validation to aggregate results across checks for more accurate pass/fail outcomes.
  * Respects configuration flags, preventing incorrect OFAC invalidations when OFAC verification is disabled.
  * Ensures issues are collected earlier, resulting in clearer, more consistent verification results.

* **Refactor**
  * Streamlined internal validation flow to reduce redundancy and improve maintainability, with no changes to public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->