### PR TITLE
feat(rn-sdk): enterprise session mode — resolve session refs before WebView boot

### DIFF
--- a/packages/rn-sdk-example-app/App.tsx
+++ b/packages/rn-sdk-example-app/App.tsx
@@ -34,7 +34,11 @@ type CallbackState =
   | { status: 'Failure'; code: string; message: string }
   | { status: 'Cancelled' };
 
-type LaunchFlow = 'onboarding' | 'disclose';
+type LaunchFlow = 'onboarding' | 'disclose' | 'enterprise';
+
+// edge-api's magic test session: returns a canned pending session
+// (minimumAge 18, never expires) from the real API without any setup.
+const ENTERPRISE_TEST_SESSION_ID = 'acedaced-aced-4ace-aced-acedacedaced';
 
 function App(): React.JSX.Element {
   const [isVerifying, setIsVerifying] = useState(false);
@@ -42,6 +46,7 @@ function App(): React.JSX.Element {
   const [showDirectCapture, setShowDirectCapture] = useState(false);
   const [userId, setUserId] = useState('example-user');
   const [scope, setScope] = useState('identity');
+  const [enterpriseRef, setEnterpriseRef] = useState(ENTERPRISE_TEST_SESSION_ID);
   const [callback, setCallback] = useState<CallbackState>({ status: 'Idle' });
 
   const captureCaps = useMemo(
@@ -55,16 +60,22 @@ function App(): React.JSX.Element {
   // The WebView's InitialRouteRedirect sends any request carrying `disclosures`
   // (or `proofItems`) straight to the disclose flow. Omitting them lands on the
   // Self-app home, from which the passport MRZ + NFC onboarding starts.
-  const request = useMemo(
-    () => ({
+  // Enterprise: only the session reference is passed — the SDK resolves the
+  // verification config from edge-api's public session endpoint.
+  const request = useMemo(() => {
+    if (flow === 'enterprise') {
+      return {
+        enterpriseSession: { url: enterpriseRef.trim() },
+      };
+    }
+    return {
       userId: userId || undefined,
       scope: scope || undefined,
       ...(flow === 'disclose'
         ? { disclosures: ['name', 'nationality', 'date_of_birth'] }
         : {}),
-    }),
-    [userId, scope, flow],
-  );
+    };
+  }, [userId, scope, flow, enterpriseRef]);
 
   const launch = (nextFlow: LaunchFlow) => {
     setFlow(nextFlow);
@@ -104,7 +115,7 @@ function App(): React.JSX.Element {
         <StatusBar barStyle="dark-content" />
         <SelfVerification
           request={request}
-          mode="self-app"
+          mode={flow === 'enterprise' ? 'embed' : 'self-app'}
           onSuccess={handleSuccess}
           onFailure={handleFailure}
           onCancelled={handleCancelled}
@@ -162,6 +173,26 @@ function App(): React.JSX.Element {
         >
           <Text style={styles.primaryButtonText}>
             Start Disclosure (prove name / nationality / DOB)
+          </Text>
+        </TouchableOpacity>
+
+        <Text style={styles.label}>
+          Enterprise verificationUrl or session id
+        </Text>
+        <TextInput
+          style={styles.input}
+          value={enterpriseRef}
+          onChangeText={setEnterpriseRef}
+          placeholder={`https://verify.self.xyz/s/${ENTERPRISE_TEST_SESSION_ID}`}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        <TouchableOpacity
+          style={styles.primaryButton}
+          onPress={() => launch('enterprise')}
+        >
+          <Text style={styles.primaryButtonText}>
+            Start Enterprise Session (config from backend)
           </Text>
         </TouchableOpacity>
 

--- a/packages/rn-sdk/src/SelfVerification.tsx
+++ b/packages/rn-sdk/src/SelfVerification.tsx
@@ -30,6 +30,11 @@ import type { SelfCryptoModule } from './handlers/CryptoHandler';
 import type { OperatingMode } from './handlers/LifecycleHandler';
 import { WebViewLoadEvents } from './analytics-events';
 import { resolveBundlePath } from './bundlePath';
+import {
+  resolveEnterpriseSession,
+  type EnterpriseSession,
+  type EnterpriseSessionError,
+} from './enterpriseSession';
 import { COLORS } from './theme';
 
 // iOS main-bundle path provider for native hosts (KMP, partner wallets) that
@@ -74,6 +79,16 @@ export interface VerificationRequest {
   // Host-minted WebView reference session id. When omitted, SelfVerification
   // mints one per load so it is always present for RN-hosted WebViews.
   referenceId?: string;
+  /**
+   * Self Enterprise session reference. When set, the verification config
+   * (scope, endpoint, disclosures, …) is resolved from edge-api's public
+   * session endpoint before the WebView boots — the partner backend creates
+   * the session with its secret API key and passes only the session
+   * reference here. Resolved fields override any inline request fields.
+   * Not named `sessionId`: that name is already used by the relayer, NFC,
+   * and KYC surfaces (see WIA-14).
+   */
+  enterpriseSession?: EnterpriseSession;
 }
 
 export interface VerificationResult {
@@ -96,11 +111,15 @@ export interface SelfSdkError {
  * whether retry is offered. Shared, snake_case taxonomy across the diagnostic
  * `kind` and the `renderError` literal.
  */
-export type LoadDiagnosticKind = 'timeout' | 'load_error' | 'version_mismatch';
+export type LoadDiagnosticKind =
+  | 'timeout'
+  | 'load_error'
+  | 'version_mismatch'
+  | 'session_resolve';
 
 export interface LoadDiagnosticEvent {
   kind: LoadDiagnosticKind;
-  source: 'bundle' | 'dev-server';
+  source: 'bundle' | 'dev-server' | 'enterprise-api';
   detail?: Record<string, unknown>;
 }
 
@@ -183,7 +202,7 @@ export interface SelfVerificationProps {
    * Consumer-supplied loading UI. When omitted, a built-in default backed by
    * the local palette renders.
    */
-  renderLoading?: (stage: 'loading' | 'slow') => React.ReactNode;
+  renderLoading?: (stage: 'loading' | 'slow' | 'resolving') => React.ReactNode;
   /**
    * Consumer-supplied error UI. `canRetry` is false for a terminal version
    * mismatch (the frozen bundle would mismatch identically on reload), true
@@ -255,7 +274,107 @@ function buildRequestSearch(request: VerificationRequest, referenceId: string): 
   return params.toString();
 }
 
-export const SelfVerification: React.FC<SelfVerificationProps> = ({
+/**
+ * Pre-WebView gate for enterprise sessions: resolves the session reference
+ * into a full VerificationRequest, then mounts the regular verification
+ * WebView with it. The WebView (and the bridge) never see the enterprise
+ * session machinery — by boot time this is an ordinary inline request, so
+ * embed mode's fail-closed request validation passes unchanged.
+ */
+export const SelfVerification: React.FC<SelfVerificationProps> = props => {
+  if (props.request.enterpriseSession) {
+    return <EnterpriseSessionGate {...props} />;
+  }
+  return <SelfVerificationInner {...props} />;
+};
+
+type ResolveState =
+  | { status: 'resolving' }
+  | { status: 'resolved'; request: VerificationRequest }
+  | { status: 'error'; error: EnterpriseSessionError };
+
+const EnterpriseSessionGate: React.FC<SelfVerificationProps> = props => {
+  const { request, onFailure, onLoadDiagnostic, renderLoading, renderError, style } = props;
+  const [state, setState] = useState<ResolveState>({ status: 'resolving' });
+  const [attempt, setAttempt] = useState(0);
+
+  // Callback refs so a re-render mid-resolve never re-triggers the fetch.
+  const onFailureRef = useRef(onFailure);
+  const onLoadDiagnosticRef = useRef(onLoadDiagnostic);
+  useEffect(() => {
+    onFailureRef.current = onFailure;
+    onLoadDiagnosticRef.current = onLoadDiagnostic;
+  });
+
+  const session = request.enterpriseSession;
+  const sessionIdentity = JSON.stringify(session ?? null);
+
+  useEffect(() => {
+    if (!session) return undefined;
+    let cancelled = false;
+    setState({ status: 'resolving' });
+    resolveEnterpriseSession(session)
+      .then(resolved => {
+        if (cancelled) return;
+        // Resolved fields win; inline extras (documentTypes, referenceId, …)
+        // pass through. enterpriseSession itself is stripped so the inner
+        // component serializes a plain request.
+        const { enterpriseSession: _omitted, ...inline } = request;
+        setState({ status: 'resolved', request: { ...inline, ...resolved } });
+      })
+      .catch((error: EnterpriseSessionError) => {
+        if (cancelled) return;
+        const code = typeof error?.code === 'string' ? error.code : 'SESSION_RESOLVE_FAILED';
+        const message =
+          typeof error?.message === 'string' ? error.message : 'Session resolve failed';
+        setState({ status: 'error', error: { code, message } as EnterpriseSessionError });
+        try {
+          // No session id in the detail — it is a bearer secret.
+          onLoadDiagnosticRef.current?.({
+            kind: 'session_resolve',
+            source: 'enterprise-api',
+            detail: { code },
+          });
+        } catch {
+          /* diagnostics must not affect the UI */
+        }
+        onFailureRef.current({ code, message });
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionIdentity, attempt]);
+
+  if (state.status === 'resolved') {
+    return <SelfVerificationInner {...props} request={state.request} />;
+  }
+
+  if (state.status === 'error') {
+    const info: LoadErrorInfo = {
+      kind: 'session_resolve',
+      canRetry: true,
+      onRetry: () => setAttempt(a => a + 1),
+    };
+    return (
+      <View style={[{ flex: 1, backgroundColor: COLORS.bg }, style]}>
+        {renderError ? renderError(info) : <DefaultErrorOverlay info={info} />}
+      </View>
+    );
+  }
+
+  return (
+    <View style={[{ flex: 1, backgroundColor: COLORS.bg }, style]}>
+      {renderLoading ? (
+        renderLoading('resolving')
+      ) : (
+        <DefaultLoadingOverlay stage="loading" />
+      )}
+    </View>
+  );
+};
+
+const SelfVerificationInner: React.FC<SelfVerificationProps> = ({
   request,
   onSuccess,
   onFailure,
@@ -649,6 +768,7 @@ export const SelfVerification: React.FC<SelfVerificationProps> = ({
         allowUniversalAccessFromFileURLs
         mediaPlaybackRequiresUserAction={false}
         originWhitelist={['*']}
+        webviewDebuggingEnabled={debug}
         style={{ flex: 1, opacity: loadStage === 'ready' ? 1 : 0 }}
       />
       {overlay}

--- a/packages/rn-sdk/src/__tests__/enterpriseSession.test.ts
+++ b/packages/rn-sdk/src/__tests__/enterpriseSession.test.ts
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  parseSessionReference,
+  resolveEnterpriseSession,
+} from '../enterpriseSession';
+
+const SESSION_ID = '3f2c8a1e-9b4d-4e6f-8a2b-1c3d5e7f9a0b';
+
+// Fixture mirroring edge-api's PublicSessionResponse
+// (self-dashboard apps/edge-api/src/routes/sessions.ts).
+const baseSession = () => ({
+  id: SESSION_ID,
+  orgId: 'a1b2c3d4-e5f6-7890-abcd-ef0123456789',
+  environment: 'live',
+  status: 'pending',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  completedAt: null,
+  expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+  flowVersionId: 'fv-1',
+  flowName: 'Age Gate',
+  externalUuid: 'c0ffee00-1234-4abc-9def-000000000001',
+  metadata: null,
+  predicatesConfig: null as Record<string, unknown> | null,
+  iconUrl: null,
+  proofAttributes: null,
+  successUrl: null,
+  failureUrl: null,
+  product: 'pre_kyc',
+  storage: { state: 'pending', uri: null, credentialId: null },
+});
+
+function mockFetchOnce(body: unknown, init?: { status?: number }) {
+  const status = init?.status ?? 200;
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('parseSessionReference', () => {
+  it('prefers an explicit id over a url', () => {
+    expect(
+      parseSessionReference({
+        id: SESSION_ID,
+        url: 'https://verify.self.xyz/s/other',
+      }),
+    ).toBe(SESSION_ID);
+  });
+
+  it('extracts the session id from a verificationUrl path', () => {
+    expect(
+      parseSessionReference({ url: `https://verify.self.xyz/s/${SESSION_ID}` }),
+    ).toBe(SESSION_ID);
+  });
+
+  it('accepts the future opaque token form in the url path', () => {
+    expect(
+      parseSessionReference({
+        url: 'https://verify.self.xyz/s/verify_live_a1B2c3D4e5F6g7H8i9',
+      }),
+    ).toBe('verify_live_a1B2c3D4e5F6g7H8i9');
+  });
+
+  it('accepts a bare non-URL string as the reference', () => {
+    expect(parseSessionReference({ url: SESSION_ID })).toBe(SESSION_ID);
+  });
+
+  it('rejects an empty session reference', () => {
+    expect(() => parseSessionReference({})).toThrowError(
+      expect.objectContaining({ code: 'SESSION_REF_INVALID' }),
+    );
+  });
+
+  it('rejects a malformed reference', () => {
+    expect(() => parseSessionReference({ id: 'nope !' })).toThrowError(
+      expect.objectContaining({ code: 'SESSION_REF_INVALID' }),
+    );
+  });
+});
+
+describe('resolveEnterpriseSession derivation', () => {
+  it('derives the full request from a live session', async () => {
+    mockFetchOnce(baseSession());
+    const request = await resolveEnterpriseSession({ id: SESSION_ID });
+
+    expect(request).toMatchObject({
+      userId: 'c0ffee00-1234-4abc-9def-000000000001',
+      userIdType: 'uuid',
+      // orgId with dashes stripped, capped at 30 chars
+      scope: 'a1b2c3d4e5f67890abcdef01234567',
+      appEndpoint: 'https://verifier.self.xyz/verify',
+      endpointType: 'https',
+      environment: 'prod',
+      appName: 'Age Gate',
+      version: 2,
+      verificationId: SESSION_ID,
+    });
+    expect(request.scope).toHaveLength(30);
+    // Load-bearing: the verifier correlates proof↔session by parsing exactly
+    // this JSON out of userContextData.
+    expect(request.userDefinedData).toBe(
+      JSON.stringify({ verificationId: SESSION_ID }),
+    );
+    expect(request.enterpriseSession).toBeUndefined();
+  });
+
+  it('maps a test-environment session to staging endpoints', async () => {
+    mockFetchOnce({ ...baseSession(), environment: 'test' });
+    const request = await resolveEnterpriseSession({ id: SESSION_ID });
+    expect(request.appEndpoint).toBe(
+      'https://verifier.staging.self.xyz/verify',
+    );
+    expect(request.endpointType).toBe('staging_https');
+    expect(request.environment).toBe('stg');
+  });
+
+  it('falls back to the default appName when flowName is empty', async () => {
+    mockFetchOnce({ ...baseSession(), flowName: null });
+    const request = await resolveEnterpriseSession({ id: SESSION_ID });
+    expect(request.appName).toBe('Self Verification');
+  });
+
+  it('maps predicatesConfig to the disclosure grammar the WebView parses', async () => {
+    mockFetchOnce({
+      ...baseSession(),
+      predicatesConfig: {
+        minimumAge: 18,
+        ofac: true,
+        excludedCountries: ['PRK', 'IRN'],
+        includedCountries: ['USA'],
+        disclosures: {
+          fullName: true,
+          documentNumber: true,
+          dateOfBirth: true,
+          gender: false,
+          expirationDate: true,
+          issuingState: true,
+        },
+      },
+    });
+    const request = await resolveEnterpriseSession({ id: SESSION_ID });
+    expect(request.disclosures).toEqual(
+      expect.arrayContaining([
+        'minimumAge:18',
+        'ofac',
+        // includedCountries non-empty → nationality requested (allowlist is
+        // enforced verifier-side against the disclosed nationality)
+        'nationality',
+        'name',
+        'passport_number',
+        'date_of_birth',
+        'expiry_date',
+        'issuing_state',
+      ]),
+    );
+    expect(request.disclosures).not.toContain('gender');
+    expect(request.excludedCountries).toEqual(['PRK', 'IRN']);
+  });
+
+  it('produces empty disclosures for a null predicatesConfig', async () => {
+    mockFetchOnce(baseSession());
+    const request = await resolveEnterpriseSession({ id: SESSION_ID });
+    expect(request.disclosures).toEqual([]);
+    expect(request.excludedCountries).toEqual([]);
+  });
+
+  it('uses the apiUrl override and encodes the reference', async () => {
+    const fetchMock = mockFetchOnce(baseSession());
+    await resolveEnterpriseSession({
+      id: SESSION_ID,
+      apiUrl: 'http://localhost:8787/',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://localhost:8787/v1/sessions/${SESSION_ID}`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+});
+
+describe('resolveEnterpriseSession failures', () => {
+  it('rejects an expired-status session', async () => {
+    mockFetchOnce({ ...baseSession(), status: 'expired' });
+    await expect(
+      resolveEnterpriseSession({ id: SESSION_ID }),
+    ).rejects.toMatchObject({
+      code: 'SESSION_EXPIRED',
+    });
+  });
+
+  it('rejects an already-terminal session', async () => {
+    mockFetchOnce({ ...baseSession(), status: 'valid' });
+    await expect(
+      resolveEnterpriseSession({ id: SESSION_ID }),
+    ).rejects.toMatchObject({
+      code: 'SESSION_ALREADY_PROCESSED',
+    });
+  });
+
+  it('rejects a pending session whose expiresAt has passed (no server sweeper)', async () => {
+    mockFetchOnce({
+      ...baseSession(),
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    await expect(
+      resolveEnterpriseSession({ id: SESSION_ID }),
+    ).rejects.toMatchObject({
+      code: 'SESSION_EXPIRED',
+    });
+  });
+
+  it('maps 404 to SESSION_NOT_FOUND', async () => {
+    mockFetchOnce({ error: { code: 'not_found' } }, { status: 404 });
+    await expect(
+      resolveEnterpriseSession({ id: SESSION_ID }),
+    ).rejects.toMatchObject({
+      code: 'SESSION_NOT_FOUND',
+    });
+  });
+
+  it('maps other HTTP failures to SESSION_RESOLVE_FAILED', async () => {
+    mockFetchOnce({ error: { code: 'internal_error' } }, { status: 500 });
+    await expect(
+      resolveEnterpriseSession({ id: SESSION_ID }),
+    ).rejects.toMatchObject({
+      code: 'SESSION_RESOLVE_FAILED',
+    });
+  });
+
+  it('rejects a response missing required fields', async () => {
+    mockFetchOnce({ id: SESSION_ID });
+    await expect(
+      resolveEnterpriseSession({ id: SESSION_ID }),
+    ).rejects.toMatchObject({
+      code: 'SESSION_RESOLVE_FAILED',
+    });
+  });
+
+  it('maps a network error to SESSION_RESOLVE_FAILED', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Network request failed')),
+    );
+    await expect(
+      resolveEnterpriseSession({ id: SESSION_ID }),
+    ).rejects.toMatchObject({
+      code: 'SESSION_RESOLVE_FAILED',
+    });
+  });
+});

--- a/packages/rn-sdk/src/enterpriseSession.ts
+++ b/packages/rn-sdk/src/enterpriseSession.ts
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { VerificationRequest } from './SelfVerification';
+
+/**
+ * Self Enterprise session reference. The partner backend creates the session
+ * (`@selfxyz/enterprise-sdk` `sessions.create`, authenticated with the secret
+ * `sk_` API key) and hands the app either the returned `verificationUrl`
+ * (`https://verify.self.xyz/s/<session-uuid>`) or the bare session id. The
+ * `sk_` key never reaches the client — the session id is the only capability
+ * this SDK consumes, resolved against edge-api's public session endpoint.
+ *
+ * The session id doubles as a bearer secret (post-completion the public
+ * endpoint returns the disclosed attributes) — it is never logged, put in
+ * analytics payloads, or serialized into diagnostics by this module.
+ */
+export interface EnterpriseSession {
+  /** Session id (UUID) from `sessions.create`. Wins over `url` when both are set. */
+  id?: string;
+  /** The `verificationUrl` from `sessions.create`; the id is extracted from its path. */
+  url?: string;
+  /** edge-api base URL override (local/staging edge-api). Default: production. */
+  apiUrl?: string;
+}
+
+export interface EnterpriseSessionError {
+  code:
+    | 'SESSION_REF_INVALID'
+    | 'SESSION_NOT_FOUND'
+    | 'SESSION_EXPIRED'
+    | 'SESSION_ALREADY_PROCESSED'
+    | 'SESSION_RESOLVE_FAILED';
+  message: string;
+}
+
+/** Shape of edge-api's public `GET /v1/sessions/:id` (PublicSessionResponse). */
+interface EnterpriseSessionInfo {
+  id: string;
+  orgId: string;
+  environment: 'test' | 'live' | string;
+  status: 'pending' | 'valid' | 'invalid' | 'error' | 'expired' | string;
+  expiresAt: string;
+  flowName: string | null;
+  externalUuid: string;
+  predicatesConfig: Record<string, unknown> | null;
+  iconUrl: string | null;
+}
+
+const DEFAULT_EDGE_API_URL = 'https://edge.dashboard.self.xyz';
+// The verifier base is server-side hosted-page config and absent from every
+// edge-api response, so it is pinned here exactly as the enterprise backend
+// SDK pins it (self-dashboard packages/self-enterprise-sdk/src/verify-proof.ts).
+// ES-01 asks edge-api to return a server-derived selfApp block instead.
+const VERIFIER_URL = 'https://verifier.self.xyz';
+const VERIFIER_URL_STAGING = 'https://verifier.staging.self.xyz';
+
+const RESOLVE_TIMEOUT_MS = 30_000;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Future-proofing: edge-api plans to flip the verificationUrl path segment
+// from the session UUID to the opaque `verify_<env>_<random>` token.
+const OPAQUE_REF_PATTERN = /^[A-Za-z0-9_-]{10,128}$/;
+
+function sessionError(
+  code: EnterpriseSessionError['code'],
+  message: string,
+): EnterpriseSessionError {
+  return { code, message };
+}
+
+/**
+ * Extracts the session reference from an EnterpriseSession: an explicit `id`
+ * wins; otherwise the last path segment of `url` (`.../s/<ref>`). Accepts a
+ * UUID or an opaque token-shaped segment.
+ */
+export function parseSessionReference(session: EnterpriseSession): string {
+  const candidate =
+    session.id?.trim() || lastPathSegment(session.url?.trim() ?? '');
+  if (!candidate) {
+    throw sessionError(
+      'SESSION_REF_INVALID',
+      'enterpriseSession requires an id or a verificationUrl',
+    );
+  }
+  if (!UUID_PATTERN.test(candidate) && !OPAQUE_REF_PATTERN.test(candidate)) {
+    throw sessionError(
+      'SESSION_REF_INVALID',
+      'enterpriseSession reference is not a session id or verification URL',
+    );
+  }
+  return candidate;
+}
+
+function lastPathSegment(url: string): string {
+  if (!url) return '';
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    return segments[segments.length - 1] ?? '';
+  } catch {
+    // Not a URL — treat the whole string as a bare reference.
+    return url;
+  }
+}
+
+// Mirrors the hosted page's buildDisclosuresFromConfig + FIELD_TO_SDK_KEY
+// (self-dashboard apps/hosted-page .../buildDisclosures.ts): flow-builder
+// field names → the boolean disclosure keys webview-app's
+// parseDisclosureConfig accepts.
+const FIELD_TO_SDK_KEY: Record<string, string> = {
+  fullName: 'name',
+  documentNumber: 'passport_number',
+  dateOfBirth: 'date_of_birth',
+  gender: 'gender',
+  nationality: 'nationality',
+  expirationDate: 'expiry_date',
+  issuingState: 'issuing_state',
+};
+
+function buildDisclosures(predicatesConfig: Record<string, unknown> | null): {
+  disclosures: string[];
+  excludedCountries: string[];
+} {
+  const disclosures = new Set<string>();
+  const excludedCountries: string[] = [];
+  if (!predicatesConfig) return { disclosures: [], excludedCountries };
+
+  if (typeof predicatesConfig.minimumAge === 'number') {
+    disclosures.add(`minimumAge:${predicatesConfig.minimumAge}`);
+  }
+  if (predicatesConfig.ofac === true) {
+    disclosures.add('ofac');
+  }
+  if (Array.isArray(predicatesConfig.excludedCountries)) {
+    for (const country of predicatesConfig.excludedCountries) {
+      if (typeof country === 'string') excludedCountries.push(country);
+    }
+  }
+  // An allowlist is enforced verifier-side against the disclosed nationality,
+  // so request nationality whenever includedCountries is non-empty.
+  if (
+    Array.isArray(predicatesConfig.includedCountries) &&
+    predicatesConfig.includedCountries.length > 0
+  ) {
+    disclosures.add('nationality');
+  }
+  const fieldDisclosures = predicatesConfig.disclosures;
+  if (fieldDisclosures && typeof fieldDisclosures === 'object') {
+    const enabled = fieldDisclosures as Record<string, unknown>;
+    for (const [field, sdkKey] of Object.entries(FIELD_TO_SDK_KEY)) {
+      if (enabled[field] === true) disclosures.add(sdkKey);
+    }
+  }
+  return { disclosures: [...disclosures], excludedCountries };
+}
+
+/**
+ * Resolves a Self Enterprise session into a full VerificationRequest by
+ * fetching edge-api's public session endpoint and replicating the hosted
+ * page's SelfApp derivation. Throws EnterpriseSessionError.
+ *
+ * The `userDefinedData` shape is load-bearing: the enterprise verifier's only
+ * proof↔session correlation is parsing `{"verificationId":"<id>"}` back out
+ * of the proof's userContextData.
+ */
+export async function resolveEnterpriseSession(
+  session: EnterpriseSession,
+): Promise<VerificationRequest> {
+  const ref = parseSessionReference(session);
+  const baseUrl = (session.apiUrl ?? DEFAULT_EDGE_API_URL).replace(/\/$/, '');
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RESOLVE_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(
+      `${baseUrl}/v1/sessions/${encodeURIComponent(ref)}`,
+      { signal: controller.signal },
+    );
+  } catch (err) {
+    throw sessionError(
+      'SESSION_RESOLVE_FAILED',
+      err instanceof Error && err.name === 'AbortError'
+        ? 'Session resolve timed out'
+        : 'Session resolve request failed',
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.status === 404) {
+    throw sessionError('SESSION_NOT_FOUND', 'Verification session not found');
+  }
+  if (!response.ok) {
+    throw sessionError(
+      'SESSION_RESOLVE_FAILED',
+      `Session resolve failed with HTTP ${response.status}`,
+    );
+  }
+
+  let info: EnterpriseSessionInfo;
+  try {
+    info = (await response.json()) as EnterpriseSessionInfo;
+  } catch {
+    throw sessionError(
+      'SESSION_RESOLVE_FAILED',
+      'Session response was not JSON',
+    );
+  }
+  if (
+    !info ||
+    typeof info.orgId !== 'string' ||
+    typeof info.externalUuid !== 'string'
+  ) {
+    throw sessionError(
+      'SESSION_RESOLVE_FAILED',
+      'Session response is missing required fields',
+    );
+  }
+
+  if (info.status === 'expired') {
+    throw sessionError('SESSION_EXPIRED', 'Verification session has expired');
+  }
+  if (info.status !== 'pending') {
+    throw sessionError(
+      'SESSION_ALREADY_PROCESSED',
+      'Verification session was already processed',
+    );
+  }
+  // edge-api has no expiry sweeper — stale sessions stay `pending` with a past
+  // expiresAt, so the client must evaluate it locally (as the hosted page does).
+  const expiresAt = Date.parse(info.expiresAt);
+  if (!Number.isNaN(expiresAt) && expiresAt <= Date.now()) {
+    throw sessionError('SESSION_EXPIRED', 'Verification session has expired');
+  }
+
+  const isStaging = info.environment === 'test';
+  const verifierBase = isStaging ? VERIFIER_URL_STAGING : VERIFIER_URL;
+  const { disclosures, excludedCountries } = buildDisclosures(
+    info.predicatesConfig,
+  );
+  const sessionId = typeof info.id === 'string' && info.id ? info.id : ref;
+
+  return {
+    userId: info.externalUuid,
+    userIdType: 'uuid',
+    scope: info.orgId.replace(/-/g, '').slice(0, 30),
+    appEndpoint: `${verifierBase}/verify`,
+    endpointType: isStaging ? 'staging_https' : 'https',
+    environment: isStaging ? 'stg' : 'prod',
+    appName: info.flowName || 'Self Verification',
+    disclosures,
+    excludedCountries,
+    version: 2,
+    verificationId: sessionId,
+    userDefinedData: JSON.stringify({ verificationId: sessionId }),
+  };
+}

--- a/packages/rn-sdk/src/index.ts
+++ b/packages/rn-sdk/src/index.ts
@@ -13,6 +13,13 @@ export {
   type LoadErrorInfo,
 } from './SelfVerification';
 
+export {
+  resolveEnterpriseSession,
+  parseSessionReference,
+  type EnterpriseSession,
+  type EnterpriseSessionError,
+} from './enterpriseSession';
+
 export { WebViewLoadEvents } from './analytics-events';
 
 export { MessageRouter } from './bridge/MessageRouter';

--- a/specs/projects/sdk/INDEX.md
+++ b/specs/projects/sdk/INDEX.md
@@ -21,6 +21,7 @@ Status: Active (WebView-first; Self app adopts WebView as host via `webview-in-a
 | Build Pipeline       | [Build Pipeline Spec](./workstreams/build-pipeline/SPEC.md)         | Bundle webview-app into native shells                   |
 | SDK Distribution     | [SDK Distribution Spec](./workstreams/sdk-distribution/SPEC.md)     | Hosted URL loading + native shell publishing            |
 | RN SDK Packaging     | [RN SDK Packaging Spec](./workstreams/rn-sdk-packaging/SPEC.md)     | Optional NFC/MRZ native modules + capabilities handshake |
+| Enterprise Session   | [Enterprise Session Spec](./workstreams/enterprise-session/SPEC.md) | Session-based enterprise flow in rn-sdk embed mode      |
 | Analytics            | [Analytics Spec](./workstreams/analytics/SPEC.md)                   | Canonical onboarding funnel events + Mixpanel dashboard |
 | Monorepo Tooling     | [Monorepo Tooling Spec](./workstreams/monorepo-tooling/SPEC.md)     | pnpm follow-ups, Turborepo, blur dependency swap        |
 | Codebase Audits      | [Audits Spec](./workstreams/audits/SPEC.md)                         | Sequential surface audits: findings → issues → fixes    |

--- a/specs/projects/sdk/workstreams/enterprise-session/SPEC.md
+++ b/specs/projects/sdk/workstreams/enterprise-session/SPEC.md
@@ -1,0 +1,87 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+SPDX-License-Identifier: BUSL-1.1
+NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+-->
+
+# SPEC — Enterprise Session Mode (rn-sdk embed)
+
+Status: Active · Updated 2026-08-03
+
+Partner apps embedding `@selfxyz/rn-sdk` run Self Enterprise's session-based
+flow: the partner backend creates a session (`@selfxyz/enterprise-sdk`
+`sessions.create`, secret `sk_` key) and hands the app only the session
+reference (the `verificationUrl` / session id). The SDK resolves the
+verification config from edge-api's public session endpoint before the
+WebView boots. The API key never reaches the client; results remain
+authoritative only via the partner's `verification.completed` webhook.
+
+## Architecture decision
+
+Resolution happens **on the RN host side, before the WebView boots**
+(`EnterpriseSessionGate` in `packages/rn-sdk/src/SelfVerification.tsx`). By
+boot time the WebView sees an ordinary inline embed request, so:
+
+- SPEC-MODES stays intact (two modes; embed's fail-closed `userId`+`scope`
+  validation passes unchanged) — no third mode, no bridge protocol change.
+- No CORS (RN `fetch`, not the `file://`-origin WebView).
+- The session id — a bearer secret; see Security — never appears in the
+  WebView URL and is excluded from diagnostics.
+
+The resolver (`packages/rn-sdk/src/enterpriseSession.ts`) replicates the
+hosted page's client-side SelfApp derivation (self-dashboard
+`apps/hosted-page/.../buildDisclosures.ts`, `self-sdk.config.ts`), an
+intentional duplication until ES-01 moves it server-side:
+
+| Request field | Derivation from `GET /v1/sessions/:id` |
+|---|---|
+| `scope` | `orgId` dashes stripped, first 30 chars |
+| `appEndpoint` | `verifier[.staging].self.xyz/verify` by `environment` (`test`→staging) — pinned client-side; not in any API response |
+| `endpointType` / `environment` | `test` → `staging_https`/`stg`, else `https`/`prod` |
+| `userId` / `userIdType` | `externalUuid` / `uuid` |
+| `appName` | `flowName` ?? `Self Verification` |
+| `disclosures` | `predicatesConfig` → boolean keys (`fullName`→`name`, `documentNumber`→`passport_number`, `dateOfBirth`→`date_of_birth`, `gender`, `nationality`, `expirationDate`→`expiry_date`, `issuingState`→`issuing_state`) + `minimumAge:<n>` + `ofac`; non-empty `includedCountries` → request `nationality` (allowlist enforced verifier-side) |
+| `userDefinedData` | **exactly** `{"verificationId":"<session-uuid>"}` — the verifier's only proof↔session correlation (parsed from `userContextData.slice(128)`) |
+| `verificationId` | session uuid (preserves the host↔`selfApp.sessionId` invariant) |
+| `version` | `2` (webview parser defaults to 1) |
+
+Lifecycle handled client-side (edge-api has no expiry sweeper): local
+`expiresAt` check, `status !== 'pending'` rejection. Typed failures:
+`SESSION_REF_INVALID` / `SESSION_NOT_FOUND` / `SESSION_EXPIRED` /
+`SESSION_ALREADY_PROCESSED` / `SESSION_RESOLVE_FAILED`, surfaced through
+`onFailure` and a retryable error overlay.
+
+`verificationUrl` parsing accepts both today's UUID path segment and the
+planned opaque `verify_<env>_<random>` token (edge-api comments say the URL
+flips to token-as-canonical-id later).
+
+## Security
+
+- The session UUID is a bearer capability (~122 bits) — and post-completion
+  the public GET returns `proofAttributes` (disclosed PII). Never log it,
+  never put it in analytics/diagnostics payloads (the resolver emits only the
+  error `code` in `onLoadDiagnostic`).
+- Completion signals to the client (`onSuccess`) are UX-only; partners must
+  trust only the signed webhook.
+
+## Backlog
+
+| ID | Title | Status | Notes |
+|---|---|---|---|
+| ES-01 | Server-derived `selfApp` block on `GET /v1/sessions/:id` | Open (enterprise team) | Removes the client-side derivation duplication; the verifier base URL is the one input absent from every API response today. Also: gate `proofAttributes` on the public GET (PII readable by UUID post-completion); fix `sessionDetailResponse` schema drift vs the wire `PublicSessionResponse`; confirm timing of the UUID→token URL flip. |
+| ES-02 | rn-sdk session resolution + request surface | Done | `enterpriseSession.ts` resolver + `EnterpriseSessionGate`; `VerificationRequest.enterpriseSession`; 19 unit tests. |
+| ES-03 | Example app enterprise mode | Done | `rn-sdk-example-app` third launch mode; zero-setup via edge-api's magic test id `acedaced-aced-4ace-aced-acedacedaced` (canned pending session, `minimumAge: 18`, never expires — verified live). |
+| ES-04 | WebView-side resolution for non-RN hosts | Deferred | KMP/native shells need the resolve inside webview-app (async `VerificationRequestProvider`), which requires the SPEC-MODES amendment. Also deferred: Self-app deeplink ingestion of `verify.self.xyz/s/...` (universal-link entitlements only cover `redirect.self.xyz`). |
+
+## Validation
+
+```bash
+pnpm --filter @selfxyz/rn-sdk test && pnpm --filter @selfxyz/rn-sdk typecheck
+pnpm --filter @selfxyz/rn-sdk-example-app types
+```
+
+On-device (example app): paste the magic test id → resolving overlay → embed
+disclose screen shows minimum-age 18 — proves resolve + derivation + routing
+against the real API. Full-proof e2e: create a staging session with a real
+flow, verify with a registered document, poll `GET /v1/sessions/:id` to
+`valid` and confirm the partner webhook fired.


### PR DESCRIPTION
Stacked on #2245.

## What

Partner apps embedding `@selfxyz/rn-sdk` run Self Enterprise's session-based flow: the partner backend creates a session with its secret `sk_` key and hands the app only the session reference (`verificationUrl` / session id). The SDK now resolves the verification config from edge-api's public session endpoint **before the WebView boots**, so by boot time the WebView sees an ordinary inline embed request — no bridge protocol change, no third operating mode, and embed mode's fail-closed `userId`+`scope` validation passes unchanged.

## How

- `packages/rn-sdk/src/enterpriseSession.ts` — resolver replicating the hosted page's SelfApp derivation (scope from orgId, verifier endpoint pinned client-side by environment, `predicatesConfig` → disclosure mapping, `userDefinedData` carrying exactly `{"verificationId":"<session-uuid>"}` as the proof↔session correlation). Accepts today's UUID path segment and the planned opaque `verify_<env>_<token>` form.
- `SelfVerification.tsx` — `EnterpriseSessionGate` resolves before mounting the inner WebView component: new `resolving` loading stage, retryable error overlay, `session_resolve` load diagnostic.
- Example app gains an enterprise launch flow wired to edge-api's magic test session (`acedaced-…`), running in embed mode.
- Spec: `specs/projects/sdk/workstreams/enterprise-session/SPEC.md` (registered in the SDK index).

## Security

- The session UUID is a bearer capability — it never appears in the WebView URL and is excluded from diagnostics (`session_resolve` detail carries only the error code).
- The API key never reaches the client; results remain authoritative only via the partner's `verification.completed` webhook.
- Lifecycle handled client-side (edge-api has no expiry sweeper): local `expiresAt` check and `status !== 'pending'` rejection with typed failures (`SESSION_REF_INVALID` / `SESSION_NOT_FOUND` / `SESSION_EXPIRED` / `SESSION_ALREADY_PROCESSED` / `SESSION_RESOLVE_FAILED`).

## Known tradeoff

The resolver intentionally duplicates the hosted page's client-side SelfApp derivation (self-dashboard `buildDisclosures.ts` / `self-sdk.config.ts`) until ES-01 moves derivation server-side — documented in the spec.

## Validation

- `packages/rn-sdk`: 200/200 tests, `pnpm types` green.
- On-device (Pixel 7a, example app): enterprise flow resolves the magic test session and boots the embed WebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)