### PR TITLE
feat(rn-sdk): keychain-backed default DocumentsStore

### DIFF
--- a/packages/rn-sdk/src/SelfVerification.tsx
+++ b/packages/rn-sdk/src/SelfVerification.tsx
@@ -166,8 +166,10 @@ export interface SelfVerificationProps {
   /**
    * Bridge handler injection points. Each is optional; omitting leaves the
    * handler with default behavior (analytics is silent, navigation reports
-   * not-handled, documents uses an in-memory store, crypto requires the
-   * native SelfCrypto module).
+   * not-handled, documents persists via react-native-keychain — in-memory
+   * only when that module is absent — and crypto requires the native
+   * SelfCrypto module). Note: `useKmpBridge` reroutes only `secureStorage`;
+   * documents-domain traffic always hits the TS handler.
    */
   analytics?: AnalyticsSink;
   navigation?: NavigationCallbacks;

--- a/packages/rn-sdk/src/__tests__/KeychainDocumentsStore.test.ts
+++ b/packages/rn-sdk/src/__tests__/KeychainDocumentsStore.test.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { describe, expect, it } from 'vitest';
+
+import { DocumentsHandler } from '../handlers/DocumentsHandler';
+import { createKeychainDocumentsStore } from '../handlers/KeychainDocumentsStore';
+import type { KeychainModule } from '../handlers/KeychainHandler';
+
+function mockKeychain(): { module: KeychainModule; services: Map<string, { username: string; password: string }> } {
+  const services = new Map<string, { username: string; password: string }>();
+  const module: KeychainModule = {
+    async getGenericPassword({ service }) {
+      return services.get(service) ?? false;
+    },
+    async setGenericPassword(username, password, { service }) {
+      services.set(service, { username, password });
+      return true;
+    },
+    async resetGenericPassword({ service }) {
+      return services.delete(service);
+    },
+  };
+  return { module, services };
+}
+
+describe('createKeychainDocumentsStore', () => {
+  it('round-trips the catalog and returns null when unset', async () => {
+    const { module } = mockKeychain();
+    const store = createKeychainDocumentsStore(module)!;
+
+    expect(await store.loadCatalog()).toBeNull();
+
+    const catalog = { documents: [{ id: 'abc', documentType: 'passport' }] };
+    await store.saveCatalog(catalog);
+    expect(await store.loadCatalog()).toEqual(catalog);
+  });
+
+  it('round-trips documents by id and deletes idempotently', async () => {
+    const { module } = mockKeychain();
+    const store = createKeychainDocumentsStore(module)!;
+
+    expect(await store.loadById('abc')).toBeNull();
+
+    const doc = { mrz: 'P<UTOERIKSSON<<ANNA<MARIA', mock: false };
+    await store.save('abc', doc);
+    expect(await store.loadById('abc')).toEqual(doc);
+
+    await store.delete('abc');
+    expect(await store.loadById('abc')).toBeNull();
+    await expect(store.delete('abc')).resolves.toBeUndefined();
+  });
+
+  it('pins the keychain service names (renames lose user documents)', async () => {
+    const { module, services } = mockKeychain();
+    const store = createKeychainDocumentsStore(module)!;
+
+    await store.saveCatalog({ documents: [] });
+    await store.save('deadbeef', { mock: true });
+
+    expect([...services.keys()]).toEqual(['self_docs_catalog', 'self_docs_doc_deadbeef']);
+  });
+
+  it('a document id cannot collide with the catalog service', async () => {
+    const { module } = mockKeychain();
+    const store = createKeychainDocumentsStore(module)!;
+
+    await store.saveCatalog({ documents: [{ id: 'catalog' }] });
+    await store.save('catalog', { mock: true });
+
+    expect(await store.loadCatalog()).toEqual({ documents: [{ id: 'catalog' }] });
+    expect(await store.loadById('catalog')).toEqual({ mock: true });
+  });
+
+  it('returns null for corrupted stored JSON', async () => {
+    const { module, services } = mockKeychain();
+    const store = createKeychainDocumentsStore(module)!;
+
+    services.set('self_docs_catalog', { username: 'catalog', password: '{not json' });
+    expect(await store.loadCatalog()).toBeNull();
+  });
+
+  it('returns null when react-native-keychain is unavailable', () => {
+    // vitest cannot parse react-native-keychain's Flow syntax, so the lazy
+    // require inside the factory throws and the factory must yield null.
+    expect(createKeychainDocumentsStore()).toBeNull();
+  });
+});
+
+describe('DocumentsHandler default store', () => {
+  it('falls back to a working in-memory store when keychain is unavailable', async () => {
+    const handler = new DocumentsHandler();
+    await handler.handle('save', { id: 'x', data: { a: 1 } });
+    expect(await handler.handle('loadById', { id: 'x' })).toEqual({ a: 1 });
+  });
+});

--- a/packages/rn-sdk/src/handlers/DocumentsHandler.ts
+++ b/packages/rn-sdk/src/handlers/DocumentsHandler.ts
@@ -5,6 +5,7 @@
 import type { BridgeDomain } from '../bridge/types';
 import type { BridgeHandler } from '../bridge/types';
 import { BridgeHandlerError } from '../bridge/types';
+import { createKeychainDocumentsStore } from './KeychainDocumentsStore';
 
 export interface DocumentsStore {
   loadCatalog(): Promise<unknown>;
@@ -36,12 +37,26 @@ const inMemoryDefault = (): DocumentsStore => {
   };
 };
 
+let warnedInMemory = false;
+
+function fallbackInMemory(): DocumentsStore {
+  if (!warnedInMemory) {
+    warnedInMemory = true;
+    console.warn(
+      '[SelfSDK] react-native-keychain is not installed; documents will be held ' +
+        'in memory and lost on restart. Install react-native-keychain or pass a ' +
+        'documents store to SelfVerification.',
+    );
+  }
+  return inMemoryDefault();
+}
+
 export class DocumentsHandler implements BridgeHandler {
   readonly domain: BridgeDomain = 'documents';
   private readonly store: DocumentsStore;
 
   constructor(store?: DocumentsStore) {
-    this.store = store ?? inMemoryDefault();
+    this.store = store ?? createKeychainDocumentsStore() ?? fallbackInMemory();
   }
 
   async handle(method: string, params: Record<string, unknown>): Promise<unknown> {

--- a/packages/rn-sdk/src/handlers/KeychainDocumentsStore.ts
+++ b/packages/rn-sdk/src/handlers/KeychainDocumentsStore.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { DocumentsStore } from './DocumentsHandler';
+import type { KeychainModule } from './KeychainHandler';
+import { loadKeychainModule } from './KeychainHandler';
+
+// Service names are a persistence contract — renaming loses user documents.
+// Deliberately outside KeychainHandler's `self_sdk_${key}` namespace (any
+// prefix under it is collidable with a webview-chosen secureStorage key) and
+// disjoint from the Self app's own `documentCatalog`/`document-<hash>`
+// services. The catalog service is not derivable from any document id.
+const CATALOG_SERVICE = 'self_docs_catalog';
+const DOC_SERVICE_PREFIX = 'self_docs_doc_';
+
+function safeParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Keychain-backed DocumentsStore for hosts that don't inject their own
+ * (`SelfVerification`'s `documents` prop). Values are stored as JSON strings
+ * in generic-password entries, one service per document plus one for the
+ * catalog. Returns null when react-native-keychain is not installed so the
+ * caller can fall back explicitly.
+ */
+export function createKeychainDocumentsStore(keychain?: KeychainModule): DocumentsStore | null {
+  const module = keychain ?? loadKeychainModule();
+  if (!module) {
+    return null;
+  }
+
+  async function read(service: string): Promise<unknown> {
+    const credentials = await module!.getGenericPassword({ service });
+    return credentials ? safeParse(credentials.password) : null;
+  }
+
+  async function write(service: string, username: string, value: unknown): Promise<void> {
+    await module!.setGenericPassword(username, JSON.stringify(value ?? null), { service });
+  }
+
+  return {
+    loadCatalog: () => read(CATALOG_SERVICE),
+    saveCatalog: catalog => write(CATALOG_SERVICE, 'catalog', catalog),
+    loadById: id => read(`${DOC_SERVICE_PREFIX}${id}`),
+    save: (id, data) => write(`${DOC_SERVICE_PREFIX}${id}`, id, data),
+    async delete(id) {
+      await module!.resetGenericPassword({ service: `${DOC_SERVICE_PREFIX}${id}` });
+    },
+  };
+}

--- a/packages/rn-sdk/src/handlers/KeychainHandler.ts
+++ b/packages/rn-sdk/src/handlers/KeychainHandler.ts
@@ -12,7 +12,7 @@ export interface KeychainModule {
   resetGenericPassword(opts: { service: string }): Promise<boolean>;
 }
 
-function loadKeychain(): KeychainModule | undefined {
+export function loadKeychainModule(): KeychainModule | undefined {
   try {
     return require('react-native-keychain') as KeychainModule;
   } catch {
@@ -27,7 +27,7 @@ export class KeychainHandler implements BridgeHandler {
   private readonly keychain: KeychainModule | undefined;
 
   constructor(keychain?: KeychainModule) {
-    this.keychain = keychain ?? loadKeychain();
+    this.keychain = keychain ?? loadKeychainModule();
   }
 
   isAvailable(): boolean {

--- a/packages/rn-sdk/src/handlers/index.ts
+++ b/packages/rn-sdk/src/handlers/index.ts
@@ -74,6 +74,7 @@ export { NavigationHandler } from './NavigationHandler';
 export type { NavigationCallbacks } from './NavigationHandler';
 export { DocumentsHandler } from './DocumentsHandler';
 export type { DocumentsStore } from './DocumentsHandler';
+export { createKeychainDocumentsStore } from './KeychainDocumentsStore';
 export { CryptoHandler } from './CryptoHandler';
 export type { SelfCryptoModule } from './CryptoHandler';
 export { LifecycleHandler } from './LifecycleHandler';

--- a/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-documents-bridge-domain.md
+++ b/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-documents-bridge-domain.md
@@ -1,0 +1,69 @@
+# WIA — Documents via the `documents` bridge domain
+
+> Last updated: 2026-08-12
+> Status: Ready
+
+- Workstream: webview-in-app
+- Owner: SDK / Platform
+- Depends on: —
+- Relates to: `WIA-APP-CUTOVER.md` blocker B2 (identity/document migration)
+
+## Why
+
+- webview-app stores documents by tunneling JSON through the `secureStorage` bridge domain
+  (`createKeychainDocumentsAdapter`, keys `self_document_catalog` / `self_doc_*`), while the
+  dedicated `documents` domain (rn-sdk `DocumentsHandler`) is dead code with an **in-memory
+  default** — a partner app embedding `@selfxyz/rn-sdk` loses every captured document on
+  restart unless it hand-implements the `documents` prop (neither example nor test app does).
+- The Self app's WIA host (`app/src/screens/dev/WebViewHostScreen.tsx:82`) already implements
+  the `documents` prop against the app's production keychain store (`documentCatalog` /
+  `document-<contentHash>` via `passportDataProvider`). Routing webview-app's document I/O
+  through the `documents` domain therefore makes the WebView operate on the app's **real**
+  document store — existing users' documents appear with **no migration step**, eliminating
+  the documents half of cutover blocker B2 (the mnemonic/secret half remains).
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| rn-sdk default store | Keychain-backed when `react-native-keychain` resolves; one-time-warn in-memory fallback otherwise | Partner apps must not silently lose documents; pure-JS tests and KMP shells must not break. No new capability field — `capabilities.secureStorage` already signals keychain availability (same module). |
+| Keychain services | `self_docs_catalog` / `self_docs_doc_<id>` | NOT under `self_sdk_`: `KeychainHandler` maps arbitrary webview keys to `self_sdk_${key}`, so that namespace is collidable. The `doc_` infix keeps a document id (even the literal `catalog`) from ever colliding with the catalog service. Also disjoint from the app's own `documentCatalog` / `document-<hash>` services. |
+| Catalog empty state | Native store returns `null`; web-side typed adapter normalizes `null`/malformed to `{ documents: [] }` | Preserves the existing `DocumentsHandler` contract (and the WIA host passthrough); mobile-sdk-alpha callers dereference `catalog.documents` unguarded, so normalization is fail-closed at the boundary. Pinned by tests on both sides. |
+| `createKeychainDocumentsAdapter` | Deleted (not deprecated) | Both packages are 0.0.1-alpha workspace-consumed; no external consumers. |
+| Orphaned `self_doc_*` secureStorage data | No migration | Dev-only data; nothing production shipped on that path. |
+| `useKmpBridge` routing | Untouched | Its predicate matches `secureStorage` only; `DocumentsBridgeHandler.kt` exists only in kmp-sdk iosMain, so widening the predicate breaks Android KMP shells. Documents in flag-on prototypes persist via react-native-keychain instead of KMP keychain. Follow-up: KMP documents-handler parity. |
+
+## Changes
+
+PR 1 — rn-sdk (API-compatible):
+- New `packages/rn-sdk/src/handlers/KeychainDocumentsStore.ts` —
+  `createKeychainDocumentsStore(keychain?)`: `DocumentsStore | null`; values stored as JSON
+  strings in generic-password keychain entries; corrupted or missing entries load as `null`;
+  delete is idempotent.
+- `DocumentsHandler` default: `store ?? createKeychainDocumentsStore() ?? warnOnce(inMemory)`.
+- JSDoc update on `SelfVerification`'s `documents` prop.
+
+PR 2 — webview-bridge + webview-app (atomic):
+- `createBridgeDocumentsSdkAdapter(bridge): DocumentsAdapter` — typed wrapper over the raw
+  `bridgeDocumentsAdapter` with catalog normalization.
+- `sdk-adapter-map.ts` swaps to it; `keychain-documents.ts` deleted.
+- `SelfClientProvider` stops constructing a second adapter; screens unchanged.
+- `KeychainDebugScreen` drops the stale `self_document_catalog` raw key.
+- Test harness `renderWithBridge` gains default `documents`-domain handlers; fixture test pins
+  the app's `DocumentCatalog` shape through normalization (B2 schema-compatibility pin).
+
+## Risks
+
+- **Release coupling**: the rn-sdk npm release whose embedded webview bundle contains PR 2 must
+  also contain PR 1's store, or partner defaults regress to non-persistent.
+- **Android keychain item size** for real passport payloads (~50 KB) via react-native-keychain —
+  verify on-device with a real chip read + relaunch before release.
+
+## Acceptance
+
+1. Example app without a `documents` prop: capture → force-kill → relaunch → document persists
+   (fails today).
+2. WIA dev build: WebView-onboarded document appears in the native app's document list; native
+   documents appear on the WebView home (B2 acceptance).
+3. All three package validations green; no residual references to
+   `createKeychainDocumentsAdapter` / `self_document_catalog` / `self_doc_`.


### PR DESCRIPTION
Stacked on #2262 (which stacks on #2245). PR 1 of 2 for the documents-domain swap — spec: `specs/projects/sdk/workstreams/webview-in-app/plans/WIA-documents-bridge-domain.md`.

## Problem

`DocumentsHandler`'s default store is in-memory, so any host that doesn't inject a `documents` store — the example app and any partner app using `@selfxyz/rn-sdk` out of the box — silently loses every captured document on app restart. This becomes load-bearing when webview-app switches its document I/O to the `documents` bridge domain (PR 2).

## Change

- New `createKeychainDocumentsStore()` (`packages/rn-sdk/src/handlers/KeychainDocumentsStore.ts`): `DocumentsStore` backed by react-native-keychain (already an optional peer dep), values as JSON strings in generic-password entries, corrupted/missing entries load as `null`, idempotent delete. Returns `null` when the module is absent.
- `DocumentsHandler` default chain: injected store → keychain store → one-time-warn in-memory fallback (pure-JS tests, shells without keychain). Hosts passing `documents` (the WIA host) are unaffected.
- Keychain services `self_docs_catalog` / `self_docs_doc_<id>`: outside `KeychainHandler`'s collidable `self_sdk_${key}` namespace, disjoint from the Self app's own `documentCatalog`/`document-<hash>` services, and the `doc_` infix keeps a document id (even the literal `catalog`) from colliding with the catalog service. Names are pinned by tests — renaming loses user data.
- No new capability field: `capabilities.secureStorage` already signals keychain availability (same module).

## Risks

- Release coupling with PR 2: the rn-sdk npm release whose embedded webview bundle routes documents over this domain must include this store, or partner defaults regress to non-persistent.
- Android keychain item size for real passport payloads (~50 KB) — to be verified on-device with a real chip read + relaunch before release.

## Validation

- `packages/rn-sdk`: 207/207 tests (7 new: service-name pins, round-trips, corrupt-JSON, collision guard, module-absent fallback), `pnpm types` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)