### PR TITLE
Fix disclosure proof button text not centered

### DIFF
--- a/packages/mobile-sdk-alpha/src/components/buttons/AbstractButton.tsx
+++ b/packages/mobile-sdk-alpha/src/components/buttons/AbstractButton.tsx
@@ -133,7 +133,6 @@ const styles = StyleSheet.create({
     borderRadius: 5,
   },
   text: {
-    flex: 1,
     fontFamily: dinot,
     textAlign: 'center',
     fontSize: 18,


### PR DESCRIPTION
## Summary
- Remove `flex: 1` from `AbstractButton` text style so content is centered by the container's `justifyContent` instead of relying on `textAlign` within a stretched element
- The old approach failed when children were View components (e.g. `LoadingContent` with `ActivityIndicator`) since `textAlign` only affects text, not nested Views
- Affects the disclosure proof flow bottom button across all its states (loading, preparing, ready)

## Test plan
- [ ] Open disclosure proof flow on device
- [ ] Verify button text is centered in all states: "Waiting for app...", "Accessing Keychain data", "Parsing passport data", "Preparing for verification", "Press and hold to verify", "Generating proof"
- [ ] Verify other buttons throughout the app remain visually correct (settings, onboarding, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined button text layout behavior in mobile SDK components to improve visual presentation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->