### PR TITLE
SELF-2469: SDK Distribution: Hosted URL loading + native shell publishing

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -1,0 +1,43 @@
+name: Publish Android SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/native-shell-android
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: ./.github/actions/cache-gradle
+
+      - name: Set version
+        run: |
+          sed -i "s/version = \".*\"/version = \"${{ inputs.version }}\"/" build.gradle.kts
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Publish
+        run: ./gradlew publishReleasePublicationToGitHubPackagesRepository
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -1,8 +1,6 @@
 name: Publish Android SDK
 
 on:
-  push:
-    branches: [self-2473/sd-04-android-maven]
   workflow_dispatch:
     inputs:
       version:
@@ -38,18 +36,17 @@ jobs:
 
       - name: Set version
         run: |
-          VERSION="${{ inputs.version || '0.1.0-test' }}"
-          sed -i "s/version = \".*\"/version = \"$VERSION\"/" build.gradle.kts
+          sed -i "s/version = \".*\"/version = \"${{ inputs.version }}\"/" build.gradle.kts
 
       - name: Build
         run: ./gradlew build
 
       - name: Publish to Maven Local (dry run)
-        if: inputs.dry-run != 'false'
+        if: inputs.dry-run
         run: ./gradlew publishToMavenLocal
 
       - name: Publish to GitHub Packages
-        if: inputs.dry-run == 'false'
+        if: ${{ !inputs.dry-run }}
         run: ./gradlew publishReleasePublicationToGitHubPackagesRepository
         env:
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -1,6 +1,8 @@
 name: Publish Android SDK
 
 on:
+  push:
+    branches: [self-2473/sd-04-android-maven]
   workflow_dispatch:
     inputs:
       version:
@@ -36,17 +38,18 @@ jobs:
 
       - name: Set version
         run: |
-          sed -i "s/version = \".*\"/version = \"${{ inputs.version }}\"/" build.gradle.kts
+          VERSION="${{ inputs.version || '0.1.0-test' }}"
+          sed -i "s/version = \".*\"/version = \"$VERSION\"/" build.gradle.kts
 
       - name: Build
         run: ./gradlew build
 
       - name: Publish to Maven Local (dry run)
-        if: inputs.dry-run
+        if: inputs.dry-run != 'false'
         run: ./gradlew publishToMavenLocal
 
       - name: Publish to GitHub Packages
-        if: ${{ !inputs.dry-run }}
+        if: inputs.dry-run == 'false'
         run: ./gradlew publishReleasePublicationToGitHubPackagesRepository
         env:
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -25,9 +25,9 @@ jobs:
       run:
         working-directory: packages/native-shell-android
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version to publish (e.g., 0.1.0)'
         required: true
         type: string
+      dry-run:
+        description: 'Dry run — build and validate without publishing'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -36,7 +41,12 @@ jobs:
       - name: Build
         run: ./gradlew build
 
-      - name: Publish
+      - name: Publish to Maven Local (dry run)
+        if: inputs.dry-run
+        run: ./gradlew publishToMavenLocal
+
+      - name: Publish to GitHub Packages
+        if: ${{ !inputs.dry-run }}
         run: ./gradlew publishReleasePublicationToGitHubPackagesRepository
         env:
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -34,9 +34,20 @@ jobs:
 
       - uses: ./.github/actions/cache-gradle
 
-      - name: Set version
+      - name: Validate version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/version = \".*\"/version = \"${{ inputs.version }}\"/" build.gradle.kts
+          [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+            echo "::error::Invalid version: $INPUT_VERSION"
+            exit 1
+          }
+
+      - name: Set version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          sed -i "s/version = \".*\"/version = \"$INPUT_VERSION\"/" build.gradle.kts
 
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/webview-deploy.yml
+++ b/.github/workflows/webview-deploy.yml
@@ -23,6 +23,12 @@ jobs:
 
       - uses: ./.github/actions/yarn-install
 
+      - name: Build workspace dependencies
+        run: |
+          yarn workspace @selfxyz/common build
+          yarn workspace @selfxyz/mobile-sdk-alpha build:ts-only
+          yarn workspace @selfxyz/webview-bridge build
+
       - name: Build hosted bundle
         run: yarn workspace @selfxyz/webview-app build:hosted
 

--- a/.github/workflows/webview-deploy.yml
+++ b/.github/workflows/webview-deploy.yml
@@ -7,6 +7,7 @@ on:
       - 'packages/webview-app/**'
       - 'packages/webview-bridge/**'
       - 'packages/mobile-sdk-alpha/**'
+      - 'common/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/webview-deploy.yml
+++ b/.github/workflows/webview-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     name: Deploy to Vercel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ./.github/actions/yarn-install
 
@@ -33,7 +33,7 @@ jobs:
         run: yarn workspace @selfxyz/webview-app build:hosted
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@16e87c0a08142b0d0d33b76aeaf20823c381b9b9 # v25.2.0
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/webview-deploy.yml
+++ b/.github/workflows/webview-deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy WebView App
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/webview-app/**'
+      - 'packages/webview-bridge/**'
+      - 'packages/mobile-sdk-alpha/**'
+  workflow_dispatch:
+
+concurrency:
+  group: webview-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Vercel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/yarn-install
+
+      - name: Build hosted bundle
+        run: yarn workspace @selfxyz/webview-app build:hosted
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: packages/webview-app
+          vercel-args: '--prod'

--- a/.github/workflows/webview-deploy.yml
+++ b/.github/workflows/webview-deploy.yml
@@ -33,4 +33,4 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: packages/webview-app
-          vercel-args: '--prod'
+          vercel-args: '--prod --prebuilt'

--- a/packages/native-shell-android/README.md
+++ b/packages/native-shell-android/README.md
@@ -1,0 +1,42 @@
+# SelfSDK — Android Native Shell
+
+## Installation
+
+Add the GitHub Packages repository and dependency to your project:
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/selfxyz/self")
+            credentials {
+                username = project.findProperty("gpr.user") as String?
+                password = project.findProperty("gpr.token") as String?
+            }
+        }
+    }
+}
+
+// app/build.gradle.kts
+dependencies {
+    implementation("xyz.self.sdk:native-shell-android:0.1.0")
+}
+```
+
+Add your GitHub credentials to `~/.gradle/gradle.properties`:
+
+```properties
+gpr.user=YOUR_GITHUB_USERNAME
+gpr.token=YOUR_GITHUB_TOKEN
+```
+
+The token needs `read:packages` scope. Generate one at https://github.com/settings/tokens.
+
+## Requirements
+
+- Android API 24+ (minSdk)
+- Java 17
+- Kotlin 1.9+

--- a/packages/native-shell-android/README.md
+++ b/packages/native-shell-android/README.md
@@ -13,8 +13,8 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://maven.pkg.github.com/selfxyz/self")
             credentials {
-                username = project.findProperty("gpr.user") as String?
-                password = project.findProperty("gpr.token") as String?
+                username = providers.gradleProperty("gpr.user").orNull
+                password = providers.gradleProperty("gpr.token").orNull
             }
         }
     }

--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.22"
     id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+    `maven-publish`
 }
 
 ktlint {
@@ -50,6 +51,19 @@ android {
     testOptions {
         unitTests.isReturnDefaultValues = true
         unitTests.isIncludeAndroidResources = true
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                groupId = "xyz.self.sdk"
+                artifactId = "native-shell-android"
+                version = "0.1.0"
+            }
+        }
     }
 }
 

--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -64,6 +64,16 @@ afterEvaluate {
                 version = "0.1.0"
             }
         }
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/selfxyz/self")
+                credentials {
+                    username = System.getenv("GITHUB_ACTOR") ?: project.findProperty("gpr.user") as String? ?: ""
+                    password = System.getenv("GITHUB_TOKEN") ?: project.findProperty("gpr.token") as String? ?: ""
+                }
+            }
+        }
     }
 }
 

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/api/SelfSdkConfig.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/api/SelfSdkConfig.kt
@@ -19,7 +19,7 @@ data class SelfSdkConfig(
     val chainID: Int? = null,
     val userDefinedData: String? = null,
     val selfDefinedData: String? = null,
-    val remoteWebAppBaseUrl: String = "https://self-app-alpha.vercel.app",
+    val remoteWebAppBaseUrl: String = "https://verify.self.xyz/v1/",
 )
 
 class SelfSdkException(

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/AndroidWebViewHost.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/AndroidWebViewHost.kt
@@ -209,7 +209,7 @@ class AndroidWebViewHost(
     companion object {
         const val FILE_CHOOSER_REQUEST_CODE = 1001
         const val CAMERA_PERMISSION_REQUEST_CODE = 1002
-        private const val DEFAULT_REMOTE_BASE_URL = "https://self-app-alpha.vercel.app"
+        private const val DEFAULT_REMOTE_BASE_URL = "https://verify.self.xyz/v1/"
         private const val BUNDLED_TOUR_PATH = "/tunnel/tour/1"
         private const val DEBUG_HOST = "127.0.0.1"
         private const val DEBUG_PORT = 5173

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/SelfVerificationActivity.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/SelfVerificationActivity.kt
@@ -43,7 +43,7 @@ class SelfVerificationActivity : AppCompatActivity() {
         val chainID = if (intent.hasExtra(EXTRA_CHAIN_ID)) intent.getIntExtra(EXTRA_CHAIN_ID, 0) else null
         val userDefinedData = intent.getStringExtra(EXTRA_USER_DEFINED_DATA)
         val selfDefinedData = intent.getStringExtra(EXTRA_SELF_DEFINED_DATA)
-        val remoteWebAppBaseUrl = intent.getStringExtra(EXTRA_REMOTE_WEB_APP_BASE_URL) ?: "https://self-app-alpha.vercel.app"
+        val remoteWebAppBaseUrl = intent.getStringExtra(EXTRA_REMOTE_WEB_APP_BASE_URL) ?: "https://verify.self.xyz/v1/"
 
         router =
             MessageRouter(

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/AndroidWebViewHostSecurityTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/AndroidWebViewHostSecurityTest.kt
@@ -28,10 +28,10 @@ class AndroidWebViewHostSecurityTest {
 
     @Test
     fun `navigation allows remote didit and debug origins`() {
-        val remoteBase = "https://self-app-alpha.vercel.app"
+        val remoteBase = "https://verify.self.xyz/v1/"
         assertTrue(
             AndroidWebViewHost.isAllowedNavigationUrl(
-                "https://self-app-alpha.vercel.app/tunnel/tour/1",
+                "https://verify.self.xyz/v1/tunnel/tour/1",
                 isDebugMode = false,
                 remoteWebAppBaseUrl = remoteBase,
             ),
@@ -71,7 +71,7 @@ class AndroidWebViewHostSecurityTest {
 
     @Test
     fun `didit on non-443 port is rejected`() {
-        val remoteBase = "https://self-app-alpha.vercel.app"
+        val remoteBase = "https://verify.self.xyz/v1/"
         assertFalse(
             AndroidWebViewHost.isAllowedNavigationUrl(
                 "https://verify.didit.me:8443/session/123",
@@ -83,10 +83,10 @@ class AndroidWebViewHostSecurityTest {
 
     @Test
     fun `bridge trust accepts remote rejects didit and arbitrary origins`() {
-        val remoteBase = "https://self-app-alpha.vercel.app"
+        val remoteBase = "https://verify.self.xyz/v1/"
         assertTrue(
             AndroidWebViewHost.isTrustedBridgeOrigin(
-                "https://self-app-alpha.vercel.app/tunnel/tour/1",
+                "https://verify.self.xyz/v1/tunnel/tour/1",
                 isDebugMode = false,
                 remoteWebAppBaseUrl = remoteBase,
             ),

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/AndroidWebViewHostSecurityTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/AndroidWebViewHostSecurityTest.kt
@@ -12,7 +12,7 @@ class AndroidWebViewHostSecurityTest {
     @Test
     fun `release builds launch remote content`() {
         assertEquals(
-            "https://self-app-alpha.vercel.app/tunnel/tour/1",
+            "https://verify.self.xyz/v1/tunnel/tour/1",
             AndroidWebViewHost.initialContentUrl(queryParams = "", isDebugMode = false),
         )
     }
@@ -64,7 +64,7 @@ class AndroidWebViewHostSecurityTest {
             AndroidWebViewHost.initialContentUrl(
                 queryParams = "",
                 isDebugMode = false,
-                remoteWebAppBaseUrl = "http://self-app-alpha.vercel.app",
+                remoteWebAppBaseUrl = "http://verify.self.xyz",
             )
         }
     }

--- a/packages/native-shell-ios/.gitignore
+++ b/packages/native-shell-ios/.gitignore
@@ -1,0 +1,6 @@
+.build/
+.swiftpm/
+Pods/
+*.xcodeproj/
+*.xcworkspace/
+DerivedData/

--- a/packages/native-shell-ios/README.md
+++ b/packages/native-shell-ios/README.md
@@ -1,0 +1,41 @@
+# SelfSDK — iOS Native Shell
+
+## Installation
+
+### Swift Package Manager
+
+In Xcode: **File → Add Package Dependencies**, enter:
+
+```
+https://github.com/selfxyz/self.git
+```
+
+Set the version rule (e.g. "Up to Next Major" from `0.1.0`).
+
+Or add to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/selfxyz/self.git", from: "0.1.0")
+]
+```
+
+### CocoaPods
+
+Add to your `Podfile`:
+
+```ruby
+pod 'SelfSDK', :git => 'https://github.com/selfxyz/self.git', :tag => '0.1.0'
+```
+
+Then run:
+
+```bash
+pod install
+```
+
+## Requirements
+
+- iOS 15.0+
+- Swift 5.9+
+- Xcode 15+

--- a/packages/native-shell-ios/SelfSDK.podspec
+++ b/packages/native-shell-ios/SelfSDK.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name = 'SelfSDK'
+  s.version = '0.1.0'
+  s.summary = 'iOS native shell for hosting the Self SDK web experience.'
+  s.homepage = 'https://github.com/selfxyz/self'
+  s.license = { :type => 'BUSL-1.1', :file => 'LICENSE' }
+  s.author = { 'Self' => 'support@self.xyz' }
+  s.source = { :git => 'https://github.com/selfxyz/self.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '15.0'
+  s.swift_version = '5.9'
+
+  s.source_files = 'Sources/SelfNativeShell/**/*.swift'
+  s.frameworks = 'UIKit', 'WebKit', 'CryptoKit'
+end

--- a/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdkConfig.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdkConfig.swift
@@ -39,7 +39,7 @@ public struct SelfSdkConfig {
         chainID: Int? = nil,
         userDefinedData: String? = nil,
         selfDefinedData: String? = nil,
-        remoteWebAppBaseURL: URL? = nil,
+        remoteWebAppBaseURL: URL? = URL(string: "https://verify.self.xyz/v1/"),
         secureStorageProvider: SecureStorageProvider
     ) {
         self.verificationId = verificationId

--- a/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
@@ -5,7 +5,7 @@ import UIKit
 import WebKit
 
 final class SelfWebViewHost: NSObject {
-    private static let defaultRemoteBaseURL = URL(string: "https://self-app-alpha.vercel.app")!
+    private static let defaultRemoteBaseURL = URL(string: "https://verify.self.xyz/v1/")!
 
     private var webView: WKWebView?
     private let router: MessageRouter

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/SelfWebViewHostTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/SelfWebViewHostTests.swift
@@ -11,8 +11,8 @@ final class SelfWebViewHostTests: XCTestCase {
 
         let url = try XCTUnwrap(host.initialContentURL(queryParams: ""))
         XCTAssertEqual(url.scheme, "https")
-        XCTAssertEqual(url.host, "self-app-alpha.vercel.app")
-        XCTAssertTrue(url.path.contains("/tunnel/tour/1"))
+        XCTAssertEqual(url.host, "verify.self.xyz")
+        XCTAssertTrue(url.path.contains("/v1/tunnel/tour/1"))
     }
 
     func testDebugBuildUsesLocalhost() throws {
@@ -26,14 +26,14 @@ final class SelfWebViewHostTests: XCTestCase {
         XCTAssertTrue(url.absoluteString.hasPrefix("http://localhost:5173"))
     }
 
-    func testAllowedNavigationAcceptsRemoteAlphaOrigin() {
+    func testAllowedNavigationAcceptsRemoteOrigin() {
         let router = MessageRouter(sendToWebView: { _ in })
         let host = SelfWebViewHost(router: router, isDebugMode: false)
         _ = host.createWebView()
 
         XCTAssertTrue(
             host.isAllowedNavigationURL(
-                URL(string: "https://self-app-alpha.vercel.app/tunnel/tour/1")
+                URL(string: "https://verify.self.xyz/v1/tunnel/tour/1")
             )
         )
         XCTAssertTrue(
@@ -67,7 +67,7 @@ final class SelfWebViewHostTests: XCTestCase {
 
         XCTAssertTrue(
             host.isTrustedBridgeURL(
-                URL(string: "https://self-app-alpha.vercel.app/tunnel/tour/1")
+                URL(string: "https://verify.self.xyz/v1/tunnel/tour/1")
             )
         )
         XCTAssertFalse(

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/SelfWebViewHostTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/SelfWebViewHostTests.swift
@@ -53,7 +53,7 @@ final class SelfWebViewHostTests: XCTestCase {
         let host = SelfWebViewHost(
             router: router,
             isDebugMode: false,
-            remoteWebAppBaseURL: URL(string: "http://self-app-alpha.vercel.app")
+            remoteWebAppBaseURL: URL(string: "http://verify.self.xyz")
         )
         _ = host.createWebView()
 

--- a/packages/self-sdk-swift/Sources/SelfSdkSwift/Providers/WebViewProviderImpl.swift
+++ b/packages/self-sdk-swift/Sources/SelfSdkSwift/Providers/WebViewProviderImpl.swift
@@ -12,7 +12,7 @@ public class WebViewProviderImpl: NSObject {
     static let loopbackHost = "127.0.0.1"
     static let diditHost = "verify.didit.me"
     static let debugPort: UInt16 = 5173
-    private static let defaultRemoteBaseURL = URL(string: "https://self-app-alpha.vercel.app")!
+    private static let defaultRemoteBaseURL = URL(string: "https://verify.self.xyz/v1/")!
 
     private var webView: WKWebView?
     private var viewController: UIViewController?

--- a/packages/self-sdk-swift/Tests/SelfSdkSwiftTests/WebViewProviderImplTests.swift
+++ b/packages/self-sdk-swift/Tests/SelfSdkSwiftTests/WebViewProviderImplTests.swift
@@ -11,7 +11,7 @@ final class WebViewProviderImplTests: XCTestCase {
 
         let url = try XCTUnwrap(provider.initialContentURL(queryParams: nil))
         XCTAssertEqual(url.scheme, "https")
-        XCTAssertEqual(url.host, "self-app-alpha.vercel.app")
+        XCTAssertEqual(url.host, "verify.self.xyz")
         XCTAssertTrue(url.path.contains("/tunnel/tour/1"))
     }
 
@@ -28,7 +28,7 @@ final class WebViewProviderImplTests: XCTestCase {
 
     func testHttpBaseURLProducesNilInRelease() {
         let provider = WebViewProviderImpl()
-        provider.configureRemoteLoading(remoteWebAppBaseURL: "http://self-app-alpha.vercel.app")
+        provider.configureRemoteLoading(remoteWebAppBaseURL: "http://verify.self.xyz")
 
         XCTAssertNil(provider.initialContentURL(queryParams: nil))
     }
@@ -43,7 +43,7 @@ final class WebViewProviderImplTests: XCTestCase {
         )
         XCTAssertTrue(
             provider.isAllowedNavigationURL(
-                URL(string: "https://self-app-alpha.vercel.app/tunnel/tour/1")
+                URL(string: "https://verify.self.xyz/v1/tunnel/tour/1")
             )
         )
     }
@@ -78,7 +78,7 @@ final class WebViewProviderImplTests: XCTestCase {
 
         XCTAssertTrue(
             provider.isTrustedBridgeURL(
-                URL(string: "https://self-app-alpha.vercel.app/tunnel/tour/1")
+                URL(string: "https://verify.self.xyz/v1/tunnel/tour/1")
             )
         )
     }

--- a/packages/webview-app/package.json
+++ b/packages/webview-app/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",
+    "build:hosted": "VITE_BASE_PATH=/v1/ vite build && node scripts/prepare-hosted.mjs",
     "dev": "vite",
     "fmt": "prettier --check .",
     "fmt:fix": "prettier --write .",

--- a/packages/webview-app/package.json
+++ b/packages/webview-app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",
-    "build:hosted": "VITE_BASE_PATH=/v1/ vite build && node scripts/prepare-hosted.mjs",
+    "build:hosted": "tsc --noEmit && VITE_BASE_PATH=/v1/ vite build && node scripts/prepare-hosted.mjs",
     "dev": "vite",
     "fmt": "prettier --check .",
     "fmt:fix": "prettier --write .",

--- a/packages/webview-app/scripts/prepare-hosted.mjs
+++ b/packages/webview-app/scripts/prepare-hosted.mjs
@@ -1,0 +1,10 @@
+import { cpSync, mkdirSync, rmSync, renameSync } from 'node:fs';
+
+const src = 'dist';
+const staging = '_hosted';
+const dest = 'dist';
+
+mkdirSync(`${staging}/v1`, { recursive: true });
+cpSync(src, `${staging}/v1`, { recursive: true });
+rmSync(src, { recursive: true, force: true });
+renameSync(staging, dest);

--- a/packages/webview-app/src/App.tsx
+++ b/packages/webview-app/src/App.tsx
@@ -62,9 +62,15 @@ import { TunnelProvingScreen } from './screens/tunnel/TunnelProvingScreen';
 import { TunnelRecoveryRequiredScreen } from './screens/tunnel/TunnelRecoveryRequiredScreen';
 import { TunnelResultScreen } from './screens/tunnel/TunnelResultScreen';
 
+function getBasename(): string | undefined {
+  const base = import.meta.env.BASE_URL;
+  if (base === './' || base === '/') return undefined;
+  return base.replace(/\/$/, '');
+}
+
 export const App: React.FC = () => (
   <PasswordGate>
-    <BrowserRouter>
+    <BrowserRouter basename={getBasename()}>
       <VerificationRequestProvider>
         <SelfClientProvider>
           <Routes>

--- a/packages/webview-app/vercel.json
+++ b/packages/webview-app/vercel.json
@@ -14,7 +14,15 @@
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
     },
     {
+      "source": "/v1/assets/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    },
+    {
       "source": "/index.html",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }]
+    },
+    {
+      "source": "/v1/index.html",
       "headers": [{ "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }]
     }
   ]

--- a/packages/webview-app/vercel.json
+++ b/packages/webview-app/vercel.json
@@ -4,6 +4,10 @@
   "buildCommand": "yarn workspace @selfxyz/common build && yarn workspace @selfxyz/mobile-sdk-alpha build:ts-only && yarn workspace @selfxyz/webview-bridge build && yarn workspace @selfxyz/webview-app run build",
   "rewrites": [
     {
+      "source": "/v1/:path*",
+      "destination": "/v1/index.html"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }

--- a/packages/webview-app/vercel.json
+++ b/packages/webview-app/vercel.json
@@ -7,5 +7,15 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    },
+    {
+      "source": "/index.html",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }]
+    }
   ]
 }

--- a/packages/webview-app/vite.config.ts
+++ b/packages/webview-app/vite.config.ts
@@ -56,8 +56,10 @@ function subresourceIntegrity(): Plugin {
   };
 }
 
+const basePath = process.env.VITE_BASE_PATH ?? '/';
+
 export default defineConfig({
-  base: '/',
+  base: basePath,
   plugins: [
     react(),
     subresourceIntegrity(),


### PR DESCRIPTION
## Summary

Three URL constants and test fixtures still referenced `https://self-app-alpha.vercel.app` after the SD-01/SD-02 migration to `https://verify.self.xyz/v1/`:

- **`SelfWebViewHost.defaultRemoteBaseURL`** (iOS) — internal fallback used when no URL is passed to the host directly; `SelfSdkConfig` was already updated but this constant was missed
- **`SelfWebViewHostTests`** (iOS) — three tests asserting against the stale default (`testReleaseBuildUsesRemoteOrigin`, `testAllowedNavigationAcceptsRemoteAlphaOrigin`, `testBridgeTrustAcceptsRemoteRejectsDidit`)
- **`AndroidWebViewHostSecurityTest`** — three tests using `self-app-alpha.vercel.app` as explicit `remoteBase` for navigation-policy behavior tests (`navigation allows remote didit and debug origins`, `didit on non-443 port is rejected`, `bridge trust accepts remote rejects didit and arbitrary origins`)

Note: `packages/kmp-sdk` still contains stale references — out of scope for this PR (separate package).

## Test plan

- iOS: existing `SelfWebViewHostTests` suite updated and passing
- Android: existing `AndroidWebViewHostSecurityTest` suite updated and passing
- CI green on all workflows ✅

---

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [x] No new native business logic added (logic belongs in TypeScript)