### PR TITLE
chore: fix build versions v2.6.9 and mobile deploy fork pr source

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -135,9 +135,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # When triggered by PR merge, use the PR source commit (e.g., from dev)
-          # This ensures we deploy with the version.json from the source branch
-          ref: ${{ github.event.pull_request.head.sha || 'staging' }}
+          # When triggered by PR merge, use the merge commit on staging
+          # This ensures we deploy exactly what landed on staging (including version.json from source + any conflict resolutions)
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'staging' }}
       - name: Read and sanitize Node.js version
         shell: bash
         run: |
@@ -163,9 +163,9 @@ jobs:
           echo "Staging HEAD message: $(git log -1 --pretty=format:'%s' origin/staging)"
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "📌 Building from PR source commit (from merged branch, e.g., dev)"
+            echo "📌 Building from merge commit on staging (includes source + conflict resolutions)"
             echo "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
-            echo "Source branch had the latest version.json with bumped build numbers"
+            echo "Merge commit includes version.json from source branch with bumped build numbers"
           elif [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/staging)" ]; then
             echo "⚠️ WARNING: Current commit differs from latest staging commit"
             echo "This might indicate we're not building from the latest staging branch"
@@ -664,9 +664,9 @@ jobs:
         if: inputs.platform != 'ios'
         with:
           fetch-depth: 0
-          # When triggered by PR merge, use the PR source commit (e.g., from dev)
-          # This ensures we deploy with the version.json from the source branch
-          ref: ${{ github.event.pull_request.head.sha || 'staging' }}
+          # When triggered by PR merge, use the merge commit on staging
+          # This ensures we deploy exactly what landed on staging (including version.json from source + any conflict resolutions)
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'staging' }}
       - uses: "google-github-actions/auth@v2"
         with:
           project_id: "plucky-tempo-454713-r0"
@@ -1139,9 +1139,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # When triggered by PR merge, use the PR source commit (e.g., from dev)
-          # This ensures we deploy with the version.json from the source branch
-          ref: ${{ github.event.pull_request.head.sha || 'staging' }}
+          # When triggered by PR merge, use the merge commit on staging
+          # This ensures we tag exactly what landed on staging (including version.json from source + any conflict resolutions)
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'staging' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -135,7 +135,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: staging
+          # When triggered by PR merge, use the PR source commit (e.g., from dev)
+          # This ensures we deploy with the version.json from the source branch
+          ref: ${{ github.event.pull_request.head.sha || 'staging' }}
       - name: Read and sanitize Node.js version
         shell: bash
         run: |
@@ -160,7 +162,11 @@ jobs:
           echo "Staging HEAD commit: $(git rev-parse origin/staging)"
           echo "Staging HEAD message: $(git log -1 --pretty=format:'%s' origin/staging)"
 
-          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/staging)" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "📌 Building from PR source commit (from merged branch, e.g., dev)"
+            echo "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+            echo "Source branch had the latest version.json with bumped build numbers"
+          elif [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/staging)" ]; then
             echo "⚠️ WARNING: Current commit differs from latest staging commit"
             echo "This might indicate we're not building from the latest staging branch"
             git log --oneline HEAD..origin/staging || true
@@ -658,7 +664,9 @@ jobs:
         if: inputs.platform != 'ios'
         with:
           fetch-depth: 0
-          ref: staging
+          # When triggered by PR merge, use the PR source commit (e.g., from dev)
+          # This ensures we deploy with the version.json from the source branch
+          ref: ${{ github.event.pull_request.head.sha || 'staging' }}
       - uses: "google-github-actions/auth@v2"
         with:
           project_id: "plucky-tempo-454713-r0"
@@ -1131,7 +1139,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: staging
+          # When triggered by PR merge, use the PR source commit (e.g., from dev)
+          # This ensures we deploy with the version.json from the source branch
+          ref: ${{ github.event.pull_request.head.sha || 'staging' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git

--- a/app/version.json
+++ b/app/version.json
@@ -1,6 +1,6 @@
 {
   "ios": {
-    "build": 178,
+    "build": 179,
     "lastDeployed": "2025-09-30T16:35:10Z"
   },
   "android": {

--- a/app/version.json
+++ b/app/version.json
@@ -1,6 +1,6 @@
 {
   "ios": {
-    "build": 179,
+    "build": 178,
     "lastDeployed": "2025-09-30T16:35:10Z"
   },
   "android": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Mobile deployment pipeline now builds from the pull request’s merge commit when runs are triggered by PRs, ensuring builds reflect proposed changes.
  * Applied this behavior consistently across iOS and Android deployment paths and related release/tag steps.
  * Improved run logs for PR-triggered builds (prints PR number and title).
  * Preserved previous staging-based behavior for non-PR runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->