### PR TITLE
SELF-761: Address Play Store warning: build outputs with 16 KB pages

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -65,7 +65,7 @@ subprojects {
 
                 if (buildGradleFile.exists()) {
                     def buildGradleText = buildGradleFile.text
-                    def namespaceMatcher = buildGradleText =~ /namespace\s*['"](.+?)['"]/
+                    def namespaceMatcher = buildGradleText =~ /namespace\s*['"](.+?)['"]/ 
                     if (namespaceMatcher.find()) {
                         namespace = namespaceMatcher[0][1]
                         println "Set namespace for ${project.name} to ${namespace} from build.gradle"
@@ -88,6 +88,90 @@ subprojects {
                     namespace = project.group
                     println "AndroidManifest.xml not found. Set namespace for ${project.name} to ${namespace}"
                 }
+            }
+        }
+    }
+}
+
+def SIXTEEN_K_PAGE_FLAG = '-Wl,-z,max-page-size=16384'
+
+subprojects { project ->
+    if (project.name != 'passportreader') {
+        return
+    }
+
+    project.plugins.withId('com.android.library') {
+        def androidExtension = project.extensions.findByName('android')
+        if (androidExtension != null) {
+            try {
+                if (androidExtension.hasProperty('ndkVersion')) {
+                    androidExtension.ndkVersion = rootProject.ext.ndkVersion
+                }
+
+                def packagingOptions = androidExtension.hasProperty('packagingOptions') ? androidExtension.packagingOptions : null
+                if (packagingOptions?.metaClass?.hasProperty(packagingOptions, 'jniLibs')) {
+                    packagingOptions.jniLibs.useLegacyPackaging = false
+                } else if (androidExtension.metaClass.hasProperty(androidExtension, 'packaging')) {
+                    androidExtension.packaging { jniLibs { useLegacyPackaging = false } }
+                }
+            } catch (Exception exception) {
+                println "⚠️ 16 KB alignment: Failed to update packaging for ${project.path}: ${exception.message}"
+            }
+        }
+
+        project.afterEvaluate {
+            def androidExt = project.extensions.findByName('android')
+            if (androidExt != null) {
+                try {
+                    def nativeConfig = androidExt.defaultConfig?.externalNativeBuild
+                    def maybeAddFlag = { nativeBlock ->
+                        if (nativeBlock == null) {
+                            return
+                        }
+
+                        def currentArgs
+                        try {
+                            currentArgs = nativeBlock.arguments
+                        } catch (MissingPropertyException ignore) {
+                            currentArgs = null
+                        }
+
+                        if (currentArgs == null) {
+                            try {
+                                nativeBlock.arguments = [SIXTEEN_K_PAGE_FLAG]
+                                return
+                            } catch (MissingPropertyException ignore) {
+                                try {
+                                    nativeBlock.arguments(SIXTEEN_K_PAGE_FLAG)
+                                } catch (Exception ignored) {
+                                    // Swallow and fall through to logging below
+                                }
+                                return
+                            }
+                        }
+
+                        if (currentArgs instanceof Collection && !currentArgs.contains(SIXTEEN_K_PAGE_FLAG)) {
+                            currentArgs.add(SIXTEEN_K_PAGE_FLAG)
+                        }
+                    }
+
+                    maybeAddFlag(nativeConfig?.cmake)
+                    maybeAddFlag(nativeConfig?.ndkBuild)
+                } catch (Exception exception) {
+                    println "⚠️ 16 KB alignment: Failed to seed native arguments for ${project.path}: ${exception.message}"
+                }
+            }
+
+            try {
+                def externalNativeTaskClass = Class.forName('com.android.build.gradle.tasks.ExternalNativeBuildTask')
+                project.tasks.withType(externalNativeTaskClass).configureEach { task ->
+                    def args = task.hasProperty('buildCommandArguments') ? task.buildCommandArguments : null
+                    if (args instanceof Collection && !args.contains(SIXTEEN_K_PAGE_FLAG)) {
+                        args.add(SIXTEEN_K_PAGE_FLAG)
+                    }
+                }
+            } catch (ClassNotFoundException ignored) {
+                println "⚠️ 16 KB alignment: ExternalNativeBuildTask class not available for ${project.path}"
             }
         }
     }

--- a/app/scripts/setup-private-modules.cjs
+++ b/app/scripts/setup-private-modules.cjs
@@ -14,6 +14,10 @@ const PRIVATE_MODULE_PATH = path.join(
   ANDROID_DIR,
   'android-passport-nfc-reader',
 );
+const PASSPORTREADER_MODULE_PATH = path.join(
+  PRIVATE_MODULE_PATH,
+  'app',
+);
 
 const GITHUB_ORG = 'selfxyz';
 const REPO_NAME = 'android-passport-nfc-reader';
@@ -237,9 +241,54 @@ function setupAndroidPassportReader() {
   // Validate the setup
   if (!isDryRun) {
     validateSetup();
+    remind16kAlignmentSteps();
   }
 
   log(`${REPO_NAME} setup complete!`, 'success');
+}
+
+function remind16kAlignmentSteps() {
+  const gradleFile = path.join(PASSPORTREADER_MODULE_PATH, 'build.gradle');
+  const jniLibsDir = path.join(
+    PASSPORTREADER_MODULE_PATH,
+    'src',
+    'main',
+    'jniLibs',
+  );
+
+  if (fs.existsSync(gradleFile)) {
+    log(
+      '✅ passportreader module detected. Root Gradle script now injects 16 KB alignment flags during builds.',
+      'success',
+    );
+    log(
+      'ℹ️ To refresh aligned binaries locally run: ./gradlew :passportreader:clean :passportreader:assembleRelease',
+      'info',
+    );
+  }
+
+  if (fs.existsSync(jniLibsDir)) {
+    const soFiles = fs
+      .readdirSync(jniLibsDir, { withFileTypes: true })
+      .flatMap((entry) => {
+        if (!entry.isDirectory()) {
+          return [];
+        }
+
+        const archDir = path.join(jniLibsDir, entry.name);
+        return fs
+          .readdirSync(archDir, { withFileTypes: true })
+          .filter((file) => file.isFile() && file.name.endsWith('.so'))
+          .map((file) => path.join(entry.name, file.name));
+      });
+
+    if (soFiles.length > 0) {
+      log(
+        `⚠️ Found prebuilt JNI libraries in passportreader: ${soFiles.join(', ')}. Ensure they are rebuilt or replaced with 16 KB aligned versions.`,
+        'warning',
+      );
+    }
+  }
 }
 
 function scrubGitRemoteUrl() {

--- a/app/scripts/setup-private-modules.cjs
+++ b/app/scripts/setup-private-modules.cjs
@@ -14,10 +14,7 @@ const PRIVATE_MODULE_PATH = path.join(
   ANDROID_DIR,
   'android-passport-nfc-reader',
 );
-const PASSPORTREADER_MODULE_PATH = path.join(
-  PRIVATE_MODULE_PATH,
-  'app',
-);
+const PASSPORTREADER_MODULE_PATH = path.join(PRIVATE_MODULE_PATH, 'app');
 
 const GITHUB_ORG = 'selfxyz';
 const REPO_NAME = 'android-passport-nfc-reader';
@@ -270,7 +267,7 @@ function remind16kAlignmentSteps() {
   if (fs.existsSync(jniLibsDir)) {
     const soFiles = fs
       .readdirSync(jniLibsDir, { withFileTypes: true })
-      .flatMap((entry) => {
+      .flatMap(entry => {
         if (!entry.isDirectory()) {
           return [];
         }
@@ -278,8 +275,8 @@ function remind16kAlignmentSteps() {
         const archDir = path.join(jniLibsDir, entry.name);
         return fs
           .readdirSync(archDir, { withFileTypes: true })
-          .filter((file) => file.isFile() && file.name.endsWith('.so'))
-          .map((file) => path.join(entry.name, file.name));
+          .filter(file => file.isFile() && file.name.endsWith('.so'))
+          .map(file => path.join(entry.name, file.name));
       });
 
     if (soFiles.length > 0) {


### PR DESCRIPTION
## Summary
- inject a 16 KB page size linker flag and disable legacy JNI packaging for the passportreader subproject from the shared Android Gradle build
- emit setup guidance after cloning the private passportreader module so local builds regenerate aligned binaries and warn when prebuilt .so files are present

## Testing
- node -e "require('./app/scripts/setup-private-modules.cjs')"


------
https://chatgpt.com/codex/tasks/task_b_68e0adfd62a8832d9827893013539ed7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android stability by aligning native binaries for 16KB page-size devices, reducing potential startup crashes.
  * Enhanced packaging behavior to avoid legacy JNI issues on newer Android setups.

* **Chores**
  * Updated Android build configuration for broader device compatibility and smoother native builds.
  * Added runtime safeguards and clearer logging during Android build steps.
  * Improved developer setup script with reminders to refresh aligned binaries and warnings for prebuilt native libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->