### PR TITLE
feat(flexible-disclosures): add first/last_name flags to SDKs

### DIFF
--- a/common/src/utils/appType.ts
+++ b/common/src/utils/appType.ts
@@ -38,6 +38,8 @@ export interface SelfAppDisclosureConfig {
   // dg1
   issuing_state?: boolean;
   name?: boolean;
+  first_name?: boolean;
+  last_name?: boolean;
   passport_number?: boolean;
   nationality?: boolean;
   date_of_birth?: boolean;

--- a/common/src/utils/circuits/registerInputs.ts
+++ b/common/src/utils/circuits/registerInputs.ts
@@ -193,12 +193,17 @@ function getSelectorDg1(document: DocumentCategory, disclosures: SelfAppDisclosu
   }
 }
 
-function getSelectorDg1Passport(disclosures: SelfAppDisclosureConfig) {
+export function getSelectorDg1Passport(disclosures: SelfAppDisclosureConfig) {
   const selector_dg1 = Array(88).fill('0');
   Object.entries(disclosures).forEach(([attribute, reveal]) => {
     if (['ofac', 'excludedCountries', 'minimumAge'].includes(attribute)) {
       return;
     }
+
+    if (!Object.keys(attributeToPosition).includes(attribute)) {
+      return;
+    }
+
     if (reveal) {
       const [start, end] = attributeToPosition[attribute as keyof typeof attributeToPosition];
       selector_dg1.fill('1', start, end + 1);
@@ -207,12 +212,17 @@ function getSelectorDg1Passport(disclosures: SelfAppDisclosureConfig) {
   return selector_dg1;
 }
 
-function getSelectorDg1IdCard(disclosures: SelfAppDisclosureConfig) {
+export function getSelectorDg1IdCard(disclosures: SelfAppDisclosureConfig) {
   const selector_dg1 = Array(90).fill('0');
   Object.entries(disclosures).forEach(([attribute, reveal]) => {
     if (['ofac', 'excludedCountries', 'minimumAge'].includes(attribute)) {
       return;
     }
+
+    if (!Object.keys(attributeToPosition_ID).includes(attribute)) {
+      return;
+    }
+
     if (reveal) {
       const [start, end] = attributeToPosition_ID[attribute as keyof typeof attributeToPosition_ID];
       selector_dg1.fill('1', start, end + 1);

--- a/common/tests/appType.test.ts
+++ b/common/tests/appType.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SelfAppDisclosureConfig } from '../src/utils/appType.js';
+
+describe('SelfAppDisclosureConfig', () => {
+  it('should accept first_name and last_name flags without error', () => {
+    const config: SelfAppDisclosureConfig = {
+      first_name: true,
+      last_name: true,
+    };
+
+    expect(config.first_name).toBe(true);
+    expect(config.last_name).toBe(true);
+  });
+
+  it('should accept first_name and last_name as false', () => {
+    const config: SelfAppDisclosureConfig = {
+      first_name: false,
+      last_name: false,
+    };
+
+    expect(config.first_name).toBe(false);
+    expect(config.last_name).toBe(false);
+  });
+
+  it('should accept first_name and last_name as optional fields', () => {
+    const config: SelfAppDisclosureConfig = {
+      name: true,
+    };
+
+    expect(config.first_name).toBeUndefined();
+    expect(config.last_name).toBeUndefined();
+  });
+
+  it('should accept first_name and last_name along with other disclosure fields', () => {
+    const config: SelfAppDisclosureConfig = {
+      first_name: true,
+      last_name: true,
+      date_of_birth: true,
+      nationality: true,
+      passport_number: true,
+    };
+
+    expect(config.first_name).toBe(true);
+    expect(config.last_name).toBe(true);
+    expect(config.date_of_birth).toBe(true);
+    expect(config.nationality).toBe(true);
+    expect(config.passport_number).toBe(true);
+  });
+});

--- a/common/tests/registerInputs.test.ts
+++ b/common/tests/registerInputs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SelfAppDisclosureConfig } from '../src/utils/appType.js';
+import {
+  getSelectorDg1IdCard,
+  getSelectorDg1Passport,
+} from '../src/utils/circuits/registerInputs.js';
+
+describe('getSelectorDg1Passport - first_name and last_name handling', () => {
+  it('should not crash when first_name is included in disclosures', () => {
+    const disclosures: SelfAppDisclosureConfig = {
+      first_name: true,
+      last_name: false,
+      date_of_birth: true,
+    };
+
+    const result = getSelectorDg1Passport(disclosures);
+
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(88);
+
+    expect(result.slice(0, 57).every((v) => v === '0')).toBe(true);
+    expect(result.slice(57, 63).every((v) => v === '1')).toBe(true);
+    expect(result.slice(63).every((v) => v === '0')).toBe(true);
+  });
+});
+
+describe('getSelectorDg1IdCard - first_name and last_name handling', () => {
+  it('should not crash when first_name is included in disclosures', () => {
+    const disclosures: SelfAppDisclosureConfig = {
+      first_name: true,
+      last_name: false,
+      date_of_birth: true,
+    };
+
+    const result = getSelectorDg1IdCard(disclosures);
+
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(90);
+
+    expect(result.slice(0, 30).every((v) => v === '0')).toBe(true);
+    expect(result.slice(30, 36).every((v) => v === '1')).toBe(true);
+    expect(result.slice(36, 90).every((v) => v === '0')).toBe(true);
+  });
+});

--- a/sdk/qrcode-angular/README.md
+++ b/sdk/qrcode-angular/README.md
@@ -154,6 +154,8 @@ export class DemoComponent {
 | ----------------------- | ---------------------- | ------- | --------------------------------------------------------- |
 | `issuing_state`         | `boolean`              | `false` | Request the issuing state from the document.              |
 | `name`                  | `boolean`              | `false` | Request the full name from the document                   |
+| `first_name`            | `boolean`              | `false` | Request only the first name from the document             |
+| `last_name`             | `boolean`              | `false` | Request only the last name from the document              |
 | `passport_number`       | `boolean`              | `false` | Request the document number.                              |
 | `nationality`           | `boolean`              | `false` | Request the user’s nationality.                           |
 | `date_of_birth`         | `boolean`              | `false` | Request the date of birth.                                |

--- a/sdk/qrcode-angular/src/lib/common.ts
+++ b/sdk/qrcode-angular/src/lib/common.ts
@@ -268,6 +268,8 @@ export const countries = {
 export interface SelfAppDisclosureConfig {
   issuing_state?: boolean;
   name?: boolean;
+  first_name?: boolean;
+  last_name?: boolean;
   passport_number?: boolean;
   nationality?: boolean;
   date_of_birth?: boolean;

--- a/sdk/qrcode/README.md
+++ b/sdk/qrcode/README.md
@@ -92,6 +92,8 @@ The `disclosures` object can include the following options:
 | ------------------- | -------- | -------------------------------------------- |
 | `issuing_state`     | boolean  | Request disclosure of passport issuing state |
 | `name`              | boolean  | Request disclosure of the user's name        |
+| `first_name`        | boolean  | Request disclosure of only the first name    |
+| `last_name`         | boolean  | Request disclosure of only the last name     |
 | `nationality`       | boolean  | Request disclosure of nationality            |
 | `date_of_birth`     | boolean  | Request disclosure of birth date             |
 | `passport_number`   | boolean  | Request disclosure of passport number        |

--- a/sdk/sdk-common/index.ts
+++ b/sdk/sdk-common/index.ts
@@ -268,6 +268,8 @@ export const countries = {
 export interface SelfAppDisclosureConfig {
   issuing_state?: boolean;
   name?: boolean;
+  first_name?: boolean;
+  last_name?: boolean;
   passport_number?: boolean;
   nationality?: boolean;
   date_of_birth?: boolean;


### PR DESCRIPTION
### Description

This PR brings changes to our SDKs in order to be able to support `first_name` and `last_name` disclosure flags. This is not yet supported by the app.

### Tested

- ran tests locally
- generated a QR code in a separate project

### How to QA

- generate a QR code
- scan it using the app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `first_name`/`last_name` fields to `SelfAppDisclosureConfig` across common and SDKs, with corresponding docs updates and tests.
> 
> - Export `getSelectorDg1Passport`/`getSelectorDg1IdCard` and add guards to ignore unknown disclosure attributes when building DG1 selectors
> - New unit tests validating type acceptance and selector behavior with `first_name`/`last_name`
> - README updates in `qrcode` and `qrcode-angular` documenting the new disclosure options
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04545c5c6d124cf9b7c8a30116ebe4d6ec830deb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first_name and last_name as optional disclosure fields across SDKs.

* **Public API**
  * Exposed two selector utilities for external use; they now safely ignore unknown attributes to avoid errors.

* **Documentation**
  * Updated SDK READMEs to document the new disclosure options.

* **Tests**
  * Added unit tests covering first_name/last_name handling and the new selector utilities' behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->