### PR TITLE
Fix Android NFC scanning in demo app

### DIFF
--- a/packages/mobile-sdk-demo/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile-sdk-demo/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,12 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+
+    <uses-feature
+      android:name="android.hardware.nfc"
+      android:required="false" />
 
     <application
       android:name=".MainApplication"
@@ -22,6 +28,10 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
+
+        <meta-data
+          android:name="android.nfc.action.TECH_DISCOVERED"
+          android:resource="@xml/nfc_tech_filter" />
       </activity>
     </application>
 </manifest>

--- a/packages/mobile-sdk-demo/android/app/src/main/java/com/selfxyz/demoapp/MainActivity.kt
+++ b/packages/mobile-sdk-demo/android/app/src/main/java/com/selfxyz/demoapp/MainActivity.kt
@@ -1,11 +1,12 @@
 package com.selfxyz.demoapp
 
-import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import android.content.Intent
+import android.util.Log
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.selfxyz.selfSDK.RNSelfPassportReaderModule
 
 class MainActivity : ReactActivity() {
     /**
@@ -20,5 +21,16 @@ class MainActivity : ReactActivity() {
      */
     override fun createReactActivityDelegate(): ReactActivityDelegate {
         return DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        Log.d("MAIN_ACTIVITY", "onNewIntent: " + intent.action)
+        try {
+            RNSelfPassportReaderModule.getInstance().receiveIntent(intent)
+        } catch (e: IllegalStateException) {
+            Log.w("MAIN_ACTIVITY", "RNSelfPassportReaderModule not ready; deferring NFC intent")
+            setIntent(intent)
+        }
     }
 }

--- a/packages/mobile-sdk-demo/android/app/src/main/res/xml/nfc_tech_filter.xml
+++ b/packages/mobile-sdk-demo/android/app/src/main/res/xml/nfc_tech_filter.xml
@@ -1,0 +1,5 @@
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <tech-list>
+        <tech>android.nfc.tech.IsoDep</tech>
+    </tech-list>
+</resources>


### PR DESCRIPTION
## Summary
- forward NFC intents to the NFC passport reader module so NFC tag discovery reaches the SDK
- declare the required Android NFC permissions/feature and wire up the IsoDep tech filter resource in the demo app

## Testing
- not run (local React Native Android environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e5e81e31bc832d8ec5aa96f76fcd3c