### PR TITLE
fix build version for v2.6.9

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,10 +1,10 @@
 {
   "ios": {
-    "build": 177,
+    "build": 178,
     "lastDeployed": "2025-09-30T16:35:10Z"
   },
   "android": {
-    "build": 107,
+    "build": 108,
     "lastDeployed": "2025-10-01T08:00:07Z"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Incremented iOS build number from 177 to 178.
  * Incremented Android build number from 107 to 108.
  * No other configuration fields changed; last deployed values remain the same.
  * No user-facing changes in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->