### PR TITLE
perf(app): strip webview-bundle source maps + skip bundle in store builds until WIA is on

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -632,6 +632,20 @@ jobs:
 
           echo "✅ Provisioning profile installation steps completed."
 
+      - name: Determine webview-bundle inclusion (WIA flag)
+        if: inputs.platform != 'android'
+        run: |
+          # Ship the embedded webview bundle only when the WebView path is on
+          # (IS_WIA_ENABLED). While it's off the bundle is dead weight, so skip it
+          # to trim app size. Tracks the source flag so it auto-returns when flipped.
+          if grep -qE 'IS_WIA_ENABLED[[:space:]]*=[[:space:]]*true' app/src/utils/devUtils.ts; then
+            echo "SELF_SKIP_WALLET_BUNDLE=0" >> "$GITHUB_ENV"
+            echo "WIA enabled → embedding webview bundle"
+          else
+            echo "SELF_SKIP_WALLET_BUNDLE=1" >> "$GITHUB_ENV"
+            echo "WIA disabled → skipping webview bundle (size trim)"
+          fi
+
       - name: Build Dependencies (iOS)
         if: inputs.platform != 'android'
         run: |
@@ -1101,6 +1115,20 @@ jobs:
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
           CI: true
+
+      - name: Determine webview-bundle inclusion (WIA flag)
+        if: inputs.platform != 'ios'
+        run: |
+          # Ship the embedded webview bundle only when the WebView path is on
+          # (IS_WIA_ENABLED). While it's off the bundle is dead weight, so skip it
+          # to trim app size. Tracks the source flag so it auto-returns when flipped.
+          if grep -qE 'IS_WIA_ENABLED[[:space:]]*=[[:space:]]*true' app/src/utils/devUtils.ts; then
+            echo "SELF_SKIP_WALLET_BUNDLE=0" >> "$GITHUB_ENV"
+            echo "WIA enabled → embedding webview bundle"
+          else
+            echo "SELF_SKIP_WALLET_BUNDLE=1" >> "$GITHUB_ENV"
+            echo "WIA disabled → skipping webview bundle (size trim)"
+          fi
 
       - name: Build Dependencies (Android)
         if: inputs.platform != 'ios'

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -350,17 +350,28 @@ platform :android do
         FileUtils.rm_rf(cxx_dir)
       end
 
+      gradle_properties = {
+        "MYAPP_UPLOAD_STORE_FILE" => ENV["ANDROID_KEYSTORE_PATH"],
+        "MYAPP_UPLOAD_STORE_PASSWORD" => ENV["ANDROID_KEYSTORE_PASSWORD"],
+        "MYAPP_UPLOAD_KEY_ALIAS" => ENV["ANDROID_KEY_ALIAS"],
+        "MYAPP_UPLOAD_KEY_PASSWORD" => ENV["ANDROID_KEY_PASSWORD"] == "EMPTY" ? "" : ENV["ANDROID_KEY_PASSWORD"],
+        "reactNativeArchitectures" => android_release_architectures,
+        "selfAppArchitectures" => android_release_architectures,
+      }
+
+      # When the embedded webview bundle is skipped (WIA off — see SELF_SKIP_WALLET_BUNDLE),
+      # `assets/self-wallet` isn't produced; tell @selfxyz/rn-sdk's release guard that the
+      # missing bundle is expected so bundleRelease doesn't fail. Only set when skipping so
+      # the guard stays strict when we DO ship the bundle (WIA on).
+      if ENV["SELF_SKIP_WALLET_BUNDLE"] == "1"
+        gradle_properties["SelfRnSdk_selfWalletBundleOptional"] = "true"
+        UI.message("📦 Webview bundle skipped; passing SelfRnSdk_selfWalletBundleOptional=true")
+      end
+
       gradle(
         task: "clean bundleRelease --stacktrace --info",
         project_dir: "android/",
-        properties: {
-          "MYAPP_UPLOAD_STORE_FILE" => ENV["ANDROID_KEYSTORE_PATH"],
-          "MYAPP_UPLOAD_STORE_PASSWORD" => ENV["ANDROID_KEYSTORE_PASSWORD"],
-          "MYAPP_UPLOAD_KEY_ALIAS" => ENV["ANDROID_KEY_ALIAS"],
-          "MYAPP_UPLOAD_KEY_PASSWORD" => ENV["ANDROID_KEY_PASSWORD"] == "EMPTY" ? "" : ENV["ANDROID_KEY_PASSWORD"],
-          "reactNativeArchitectures" => android_release_architectures,
-          "selfAppArchitectures" => android_release_architectures,
-        },
+        properties: gradle_properties,
       )
     end
 

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -403,7 +403,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nSRC=\"${PROJECT_DIR}/../node_modules/@selfxyz/rn-sdk/assets/self-wallet\"\nDST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/self-wallet\"\nrm -rf \"$DST\"\nmkdir -p \"$DST\"\ncp -R \"$SRC\"/. \"$DST\"\n";
+			shellScript = "set -e\nSRC=\"${PROJECT_DIR}/../node_modules/@selfxyz/rn-sdk/assets/self-wallet\"\nDST=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/self-wallet\"\n# Skip when the webview bundle is intentionally not produced (WIA off) or absent,\n# so the archive doesn't hard-fail on a missing source (set -e + cp).\nif [ \"${SELF_SKIP_WALLET_BUNDLE:-0}\" = \"1\" ] || [ ! -d \"$SRC\" ]; then\n  echo \"Copy self-wallet assets: skipped (SELF_SKIP_WALLET_BUNDLE=${SELF_SKIP_WALLET_BUNDLE:-0})\"\n  exit 0\nfi\nrm -rf \"$DST\"\nmkdir -p \"$DST\"\ncp -R \"$SRC\"/. \"$DST\"\n";
 		};
 		E88323604DFAAA92032925C9 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/rn-sdk/package.json
+++ b/packages/rn-sdk/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "pnpm --filter @selfxyz/webview-app build && pnpm copy-assets && tsup",
-    "copy-assets": "rm -rf ./assets/self-wallet && mkdir -p ./assets/self-wallet && cp -r ../webview-app/dist/. ./assets/self-wallet/ && node scripts/strip-embedded-sri.cjs",
+    "copy-assets": "node scripts/copy-embedded-bundle.cjs",
     "prepublishOnly": "pnpm build",
     "test": "pnpm copy-assets && tsup && vitest run",
     "typecheck": "tsc --noEmit",

--- a/packages/rn-sdk/scripts/copy-embedded-bundle.cjs
+++ b/packages/rn-sdk/scripts/copy-embedded-bundle.cjs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+// Copies the built WebView bundle (../webview-app/dist) into ./assets/self-wallet
+// so it can be embedded and loaded over file://. Two behaviors matter here:
+//
+//  1. Source maps are always excluded. The .js.map files add ~21MB to the
+//     shipped package but are never used at runtime on device; dropping them
+//     roughly halves the embedded bundle size.
+//  2. SELF_SKIP_WALLET_BUNDLE=1 skips the copy entirely. Production builds that
+//     do not embed the wallet (bundle served/loaded elsewhere) can avoid paying
+//     the copy cost. When skipping we also remove any stale prior bundle so it
+//     cannot leak into a build that is supposed to ship without one.
+const fs = require('node:fs');
+const path = require('node:path');
+
+const src = path.join(__dirname, '../../webview-app/dist');
+const dst = path.join(__dirname, '../assets/self-wallet');
+
+if (process.env.SELF_SKIP_WALLET_BUNDLE === '1') {
+  // Remove any bundle left over from a prior build; do NOT copy or strip SRI.
+  fs.rmSync(dst, { recursive: true, force: true });
+  console.log(
+    'copy-embedded-bundle: skipping embedded webview bundle (SELF_SKIP_WALLET_BUNDLE=1)',
+  );
+  process.exit(0);
+}
+
+if (!fs.existsSync(src)) {
+  console.error(
+    `copy-embedded-bundle: ${src} not found; build @selfxyz/webview-app first`,
+  );
+  process.exit(1);
+}
+
+fs.rmSync(dst, { recursive: true, force: true });
+fs.mkdirSync(dst, { recursive: true });
+// Exclude source maps: dead weight on device, ~21MB of .js.map.
+fs.cpSync(src, dst, { recursive: true, filter: (p) => !p.endsWith('.map') });
+console.log(`copy-embedded-bundle: copied ${src} -> ${dst} (source maps excluded)`);
+
+// Strip SRI from the embedded index.html so the file:// bundle boots on iOS.
+// strip-embedded-sri.cjs runs its logic as a top-level side-effect on require.
+require('./strip-embedded-sri.cjs');

--- a/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-APP-CUTOVER.md
+++ b/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-APP-CUTOVER.md
@@ -52,7 +52,7 @@ Today `app/` (Self wallet) runs the **entire** verification flow natively (via `
 - Android native = runtime-cloned private repos (`setup-private-modules.cjs`, auth `SELFXYZ_APP_TOKEN`); iOS = git pods. app does **not** bundle webview-app today (only the dev screen loads it).
 - To consume AARs: add `self-sdk-dist` Maven repo + `SELF_SDK_GITHUB_TOKEN` to `app/android/build.gradle` `allprojects` and EAS/CI; EAS is a POC (`eas.json` single `poc` profile) — production is GitHub Actions + fastlane.
 - Dedup at cutover: remove app's `jmrtd:0.7.35`, `:react-native-passport-reader`, `:passportreader`, `QKMRZScanner`, direct `SelfNFCPassportReader` pod, direct ML Kit text-recognition; strip the two clones from `setup-private-modules.cjs`; keep `:mobile-sdk-alpha`, `jp2-android` exclusion, barcode force. Re-run `check-16kb-alignment.sh` on the AAR AAB.
-- Size: ~58 MB webview bundle rides along; net size improves only after vendored native removed.
+- Size: the embedded webview bundle is **58 MB** (of which ~21 MB is `*.js.map` source maps). Two size measures landed: (1) `copy-assets` now **excludes source maps** (via `packages/rn-sdk/scripts/copy-embedded-bundle.cjs`); (2) store builds **skip the bundle entirely while `IS_WIA_ENABLED` is off** — `mobile-deploy.yml` sets `SELF_SKIP_WALLET_BUNDLE` from the flag, the copy script no-ops, Android passes `-PSelfRnSdk_selfWalletBundleOptional=true`, and the iOS "Copy self-wallet assets" phase early-exits. The bundle auto-returns when the flag flips. Net size still improves further only after vendored native is removed at cutover.
 
 ## Minimal version (small, non-destructive — reasonable next step)
 Prove the scaffolded path completes **one** real flow on device behind the flag, without touching production users:


### PR DESCRIPTION
Trims the embedded webview bundle (`self-wallet`, **58 MB**) out of the app until the WebView path is live. Independent of the B2 PR (#2230) — build-config + rn-sdk copy-script only.

### Two changes
1. **Always exclude source maps.** `copy-assets` now runs `packages/rn-sdk/scripts/copy-embedded-bundle.cjs`, which copies `webview-app/dist` → `assets/self-wallet` excluding `*.map` (~21 MB of source maps that were shipping). Verified: 0 `.map` files, `index.html` present + SRI-stripped, dir ~43 MB (was 58); rn-sdk 175 tests pass.
2. **Skip the bundle on store builds while `IS_WIA_ENABLED` is off.** The bundle ships even though the WebView path is gated off (assets merge at build time), so it's dead weight today. `mobile-deploy.yml` computes `SELF_SKIP_WALLET_BUNDLE` from the source flag → the copy script no-ops (no bundle produced), Android release passes `-PSelfRnSdk_selfWalletBundleOptional=true` (fastlane) so rn-sdk's release guard tolerates the absence, and the iOS "Copy self-wallet assets" phase early-exits. **Auto-returns when `IS_WIA_ENABLED` flips true** — no manual coordination.

### Safety
- No runtime regression: the WebView path is unreachable while `IS_WIA_ENABLED=false`, so an absent bundle is inert.
- Does not touch `rn-sdk-test-app` (keeps its bundle); default `copy-assets` behavior unchanged apart from dropping maps.

### Validation
- rn-sdk: map-exclude + skip verified locally; 175 tests pass.
- YAML (`mobile-deploy.yml`), Ruby (`Fastfile`), pbxproj (`plutil -lint`) and the iOS phase shell (`bash -n`) all valid.
- End-to-end check (post-merge): a prod `mobile-deploy` dispatch with the flag off should produce an AAB/IPA with no `self-wallet/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional WebView bundle inclusion for Android and iOS builds.
  * Builds now automatically omit the embedded wallet bundle when the in-app WebView feature is disabled.
  * Source maps are excluded from embedded WebView assets to reduce bundle size.
  * Embedded assets are restored automatically when the feature is re-enabled.

* **Documentation**
  * Updated build and release documentation with bundle size details and inclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->