### PR TITLE
fix(core): generate typechain types before running tests

### DIFF
--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -34,13 +34,15 @@
     "dist"
   ],
   "scripts": {
-    "build": "typechain --target ethers-v6 --node16-modules --out-dir src/typechain-types src/abi/**.json && tsup index.ts --format cjs,esm --dts --clean --sourcemap",
+    "build": "pnpm codegen && tsup index.ts --format cjs,esm --dts --clean --sourcemap",
     "build:deps": "pnpm -r --filter @selfxyz/core... run build",
+    "codegen": "typechain --target ethers-v6 --node16-modules --out-dir src/typechain-types src/abi/**.json",
     "copy-abi": "bash scripts/copyAbi.sh",
     "format": "prettier --write .",
     "install-sdk": "pnpm install --filter @selfxyz/core...",
     "lint": "prettier --check .",
     "prepublishOnly": "pnpm build",
+    "pretest": "pnpm codegen",
     "test": "node --loader ts-node/esm --test tests/*.test.ts",
     "types": "pnpm build"
   },


### PR DESCRIPTION
## What

`@selfxyz/core`'s `test` script now runs the typechain codegen step first, so the package's tests work in a clean checkout.

- Extracted the typechain invocation from `build` into a reusable `codegen` script.
- `build` calls `pnpm codegen`; a new `pretest` hook does the same.

## Why

Addresses the Codex P2 review comment on #2257 (staging release PR).

`sdk/core/tests/deprecationWarning.test.ts` (added in #2252) imports `../src/SelfBackendVerifier.js`, which has a runtime import of `./typechain-types/index.js`. That directory is gitignored and only produced by `pnpm build`. The `test` script never built, and Turbo's `test` task is `dependsOn: ["^build"]` — dependencies only, not the package under test. So in a clean checkout the suite failed during module resolution before reaching any assertion.

Reproduced locally by removing `sdk/core/src/typechain-types/`:

```
# tests 4
# pass 3
# fail 1
```

## Validation

```
$ rm -rf sdk/core/src/typechain-types && pnpm --filter @selfxyz/core test
# tests 4
# pass 4
# fail 0
# duration_ms 1288.1

$ pnpm --filter @selfxyz/core build   # ✅
$ pnpm --filter @selfxyz/core lint    # ✅
```

Codegen adds ~1s to a test run.

## Note

This lands on `dev`. The staging release branch `release/staging-2026-08-07` (#2257) won't pick it up unless the release branch is re-cut or the commit is cherry-picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK build and test workflows to generate the latest contract bindings automatically.
  * Added support for generating ethers v6-compatible TypeChain bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->