### PR TITLE
move fcm token storage

### DIFF
--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -20,6 +20,7 @@ import { navigationRef } from '@/navigation';
 import { unsafe_getPrivateKey } from '@/providers/authProvider';
 import { selfClientDocumentsAdapter } from '@/providers/passportDataProvider';
 import { logNFCEvent, logProofEvent } from '@/Sentry';
+import { useSettingStore } from '@/stores/settingStore';
 import analytics from '@/utils/analytics';
 
 type GlobalCrypto = { crypto?: { subtle?: Crypto['subtle'] } };
@@ -157,6 +158,35 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
         navigationRef.navigate('AccountRecoveryChoice');
       }
     });
+
+    addListener(
+      SdkEvents.PROVING_BEGIN_GENERATION,
+      async ({ uuid, isMock, context }) => {
+        const { fcmToken } = useSettingStore.getState();
+
+        if (fcmToken) {
+          try {
+            analytics().trackEvent('DEVICE_TOKEN_REG_STARTED');
+            logProofEvent('info', 'Device token registration started', context);
+
+            const { registerDeviceToken: registerFirebaseDeviceToken } =
+              await import('@/utils/notifications/notificationService');
+            await registerFirebaseDeviceToken(uuid, fcmToken, isMock);
+
+            analytics().trackEvent('DEVICE_TOKEN_REG_SUCCESS');
+            logProofEvent('info', 'Device token registration success', context);
+          } catch (error) {
+            logProofEvent('warn', 'Device token registration failed', context, {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            console.error('Error registering device token:', error);
+            analytics().trackEvent('DEVICE_TOKEN_REG_FAILED', {
+              message: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
+      },
+    );
 
     addListener(SdkEvents.PROOF_EVENT, ({ level, context, event, details }) => {
       // Log proof events for monitoring/debugging

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -166,21 +166,21 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
 
         if (fcmToken) {
           try {
-            analytics().trackEvent('DEVICE_TOKEN_REG_STARTED');
+            adapters.analytics?.trackEvent('DEVICE_TOKEN_REG_STARTED');
             logProofEvent('info', 'Device token registration started', context);
 
             const { registerDeviceToken: registerFirebaseDeviceToken } =
               await import('@/utils/notifications/notificationService');
             await registerFirebaseDeviceToken(uuid, fcmToken, isMock);
 
-            analytics().trackEvent('DEVICE_TOKEN_REG_SUCCESS');
+            adapters.analytics?.trackEvent('DEVICE_TOKEN_REG_SUCCESS');
             logProofEvent('info', 'Device token registration success', context);
           } catch (error) {
             logProofEvent('warn', 'Device token registration failed', context, {
               error: error instanceof Error ? error.message : String(error),
             });
             console.error('Error registering device token:', error);
-            analytics().trackEvent('DEVICE_TOKEN_REG_FAILED', {
+            adapters.analytics?.trackEvent('DEVICE_TOKEN_REG_FAILED', {
               message: error instanceof Error ? error.message : String(error),
             });
           }

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -166,21 +166,21 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
 
         if (fcmToken) {
           try {
-            adapters.analytics?.trackEvent('DEVICE_TOKEN_REG_STARTED');
+            analytics().trackEvent('DEVICE_TOKEN_REG_STARTED');
             logProofEvent('info', 'Device token registration started', context);
 
             const { registerDeviceToken: registerFirebaseDeviceToken } =
               await import('@/utils/notifications/notificationService');
             await registerFirebaseDeviceToken(uuid, fcmToken, isMock);
 
-            adapters.analytics?.trackEvent('DEVICE_TOKEN_REG_SUCCESS');
+            analytics().trackEvent('DEVICE_TOKEN_REG_SUCCESS');
             logProofEvent('info', 'Device token registration success', context);
           } catch (error) {
             logProofEvent('warn', 'Device token registration failed', context, {
               error: error instanceof Error ? error.message : String(error),
             });
             console.error('Error registering device token:', error);
-            adapters.analytics?.trackEvent('DEVICE_TOKEN_REG_FAILED', {
+            analytics().trackEvent('DEVICE_TOKEN_REG_FAILED', {
               message: error instanceof Error ? error.message : String(error),
             });
           }

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -96,15 +96,6 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
       auth: {
         getPrivateKey: () => unsafe_getPrivateKey(),
       },
-      notification: {
-        registerDeviceToken: async (sessionId, deviceToken, isMock) => {
-          // Forward to our app-level function which handles staging vs production
-          // and also fetches the token if not provided
-          const { registerDeviceToken: registerFirebaseDeviceToken } =
-            await import('@/utils/notifications/notificationService');
-          return registerFirebaseDeviceToken(sessionId, deviceToken, isMock);
-        },
-      },
     }),
     [],
   );

--- a/app/src/screens/prove/ConfirmBelongingScreen.tsx
+++ b/app/src/screens/prove/ConfirmBelongingScreen.tsx
@@ -21,6 +21,7 @@ import { Title } from '@/components/typography/Title';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
 import { styles } from '@/screens/prove/ProofRequestStatusScreen';
+import { useSettingStore } from '@/stores/settingStore';
 import { flushAllAnalytics, trackNfcEvent } from '@/utils/analytics';
 import { black, white } from '@/utils/colors';
 import { notificationSuccess } from '@/utils/haptic';
@@ -40,8 +41,8 @@ const ConfirmBelongingScreen: React.FC<ConfirmBelongingScreenProps> = () => {
   const [_requestingPermission, setRequestingPermission] = useState(false);
   const currentState = useProvingStore(state => state.currentState);
   const init = useProvingStore(state => state.init);
-  const setFcmToken = useProvingStore(state => state.setFcmToken);
   const setUserConfirmed = useProvingStore(state => state.setUserConfirmed);
+  const setFcmToken = useSettingStore(state => state.setFcmToken);
   const isReadyToProve = currentState === 'ready_to_prove';
   useEffect(() => {
     notificationSuccess();
@@ -74,7 +75,7 @@ const ConfirmBelongingScreen: React.FC<ConfirmBelongingScreenProps> = () => {
       if (permissionGranted) {
         const token = await getFCMToken();
         if (token) {
-          setFcmToken(token, selfClient);
+          setFcmToken(token);
           trackEvent(ProofEvents.FCM_TOKEN_STORED);
         }
       }

--- a/app/src/stores/settingStore.ts
+++ b/app/src/stores/settingStore.ts
@@ -20,6 +20,8 @@ interface PersistedSettingsState {
   isDevMode: boolean;
   setDevModeOn: () => void;
   setDevModeOff: () => void;
+  fcmToken: string | null;
+  setFcmToken: (token: string | null) => void;
 }
 
 interface NonPersistedSettingsState {
@@ -68,6 +70,9 @@ export const useSettingStore = create<SettingsState>()(
       isDevMode: false,
       setDevModeOn: () => set({ isDevMode: true }),
       setDevModeOff: () => set({ isDevMode: false }),
+
+      fcmToken: null,
+      setFcmToken: (token: string | null) => set({ fcmToken: token }),
 
       // Non-persisted state (will not be saved to storage)
       hideNetworkModal: false,

--- a/app/tests/src/utils/proving/validateDocument.test.ts
+++ b/app/tests/src/utils/proving/validateDocument.test.ts
@@ -76,9 +76,6 @@ function createTestClient() {
           })),
         },
       },
-      notification: {
-        registerDeviceToken: async () => Promise.resolve(),
-      },
       crypto: {
         hash: jest.fn(),
         sign: jest.fn(),

--- a/app/tests/utils/selfClientProvider.ts
+++ b/app/tests/utils/selfClientProvider.ts
@@ -62,7 +62,4 @@ export const mockAdapters = {
   network: mockNetwork,
   crypto: mockCrypto,
   documents: mockDocuments,
-  notification: {
-    registerDeviceToken: async () => Promise.resolve(),
-  },
 };

--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -40,7 +40,7 @@ const optionalDefaults: Required<Pick<Adapters, 'clock' | 'logger'>> = {
   },
 };
 
-const REQUIRED_ADAPTERS = ['auth', 'scanner', 'network', 'crypto', 'documents', 'notification'] as const;
+const REQUIRED_ADAPTERS = ['auth', 'scanner', 'network', 'crypto', 'documents'] as const;
 
 export const createListenersMap = (): {
   map: Map<SDKEvent, Set<(p: any) => void>>;

--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -132,13 +132,6 @@ export function createSelfClient({
     return adapters.auth.getPrivateKey();
   }
 
-  async function registerNotificationsToken(sessionId: string, deviceToken?: string, isMock?: boolean): Promise<void> {
-    if (!_adapters.notification) {
-      throw notImplemented('notification');
-    }
-    return _adapters.notification.registerDeviceToken(sessionId, deviceToken, isMock);
-  }
-
   async function hasPrivateKey(): Promise<boolean> {
     if (!adapters.auth) return false;
     try {

--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -153,7 +153,6 @@ export function createSelfClient({
     logProofEvent: (level: LogLevel, message: string, context: ProofContext, details?: Record<string, any>) => {
       emit(SdkEvents.PROOF_EVENT, { context, event: message, details, level });
     },
-    registerNotificationsToken,
     // TODO: inline for now
     loadDocumentCatalog: async () => {
       return _adapters.documents.loadDocumentCatalog();

--- a/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
+++ b/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
@@ -214,9 +214,7 @@ export interface ProvingState {
   error_code: string | null;
   reason: string | null;
   endpointType: EndpointType | null;
-  fcmToken: string | null;
   env: 'prod' | 'stg' | null;
-  setFcmToken: (token: string, selfClient: SelfClient) => void;
   init: (
     selfClient: SelfClient,
     circuitType: 'dsc' | 'disclose' | 'register',
@@ -487,11 +485,6 @@ export const useProvingStore = create<ProvingState>((set, get) => {
     error_code: null,
     reason: null,
     endpointType: null,
-    fcmToken: null,
-    setFcmToken: (token: string, selfClient: SelfClient) => {
-      set({ fcmToken: token });
-      selfClient.trackEvent(ProofEvents.FCM_TOKEN_STORED);
-    },
     _handleWebSocketMessage: async (event: MessageEvent, selfClient: SelfClient) => {
       if (!actor) {
         console.error('Cannot process message: State machine not initialized.');
@@ -1201,7 +1194,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
     startProving: async (selfClient: SelfClient) => {
       _checkActorInitialized(actor);
       const startTime = Date.now();
-      const { wsConnection, sharedKey, passportData, secret, uuid, fcmToken } = get();
+      const { wsConnection, sharedKey, passportData, secret, uuid } = get();
       const context = createProofContext(selfClient, 'startProving', {
         sessionId: uuid || get().uuid || 'unknown-session',
       });
@@ -1223,24 +1216,12 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       }
 
       try {
-        if (fcmToken) {
-          try {
-            const isMockPassport = passportData?.mock;
-            selfClient.trackEvent(ProofEvents.DEVICE_TOKEN_REG_STARTED);
-            selfClient.logProofEvent('info', 'Device token registration started', context);
-            await selfClient.registerNotificationsToken(uuid, fcmToken, isMockPassport);
-            selfClient.trackEvent(ProofEvents.DEVICE_TOKEN_REG_SUCCESS);
-            selfClient.logProofEvent('info', 'Device token registration success', context);
-          } catch (error) {
-            selfClient.logProofEvent('warn', 'Device token registration failed', context, {
-              error: error instanceof Error ? error.message : String(error),
-            });
-            console.error('Error registering device token:', error);
-            selfClient.trackEvent(ProofEvents.DEVICE_TOKEN_REG_FAILED, {
-              message: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }
+        // Emit event for FCM token registration
+        selfClient.emit(SdkEvents.PROVING_BEGIN_GENERATION, {
+          uuid,
+          isMock: passportData?.mock ?? false,
+          context,
+        });
 
         selfClient.trackEvent(ProofEvents.PAYLOAD_GEN_STARTED);
         selfClient.logProofEvent('info', 'Payload generation started', context);

--- a/packages/mobile-sdk-alpha/src/types/events.ts
+++ b/packages/mobile-sdk-alpha/src/types/events.ts
@@ -68,6 +68,14 @@ export enum SdkEvents {
    * and guide them through the recovery process to regain access.
    */
   PROVING_ACCOUNT_RECOVERY_REQUIRED = 'PROVING_ACCOUNT_RECOVERY_REQUIRED',
+
+  /**
+   * Emitted when the proving generation process begins.
+   *
+   * **Recommended:** Use this to handle notification token registration and other setup tasks
+   * that need to occur when proof generation starts.
+   */
+  PROVING_BEGIN_GENERATION = 'PROVING_BEGIN_GENERATION',
   /**
    * Emitted for various proof-related events during the proving process.
    *
@@ -97,6 +105,11 @@ export interface SDKEventMap {
     documentCategory: DocumentCategory | null;
   };
   [SdkEvents.PROVING_ACCOUNT_RECOVERY_REQUIRED]: undefined;
+  [SdkEvents.PROVING_BEGIN_GENERATION]: {
+    uuid: string;
+    isMock: boolean;
+    context: ProofContext;
+  };
 
   [SdkEvents.PROGRESS]: Progress;
   [SdkEvents.ERROR]: Error;

--- a/packages/mobile-sdk-alpha/src/types/public.ts
+++ b/packages/mobile-sdk-alpha/src/types/public.ts
@@ -90,10 +90,6 @@ export interface MRZValidation {
   overall: boolean;
 }
 
-export interface NotificationAdapter {
-  registerDeviceToken(sessionId: string, deviceToken?: string, isMock?: boolean): Promise<void>;
-}
-
 export type LogLevel = 'info' | 'warn' | 'error';
 
 export interface Progress {
@@ -110,7 +106,6 @@ export interface Adapters {
   analytics?: AnalyticsAdapter;
   auth: AuthAdapter;
   documents: DocumentsAdapter;
-  notification: NotificationAdapter;
 }
 
 export interface LoggerAdapter {
@@ -181,7 +176,6 @@ export interface SelfClient {
   logProofEvent(level: LogLevel, message: string, context: ProofContext, details?: Record<string, any>): void;
   loadDocumentCatalog(): Promise<DocumentCatalog>;
   saveDocumentCatalog(catalog: DocumentCatalog): Promise<void>;
-  registerNotificationsToken(sessionId: string, deviceToken?: string, isMock?: boolean): Promise<void>;
   loadDocumentById(id: string): Promise<IDDocument | null>;
   saveDocument(id: string, passportData: IDDocument): Promise<void>;
   deleteDocument(id: string): Promise<void>;

--- a/packages/mobile-sdk-alpha/tests/documents/utils.test.ts
+++ b/packages/mobile-sdk-alpha/tests/documents/utils.test.ts
@@ -14,9 +14,6 @@ const createMockSelfClientWithDocumentsAdapter = (documentsAdapter: DocumentsAda
     config: defaultConfig,
     listeners: new Map(),
     adapters: {
-      notification: {
-        registerDeviceToken: async () => Promise.resolve(),
-      },
       auth: {
         getPrivateKey: async () => null,
       },

--- a/packages/mobile-sdk-alpha/tests/utils/testHelpers.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/testHelpers.ts
@@ -4,7 +4,6 @@
 
 /* eslint-disable sort-exports/sort-exports */
 import type { CryptoAdapter, DocumentsAdapter, NetworkAdapter, ScannerAdapter } from '../../src';
-import type { NotificationAdapter } from '../../src/types/public';
 
 // Shared test data
 export const sampleMRZ = `P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\nL898902C36UTO7408122F1204159ZE184226B<<<<<10`;
@@ -66,17 +65,12 @@ const mockAuth = {
   getPrivateKey: async () => 'stubbed-private-key',
 };
 
-const mockNotification: NotificationAdapter = {
-  registerDeviceToken: async () => Promise.resolve(),
-};
-
 export const mockAdapters = {
   scanner: mockScanner,
   network: mockNetwork,
   crypto: mockCrypto,
   documents: mockDocuments,
   auth: mockAuth,
-  notification: mockNotification,
 };
 
 // Shared test expectations

--- a/packages/mobile-sdk-demo/src/providers/SelfClientProvider.tsx
+++ b/packages/mobile-sdk-demo/src/providers/SelfClientProvider.tsx
@@ -81,11 +81,6 @@ export function SelfClientProvider({ children }: PropsWithChildren) {
           }
         },
       },
-      notification: {
-        async registerDeviceToken(): Promise<void> {
-          // No-op notification adapter for the demo application
-        },
-      },
     }),
     [],
   );

--- a/sdk/core/src/SelfBackendVerifier.ts
+++ b/sdk/core/src/SelfBackendVerifier.ts
@@ -328,7 +328,7 @@ export class SelfBackendVerifier {
             ? verificationConfig.minimumAge <= Number.parseInt(genericDiscloseOutput.minimumAge, 10)
             : true,
         isOfacValid:
-        //isOfacValid is true when a person is in OFAC list
+          //isOfacValid is true when a person is in OFAC list
           verificationConfig.ofac !== undefined && verificationConfig.ofac ? cumulativeOfac : false,
       },
       forbiddenCountriesList,


### PR DESCRIPTION
move fcm token from proving store to setting store for better separation of concerns.

having fcm token in the proving machine felt a bit out of place. its not core to proving in any way. moving it out means we dont need to expose it to the sdk. this is good because sdk users can setup notifications how they wish. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes notification adapter from SDK, adds a PROVING_BEGIN_GENERATION event, moves FCM token to Settings store, and handles device token registration in the app via a listener.
> 
> - **SDK (mobile-sdk-alpha)**:
>   - **API Changes**: Remove `notification` adapter and `registerNotificationsToken` from `SelfClient`; drop from `Adapters`/`REQUIRED_ADAPTERS`.
>   - **Events**: Add `SdkEvents.PROVING_BEGIN_GENERATION` with payload (`uuid`, `isMock`, `context`).
>   - **Proving**: Emit `PROVING_BEGIN_GENERATION` at start; remove `fcmToken`/`setFcmToken` from proving state.
> - **App**:
>   - **Settings Store**: Add `fcmToken` and `setFcmToken` to `useSettingStore` (persisted).
>   - **ConfirmBelongingScreen**: Store FCM via `useSettingStore` instead of proving store.
>   - **SelfClientProvider**: Add listener for `PROVING_BEGIN_GENERATION` to register device token using stored `fcmToken`; remove SDK-level notification adapter usage.
> - **Demo & Tests**:
>   - Update demo provider and tests to reflect removal of notification adapter and new event-driven flow.
> - **Misc**:
>   - Minor comment fix in `SelfBackendVerifier`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5522ccc7938cbc461cf5a739627eea7218dcace. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device token registration now occurs automatically when proof generation begins, with explicit success/error tracking and analytics.

* **Refactor**
  * FCM token persisted in Settings and token management decoupled from proving flows via an explicit start-generation signal.

* **Breaking Changes**
  * Notification adapter and related public APIs were removed from the SDK surface; callers must no longer rely on notification registration methods.

* **Tests**
  * Test fixtures and mocks updated to remove notification adapter and related mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->