### PR TITLE
fix(common): add repository field required by npm provenance

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -2,6 +2,10 @@
   "name": "@selfxyz/common",
   "version": "0.0.10",
   "description": "Constants and utils for self sdks",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/selfxyz/self"
+  },
   "license": "MIT",
   "author": "@Selfxyz Team",
   "sideEffects": [


### PR DESCRIPTION
## Summary
The `publish-common` job in the deprecation release run failed with npm E422: the workflow publishes with sigstore provenance, and provenance validation requires `repository.url` to match `https://github.com/selfxyz/self` — `common/package.json` had no `repository` field at all. `sdk/core` and `sdk/qrcode` carry the field, which is why they published fine in the same run.

`common@0.0.10` is being published manually in the meantime (manual publish attaches no provenance); this fix is so the next workflow release of `common` doesn't fail the same way.

## Changes
- Add `repository: { type: git, url: https://github.com/selfxyz/self }` to `common/package.json`, matching `sdk/core`/`sdk/qrcode`

## Testing
- Field matches the value provenance expects per the E422 error in run 30924748449
- Metadata-only change; no code or version change (so this merge alone won't re-trigger a publish)

Part of SELF-3764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository metadata to the package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->