### PR TITLE
feat: add dsc_sha384_rsapss_65537_48_3072

### DIFF
--- a/circuits/circuits/dsc/instances/dsc_sha384_rsapss_65537_48_3072.circom
+++ b/circuits/circuits/dsc/instances/dsc_sha384_rsapss_65537_48_3072.circom
@@ -1,0 +1,5 @@
+pragma circom 2.1.9;
+
+include "../dsc.circom";
+
+component main { public [ merkle_root ] } = DSC(18, 120, 35);

--- a/circuits/tests/disclose/vc_and_disclose.test.ts
+++ b/circuits/tests/disclose/vc_and_disclose.test.ts
@@ -71,9 +71,9 @@ describe('Disclose', function () {
       path.join(__dirname, '../../circuits/disclose/vc_and_disclose.circom'),
       {
         include: [
-          '../node_modules',
-          '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/@zk-kit/binary-merkle-root.circom/src',
+          'node_modules/circomlib/circuits',
         ],
       }
     );

--- a/circuits/tests/disclose/vc_and_disclose_aadhaar.test.ts
+++ b/circuits/tests/disclose/vc_and_disclose_aadhaar.test.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // const privateKeyPath = path.join(__dirname, '../../../node_modules/anon-aadhaar-circuits/assets/testPrivateKey.pem');
 const privateKeyPem = fs.readFileSync(
-  path.join(__dirname, '../../../node_modules/anon-aadhaar-circuits/assets/testPrivateKey.pem'),
+  path.join(__dirname, '../../node_modules/anon-aadhaar-circuits/assets/testPrivateKey.pem'),
   'utf8'
 );
 
@@ -52,7 +52,7 @@ describe(' VC and Disclose Aadhaar Circuit Tests', function () {
       {
         verbose: true,
         logOutput: true,
-        include: ['../node_modules', '../node_modules/circomlib/circuits'],
+        include: ['node_modules', 'node_modules/circomlib/circuits'],
       }
     );
   });

--- a/circuits/tests/disclose/vc_and_disclose_id.test.ts
+++ b/circuits/tests/disclose/vc_and_disclose_id.test.ts
@@ -66,9 +66,9 @@ describe('Disclose', function () {
       path.join(__dirname, '../../circuits/disclose/vc_and_disclose_id.circom'),
       {
         include: [
-          '../node_modules',
-          '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/@zk-kit/binary-merkle-root.circom/src',
+          'node_modules/circomlib/circuits',
         ],
       }
     );

--- a/circuits/tests/dsc/dsc.test.ts
+++ b/circuits/tests/dsc/dsc.test.ts
@@ -45,9 +45,9 @@ testSuite.forEach(({ sigAlg, hashFunction, domainParameter, keyLength }) => {
         ),
         {
           include: [
-            '../node_modules',
-            '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-            '../node_modules/circomlib/circuits',
+            'node_modules',
+            'node_modules/@zk-kit/binary-merkle-root.circom/src',
+            'node_modules/circomlib/circuits',
           ],
         }
       );

--- a/circuits/tests/dsc/test_cases.ts
+++ b/circuits/tests/dsc/test_cases.ts
@@ -41,6 +41,13 @@ export const fullSigAlgs = [
     domainParameter: '3',
     keyLength: '3072',
   },
+  {
+    sigAlg: 'rsapss',
+    hashFunction: 'sha384',
+    saltLen: '48',
+    domainParameter: '65537',
+    keyLength: '3072',
+  },
   //ECDSA
   //brainpool
   { sigAlg: 'ecdsa', hashFunction: 'sha1', domainParameter: 'brainpoolP256r1', keyLength: '256' },

--- a/circuits/tests/ofac/ofac.test.ts
+++ b/circuits/tests/ofac/ofac.test.ts
@@ -81,9 +81,9 @@ describe('OFAC - Passport number and Nationality match', function () {
       path.join(__dirname, '../../circuits/tests/ofac/ofac_passport_number_tester.circom'),
       {
         include: [
-          '../node_modules',
-          '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/@zk-kit/binary-merkle-root.circom/src',
+          'node_modules/circomlib/circuits',
         ],
       }
     );
@@ -142,9 +142,9 @@ describe('OFAC - Name and DOB match', function () {
       path.join(__dirname, '../../circuits/tests/ofac/ofac_name_dob_tester.circom'),
       {
         include: [
-          '../node_modules',
-          '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/@zk-kit/binary-merkle-root.circom/src',
+          'node_modules/circomlib/circuits',
         ],
       }
     );
@@ -210,9 +210,9 @@ describe('OFAC - Name and YOB match', function () {
       path.join(__dirname, '../../circuits/tests/ofac/ofac_name_yob_tester.circom'),
       {
         include: [
-          '../node_modules',
-          '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/@zk-kit/binary-merkle-root.circom/src',
+          'node_modules/circomlib/circuits',
         ],
       }
     );
@@ -276,9 +276,9 @@ describe('OFAC - SMT Security Tests', function () {
       path.join(__dirname, '../../circuits/tests/ofac/ofac_passport_number_tester.circom'),
       {
         include: [
-          '../node_modules',
-          '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/@zk-kit/binary-merkle-root.circom/src',
+          'node_modules/circomlib/circuits',
         ],
       }
     );
@@ -380,9 +380,9 @@ describe('OFAC - ID Card - Name and DOB match', function () {
       path.join(__dirname, '../../circuits/tests/ofac/ofac_name_dob_id_tester.circom'),
       {
         include: [
-          '../node_modules',
-          '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/@zk-kit/binary-merkle-root.circom/src',
+          'node_modules/circomlib/circuits',
         ],
       }
     );
@@ -439,9 +439,9 @@ describe('OFAC - ID Card - Name and YOB match', function () {
       path.join(__dirname, '../../circuits/tests/ofac/ofac_name_yob_id_tester.circom'),
       {
         include: [
-          '../node_modules',
-          '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/@zk-kit/binary-merkle-root.circom/src',
+          'node_modules/circomlib/circuits',
         ],
       }
     );

--- a/circuits/tests/other_circuits/custom_hasher.test.ts
+++ b/circuits/tests/other_circuits/custom_hasher.test.ts
@@ -23,16 +23,16 @@ describe('CustomHasher', function () {
     );
     circuitCustomHasher = await wasm_tester(circuitPathCustomHasher, {
       include: [
-        '../node_modules',
-        '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-        '../node_modules/circomlib/circuits',
+        'node_modules',
+        'node_modules/@zk-kit/binary-merkle-root.circom/src',
+        'node_modules/circomlib/circuits',
       ],
     });
     circuitPackBytesAndPoseidon = await wasm_tester(circuitPathPackBytesAndPoseidon, {
       include: [
-        '../node_modules',
-        '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-        '../node_modules/circomlib/circuits',
+        'node_modules',
+        'node_modules/@zk-kit/binary-merkle-root.circom/src',
+        'node_modules/circomlib/circuits',
       ],
     });
   });

--- a/circuits/tests/other_circuits/is_older_than.test.ts
+++ b/circuits/tests/other_circuits/is_older_than.test.ts
@@ -78,7 +78,7 @@ describe('DateIsLessChecker Circuit Test', function () {
     circuit = await wasm_tester(
       path.join(__dirname, '../../circuits/tests/utils/isOlderThan_tester.circom'),
       {
-        include: ['../node_modules'],
+        include: ['node_modules'],
       }
     );
   });

--- a/circuits/tests/other_circuits/is_valid.test.ts
+++ b/circuits/tests/other_circuits/is_valid.test.ts
@@ -69,7 +69,7 @@ describe('DateIsLessChecker Circuit Test', function () {
     circuit = await wasm_tester(
       path.join(__dirname, '../../circuits/tests/utils/isValid_tester.circom'),
       {
-        include: ['../node_modules'],
+        include: ['node_modules'],
       }
     );
   });

--- a/circuits/tests/other_circuits/prove_country_is_not_in_list.test.ts
+++ b/circuits/tests/other_circuits/prove_country_is_not_in_list.test.ts
@@ -21,9 +21,9 @@ describe('ProveCountryIsNotInList', function () {
     );
     circuit = await wasm_tester(circuitPath, {
       include: [
-        '../node_modules',
-        '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-        '../node_modules/circomlib/circuits',
+        'node_modules',
+        'node_modules/@zk-kit/binary-merkle-root.circom/src',
+        'node_modules/circomlib/circuits',
       ],
     });
   });

--- a/circuits/tests/other_circuits/qrdata_extractor.test.ts
+++ b/circuits/tests/other_circuits/qrdata_extractor.test.ts
@@ -14,7 +14,7 @@ import fs from 'fs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const privateKeyPem = fs.readFileSync(
-  path.join(__dirname, '../../../node_modules/anon-aadhaar-circuits/assets/testPrivateKey.pem'),
+  path.join(__dirname, '../../node_modules/anon-aadhaar-circuits/assets/testPrivateKey.pem'),
   'utf8'
 );
 
@@ -28,9 +28,9 @@ describe('Aadhaar QR Data Extractor1', function () {
         verbose: true,
         logOutput: true,
         include: [
-          '../node_modules',
-          '../node_modules/anon-aadhaar-circuits/src/helpers/constants.circom',
-          '../node_modules/circomlib/circuits',
+          'node_modules',
+          'node_modules/anon-aadhaar-circuits/src/helpers/constants.circom',
+          'node_modules/circomlib/circuits',
         ],
       }
     );

--- a/circuits/tests/register/register.test.ts
+++ b/circuits/tests/register/register.test.ts
@@ -62,9 +62,9 @@ testSuite.forEach(
           ),
           {
             include: [
-              '../node_modules',
-              '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-              '../node_modules/circomlib/circuits',
+              'node_modules',
+              'node_modules/@zk-kit/binary-merkle-root.circom/src',
+              'node_modules/circomlib/circuits',
             ],
           }
         );

--- a/circuits/tests/register/register_aadhaar.test.ts
+++ b/circuits/tests/register/register_aadhaar.test.ts
@@ -18,11 +18,11 @@ import { pubkeys } from './pubkeys.js';
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 const privateKeyPem = fs.readFileSync(
-  path.join(__dirname, '../../../node_modules/anon-aadhaar-circuits/assets/testPrivateKey.pem'),
+  path.join(__dirname, '../../node_modules/anon-aadhaar-circuits/assets/testPrivateKey.pem'),
   'utf8'
 );
 const publicKeyPem = fs.readFileSync(
-  path.join(__dirname, '../../../common/src/utils/aadhaar/assets/testPublicKey.pem'),
+  path.join(__dirname, '../../node_modules/anon-aadhaar-circuits/assets/testPublicKey.pem'),
   'utf8'
 );
 
@@ -35,7 +35,7 @@ describe('REGISTER AADHAAR Circuit Tests', function () {
       {
         verbose: true,
         logOutput: true,
-        include: ['../node_modules'],
+        include: ['node_modules', 'node_modules/circomlib/circuits'],
       }
     );
   });

--- a/circuits/tests/register_id/register_id.test.ts
+++ b/circuits/tests/register_id/register_id.test.ts
@@ -59,9 +59,9 @@ testSuite.forEach(
           ),
           {
             include: [
-              '../node_modules',
-              '../node_modules/@zk-kit/binary-merkle-root.circom/src',
-              '../node_modules/circomlib/circuits',
+              'node_modules',
+              'node_modules/@zk-kit/binary-merkle-root.circom/src',
+              'node_modules/circomlib/circuits',
             ],
           }
         );

--- a/circuits/tests/utils/ecdsa.test.ts
+++ b/circuits/tests/utils/ecdsa.test.ts
@@ -91,7 +91,7 @@ describe('ecdsa', () => {
           const circuit = await wasmTester(
             path.join(__dirname, `../../circuits/tests/utils/ecdsa/test_${curve}.circom`),
             {
-              include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+              include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
             }
           );
 
@@ -119,7 +119,7 @@ describe('ecdsa', () => {
       const circuit = await wasmTester(
         path.join(__dirname, `../../circuits/tests/utils/ecdsa/test_${curve}.circom`),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 
@@ -144,7 +144,7 @@ describe('ecdsa', () => {
     const circuit = await wasmTester(
       path.join(__dirname, `../../circuits/tests/utils/ecdsa/test_p256.circom`),
       {
-        include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+        include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
       }
     );
 
@@ -206,7 +206,7 @@ describe('ecdsa', () => {
     const circuit = await wasmTester(
       path.join(__dirname, `../../circuits/tests/utils/ecdsa/test_p256.circom`),
       {
-        include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+        include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
       }
     );
 

--- a/circuits/tests/utils/rsaPkcs1v1_5.test.ts
+++ b/circuits/tests/utils/rsaPkcs1v1_5.test.ts
@@ -37,7 +37,7 @@ describe('VerifyRsaPkcs1v1_5 Circuit Test', function () {
       const circuit = await wasmTester(
         path.join(__dirname, `../../circuits/tests/utils/rsa/test_${algorithm}.circom`),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 
@@ -61,7 +61,7 @@ describe('VerifyRsaPkcs1v1_5 Circuit Test', function () {
       const circuit = await wasmTester(
         path.join(__dirname, `../../circuits/tests/utils/rsa/test_${algorithm}.circom`),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 
@@ -83,7 +83,7 @@ describe('VerifyRsaPkcs1v1_5 Circuit Test', function () {
       const circuit = await wasmTester(
         path.join(__dirname, `../../circuits/tests/utils/rsa/test_${algorithm}.circom`),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 

--- a/circuits/tests/utils/rsapss.test.ts
+++ b/circuits/tests/utils/rsapss.test.ts
@@ -30,7 +30,7 @@ describe('VerifyRsapss Circuit Test', function () {
             `../../circuits/tests/utils/rsapss/test_${algorithm.algo}_${algorithm.saltLength}.circom`
           ),
           {
-            include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+            include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
           }
         );
 
@@ -68,7 +68,7 @@ describe('VerifyRsapss Circuit Test', function () {
           `../../circuits/tests/utils/rsapss/test_${algorithm.algo}_${algorithm.saltLength}.circom`
         ),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 
@@ -101,7 +101,7 @@ describe('VerifyRsapss Circuit Test', function () {
           `../../circuits/tests/utils/rsapss/test_${algorithm.algo}_${algorithm.saltLength}.circom`
         ),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 
@@ -133,7 +133,7 @@ describe('VerifyRsapss Circuit Test', function () {
           `../../circuits/tests/utils/rsapss/test_${algorithm.algo}_${algorithm.saltLength}.circom`
         ),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 
@@ -163,7 +163,7 @@ describe('VerifyRsapss Circuit Test', function () {
           `../../circuits/tests/utils/rsapss/test_${algorithm.algo}_${algorithm.saltLength}.circom`
         ),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 
@@ -191,7 +191,7 @@ describe('VerifyRsapss Circuit Test', function () {
           `../../circuits/tests/utils/rsapss/test_${algorithm.algo}_${algorithm.saltLength}.circom`
         ),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 
@@ -222,7 +222,7 @@ describe('VerifyRsapss Circuit Test', function () {
           `../../circuits/tests/utils/rsapss/test_${algorithm.algo}_${algorithm.saltLength}.circom`
         ),
         {
-          include: ['../node_modules', '../node_modules/@zk-kit/binary-merkle-root.circom/src'],
+          include: ['node_modules', 'node_modules/@zk-kit/binary-merkle-root.circom/src'],
         }
       );
 


### PR DESCRIPTION
support for serbia dsc 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an additional DSC circuit variant exposing a public merkle_root input for verification workflows.

- **Tests**
  - Added RSA‑PSS test vector (SHA‑384, 3072‑bit key, exponent 65537, 48‑byte salt).
  - Standardized test dependency resolution to use top-level node_modules paths for more reliable test loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->