### PR TITLE
fix: ensure verification finishes in background once app says it is safe to close

### DIFF
--- a/app/src/navigation/index.tsx
+++ b/app/src/navigation/index.tsx
@@ -3,7 +3,8 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import React, { useEffect } from 'react';
-import { Platform } from 'react-native';
+import type { AppStateStatus } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import type { StaticParamList } from '@react-navigation/native';
 import {
@@ -32,7 +33,9 @@ import verificationScreens from '@/navigation/verification';
 import type { ModalNavigationParams } from '@/screens/app/ModalScreen';
 import type { WebViewScreenParams } from '@/screens/shared/WebViewScreen';
 import { trackScreenView } from '@/services/analytics';
+import { checkPendingRegistrationWithRetry } from '@/services/registration/pendingRegistrationService';
 import type { ProofHistory } from '@/stores/proofTypes';
+import { useSettingStore } from '@/stores/settingStore';
 
 export const navigationScreens = {
   ...appScreens,
@@ -233,6 +236,58 @@ const NavigationWithTracking = () => {
     return () => {
       cleanup();
     };
+  }, [selfClient]);
+
+  // Pending registration check with AppState-based foreground retry
+  useEffect(() => {
+    const appStateRef = { current: AppState.currentState };
+    const isCheckingRef = { current: false };
+
+    const runCheck = async () => {
+      if (isCheckingRef.current || !selfClient) return;
+      const { pendingRegistrationUuid } = useSettingStore.getState();
+      if (!pendingRegistrationUuid) return;
+
+      isCheckingRef.current = true;
+      try {
+        await checkPendingRegistrationWithRetry();
+      } finally {
+        isCheckingRef.current = false;
+      }
+    };
+
+    // Wait for zustand to rehydrate from AsyncStorage before initial check
+    const runCheckAfterHydration = () => {
+      if (useSettingStore.persist.hasHydrated()) {
+        runCheck();
+      } else {
+        const unsubscribe = useSettingStore.persist.onFinishHydration(() => {
+          unsubscribe();
+          runCheck();
+        });
+      }
+    };
+
+    // Initial check on mount (after hydration)
+    runCheckAfterHydration();
+
+    // Check when app comes to foreground
+    const subscription = AppState.addEventListener(
+      'change',
+      (nextState: AppStateStatus) => {
+        const prevState = appStateRef.current;
+        appStateRef.current = nextState;
+
+        if (
+          (prevState === 'background' || prevState === 'inactive') &&
+          nextState === 'active'
+        ) {
+          runCheck();
+        }
+      },
+    );
+
+    return () => subscription.remove();
   }, [selfClient]);
 
   return (

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -236,10 +236,14 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
             if (documentId) {
               setPendingRegistration(uuid, documentId, isMock);
             } else {
-              console.warn('Cannot save pending registration: no selectedDocumentId');
+              console.warn(
+                'Cannot save pending registration: no selectedDocumentId',
+              );
             }
           } catch {
-            console.warn('Cannot save pending registration: failed to load catalog');
+            console.warn(
+              'Cannot save pending registration: failed to load catalog',
+            );
           }
         }
 

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -28,6 +28,7 @@ import {
   unsafe_getPrivateKey,
 } from '@/providers/authProvider';
 import {
+  loadDocumentCatalogDirectlyFromKeychain,
   selfClientDocumentsAdapter,
   setPassportKeychainErrorCallback,
 } from '@/providers/passportDataProvider';
@@ -173,6 +174,9 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
     });
 
     addListener(SdkEvents.PROVING_ACCOUNT_VERIFIED_SUCCESS, () => {
+      // Clear pending registration since verification completed successfully
+      useSettingStore.getState().clearPendingRegistration();
+
       setTimeout(() => {
         if (navigationRef.isReady()) {
           navigationRef.navigate({
@@ -186,6 +190,9 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
     addListener(
       SdkEvents.PROVING_REGISTER_ERROR_OR_FAILURE,
       async ({ hasValidDocument: _hasValidDocument }) => {
+        // Clear pending registration since registration failed
+        useSettingStore.getState().clearPendingRegistration();
+
         setTimeout(() => {
           if (navigationRef.isReady()) {
             navigationRef.navigate({ name: 'Home', params: {} });
@@ -219,7 +226,22 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
     addListener(
       SdkEvents.PROVING_BEGIN_GENERATION,
       async ({ uuid, isMock, context }) => {
-        const { fcmToken } = useSettingStore.getState();
+        const { fcmToken, setPendingRegistration } = useSettingStore.getState();
+
+        // Persist pending registration only for register circuit (after 2nd fingerprint)
+        if (context.circuitType === 'register') {
+          try {
+            const catalog = await loadDocumentCatalogDirectlyFromKeychain();
+            const documentId = catalog.selectedDocumentId;
+            if (documentId) {
+              setPendingRegistration(uuid, documentId, isMock);
+            } else {
+              console.warn('Cannot save pending registration: no selectedDocumentId');
+            }
+          } catch {
+            console.warn('Cannot save pending registration: failed to load catalog');
+          }
+        }
 
         if (fcmToken) {
           try {

--- a/app/src/screens/app/LoadingScreen.tsx
+++ b/app/src/screens/app/LoadingScreen.tsx
@@ -89,7 +89,8 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({ route }) => {
 
   // States where it's safe to close the app
   const safeToCloseStates = ['proving', 'post_proving', 'completed'];
-  const canCloseApp = safeToCloseStates.includes(currentState);
+  const canCloseApp =
+    safeToCloseStates.includes(currentState) && circuitType === 'register';
 
   // Initialize proving process
   useEffect(() => {

--- a/app/src/services/registration/pendingRegistrationService.ts
+++ b/app/src/services/registration/pendingRegistrationService.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { Socket } from 'socket.io-client';
+import socketIo from 'socket.io-client';
+
+import { getWSDbRelayerUrl } from '@selfxyz/common/utils/proving';
+
+import { updateDocumentRegistrationState } from '@/providers/passportDataProvider';
+import { useSettingStore } from '@/stores/settingStore';
+
+const STATUS_SUCCESS = 4;
+const STATUS_FAILURE = [3, 5];
+const CHECK_TIMEOUT_MS = 60000;
+const RETRY_DELAYS_MS = [5000, 10000, 20000, 30000, 30000]; // 5 retries with increasing delays
+
+/**
+ * Check pending registration with retries. Completes registration if TEE finished while app was closed.
+ */
+export async function checkPendingRegistrationWithRetry(): Promise<{
+  completed: boolean;
+  documentId: string | null;
+}> {
+  const {
+    pendingRegistrationUuid,
+    pendingRegistrationDocumentId,
+    pendingRegistrationIsMock,
+    clearPendingRegistration,
+  } = useSettingStore.getState();
+
+  if (!pendingRegistrationUuid) {
+    return { completed: false, documentId: null };
+  }
+
+  const wsUrl = getWSDbRelayerUrl(
+    pendingRegistrationIsMock ? 'staging_celo' : 'celo',
+  );
+
+  for (let i = 0; i < RETRY_DELAYS_MS.length; i++) {
+    const status = await checkStatus(wsUrl, pendingRegistrationUuid);
+
+    if (status === STATUS_SUCCESS && pendingRegistrationDocumentId) {
+      await updateDocumentRegistrationState(
+        pendingRegistrationDocumentId,
+        true,
+      );
+      clearPendingRegistration();
+      console.log(
+        'Completed pending registration:',
+        pendingRegistrationDocumentId,
+      );
+      return { completed: true, documentId: pendingRegistrationDocumentId };
+    }
+
+    if (status !== null && STATUS_FAILURE.includes(status)) {
+      clearPendingRegistration();
+      return { completed: false, documentId: null };
+    }
+
+    // Still processing - wait before retry (skip wait on last attempt)
+    if (i < RETRY_DELAYS_MS.length - 1) {
+      await new Promise(r => setTimeout(r, RETRY_DELAYS_MS[i]));
+    }
+  }
+
+  return { completed: false, documentId: null };
+}
+
+/**
+ * Connect to db-relayer WebSocket and get status for a registration UUID.
+ */
+function checkStatus(wsUrl: string, uuid: string): Promise<number | null> {
+  return new Promise(resolve => {
+    let socket: Socket | null = null;
+    let resolved = false;
+
+    const done = (value: number | null) => {
+      if (resolved) return;
+      resolved = true;
+      if (socket) {
+        socket.close();
+        socket = null;
+      }
+      resolve(value);
+    };
+
+    const timeout = setTimeout(() => done(null), CHECK_TIMEOUT_MS);
+
+    try {
+      socket = socketIo(wsUrl, { path: '/', transports: ['websocket'] });
+
+      socket.on('connect', () => socket?.emit('subscribe', uuid));
+
+      socket.on('status', (msg: unknown) => {
+        clearTimeout(timeout);
+        const status =
+          typeof msg === 'string'
+            ? (JSON.parse(msg) as { status: number }).status
+            : (msg as { status: number }).status;
+        done(status);
+      });
+
+      socket.on('connect_error', () => {
+        clearTimeout(timeout);
+        done(null);
+      });
+
+      socket.on('disconnect', () => done(null));
+    } catch {
+      clearTimeout(timeout);
+      done(null);
+    }
+  });
+}

--- a/app/src/stores/settingStore.ts
+++ b/app/src/stores/settingStore.ts
@@ -48,7 +48,11 @@ interface PersistedSettingsState {
   pendingRegistrationDocumentId: string | null;
   pendingRegistrationTimestamp: number | null;
   pendingRegistrationIsMock: boolean;
-  setPendingRegistration: (uuid: string, documentId: string, isMock: boolean) => void;
+  setPendingRegistration: (
+    uuid: string,
+    documentId: string,
+    isMock: boolean,
+  ) => void;
   clearPendingRegistration: () => void;
 }
 
@@ -159,7 +163,11 @@ export const useSettingStore = create<SettingsState>()(
       pendingRegistrationDocumentId: null,
       pendingRegistrationTimestamp: null,
       pendingRegistrationIsMock: false,
-      setPendingRegistration: (uuid: string, documentId: string, isMock: boolean) =>
+      setPendingRegistration: (
+        uuid: string,
+        documentId: string,
+        isMock: boolean,
+      ) =>
         set({
           pendingRegistrationUuid: uuid,
           pendingRegistrationDocumentId: documentId,

--- a/app/src/stores/settingStore.ts
+++ b/app/src/stores/settingStore.ts
@@ -43,6 +43,13 @@ interface PersistedSettingsState {
   subscribedTopics: string[];
   toggleCloudBackupEnabled: () => void;
   turnkeyBackupEnabled: boolean;
+  // Pending registration tracking - for resuming registration after app restart
+  pendingRegistrationUuid: string | null;
+  pendingRegistrationDocumentId: string | null;
+  pendingRegistrationTimestamp: number | null;
+  pendingRegistrationIsMock: boolean;
+  setPendingRegistration: (uuid: string, documentId: string, isMock: boolean) => void;
+  clearPendingRegistration: () => void;
 }
 
 interface NonPersistedSettingsState {
@@ -146,6 +153,26 @@ export const useSettingStore = create<SettingsState>()(
       skipDocumentSelectorIfSingle: true,
       setSkipDocumentSelectorIfSingle: (value: boolean) =>
         set({ skipDocumentSelectorIfSingle: value }),
+
+      // Pending registration tracking - for resuming registration after app restart
+      pendingRegistrationUuid: null,
+      pendingRegistrationDocumentId: null,
+      pendingRegistrationTimestamp: null,
+      pendingRegistrationIsMock: false,
+      setPendingRegistration: (uuid: string, documentId: string, isMock: boolean) =>
+        set({
+          pendingRegistrationUuid: uuid,
+          pendingRegistrationDocumentId: documentId,
+          pendingRegistrationTimestamp: Date.now(),
+          pendingRegistrationIsMock: isMock,
+        }),
+      clearPendingRegistration: () =>
+        set({
+          pendingRegistrationUuid: null,
+          pendingRegistrationDocumentId: null,
+          pendingRegistrationTimestamp: null,
+          pendingRegistrationIsMock: false,
+        }),
 
       // Non-persisted state (will not be saved to storage)
       hideNetworkModal: false,


### PR DESCRIPTION
### Description

Previously it would tell users it is safe to close the app before it was actually safe to close. Closing at this point would result in newly added documents not being registered. Firstly, changed to only show the screen 'safe to close' after the 2nd user authentication input, and the mobile has sent the payload to the TEE for the proof. Secondly, if a user does close the app after that point, it will actually finish registration. It used to show a notification saying the document was finished and ready, even when it was still unregistered. 

### Tested

Tested on local mobile build closing the mobile app after it says it is safe to close. Safe to close was displayed at correct spot in the registration process and it would finish registering even when app was closed.

### How to QA

Replicate testing in local mobile build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures registration completes even if the app is closed after the second auth, and tightens when the UI indicates it's safe to close.
> 
> - Adds `pendingRegistrationService` to poll db-relayer via WebSocket with retries, finalizing registration via `updateDocumentRegistrationState` and clearing state on success/failure
> - Persists pending registration (`uuid`, `documentId`, `isMock`, timestamp) in `settingStore` with `setPendingRegistration`/`clearPendingRegistration`
> - Saves pending registration on `PROVING_BEGIN_GENERATION` (register circuit) and clears it on `PROVING_ACCOUNT_VERIFIED_SUCCESS` or `PROVING_REGISTER_ERROR_OR_FAILURE`
> - Navigation checks for pending registration after store hydration and whenever app returns to foreground, using `AppState` and `checkPendingRegistrationWithRetry`
> - Loading screen only marks `canCloseApp` when in `proving`/`post_proving`/`completed` AND `circuitType === 'register'`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 426e975a44e05f6505a7afc4fd516b1bc304851b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interrupted registrations now automatically resume when restarting the app, eliminating progress loss
  * Enhanced handling of app state transitions to ensure registration flows continue smoothly when switching between background and foreground
  * Improved registration verification with built-in automatic retry logic and intelligent reconnection capabilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->