### PR TITLE
Update mobile deploy version workflow

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1032,7 +1032,7 @@ jobs:
         with:
           token: ${{ github.token }}
           fetch-depth: 0
-          ref: dev
+          ref: staging
       - name: Read and sanitize Node.js version
         shell: bash
         run: |
@@ -1105,9 +1105,9 @@ jobs:
           git checkout -b temp-for-version-commit
           git commit -m "chore: update version files after deployment [skip ci]"
 
-          # Create a new branch from dev
-          git fetch origin dev
-          git checkout -b ${BRANCH_NAME} origin/dev
+          # Create a new branch from staging
+          git fetch origin staging
+          git checkout -b ${BRANCH_NAME} origin/staging
 
           # Cherry-pick the commit with the version changes
           git cherry-pick temp-for-version-commit

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1101,19 +1101,10 @@ jobs:
             exit 0
           fi
 
-          # Commit the changes on a temporary local branch
-          git checkout -b temp-for-version-commit
-          git commit -m "chore: update version files after deployment [skip ci]"
-
-          # Create a new branch from staging
+          # Create a new branch forked from staging and commit the changes
           git fetch origin staging
-          git checkout -b ${BRANCH_NAME} origin/staging
-
-          # Cherry-pick the commit with the version changes
-          git cherry-pick temp-for-version-commit
-
-          # Clean up temporary branch
-          git branch -D temp-for-version-commit
+          git checkout -B ${BRANCH_NAME} origin/staging
+          git commit -m "chore: update version files after deployment [skip ci]"
 
           # Push the new branch and create the PR
           git push --set-upstream origin ${BRANCH_NAME}


### PR DESCRIPTION
## Summary
- ensure the update-version job checks out staging instead of dev
- base the automation branch on origin/staging while keeping PRs targeting dev

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68e5b2f9a944832d98b95d46899b318a