### PR TITLE
Add and verify TEE prover signature in disclose flow

### DIFF
--- a/contracts/UPGRADE_GUIDE.md
+++ b/contracts/UPGRADE_GUIDE.md
@@ -252,10 +252,11 @@ would widen what it decodes. Fixing the producer is the correct side.
 
 ### (d) Deploy ordering for prover signature enforcement (v2.15.0)
 
-From v2.15.0, `registerCommitment` and `registerDscKeyCommitment` **unconditionally** require their 65-byte `signature`
-to recover (via `keccak256(abi.encode(a, b, c, pubSignals))`, raw prehash, no EIP-191 prefix) to a registered prover
-key. There is no toggle and no storage change — enforcement is live from the upgrade block, and a relayer still sending
-placeholder zeros bricks the entire register flow with `UnauthorizedProverSigner`.
+From v2.15.0, `registerCommitment`, `registerDscKeyCommitment`, and the disclose flow (`verify`, via the signature
+embedded in `proofPayload`) **unconditionally** require their 65-byte signature to recover (via
+`keccak256(abi.encode(a, b, c, pubSignals))`, raw prehash, no EIP-191 prefix) to a registered prover key. There is no
+toggle and no storage change — enforcement is live from the upgrade block, and a relayer still sending placeholder zeros
+bricks both the register and disclose flows with `UnauthorizedProverSigner`.
 
 Hard ordering, each step verified before the next:
 
@@ -263,13 +264,13 @@ Hard ordering, each step verified before the next:
 2. Prover image digests registered in the prover-only `PCR0Manager`, per (b).
 3. `tee-prover-server` deployed with the `chain` feature enabled and its bare-nonce build, per the prerequisite above.
 4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address.
-5. Relayer + db-relayer deployed with the signature pipeline, and real (non-zero) signatures observed reaching
-   `verifySelfProof`/register calldata.
+5. Relayer + db-relayer deployed with the signature pipeline for **both flows** (register calldata and the disclose
+   `proofPayload`), and real (non-zero) signatures observed reaching the chain.
 6. **Only then** upgrade the hub implementation to v2.15.0.
 
 Keys are ephemeral per enclave boot: every reboot mints a new key that must be registered before its proofs are
 accepted, and `revokeProverKey` (SECURITY_ROLE) retires a compromised one immediately — revoking the only registered key
-halts the register flow until a fresh attestation registers a replacement.
+halts the register and disclose flows until a fresh attestation registers a replacement.
 
 ---
 

--- a/contracts/UPGRADE_GUIDE.md
+++ b/contracts/UPGRADE_GUIDE.md
@@ -256,17 +256,71 @@ From v2.15.0, `registerCommitment`, `registerDscKeyCommitment`, and the disclose
 embedded in `proofPayload`) **unconditionally** require their 65-byte signature to recover (via
 `keccak256(abi.encode(a, b, c, pubSignals))`, raw prehash, no EIP-191 prefix) to a registered prover key. There is no
 toggle and no storage change — enforcement is live from the upgrade block, and a relayer still sending placeholder zeros
-bricks both the register and disclose flows with `UnauthorizedProverSigner`.
+bricks both the register and disclose flows.
 
-Hard ordering, each step verified before the next:
+**Adding the `signature` parameter changes both function selectors.** There is no overload: the 3-argument functions
+cease to exist at the upgrade block.
+
+| Function                   | v2.14.0 (3-arg) | v2.15.0 (4-arg) |
+| -------------------------- | --------------- | --------------- |
+| `registerCommitment`       | `0xf2ea431c`    | `0x848cd73b`    |
+| `registerDscKeyCommitment` | `0x8322963f`    | `0xed9b4fd7`    |
+
+**The disclose flow breaks the same way for a different reason.** `verifySelfProof(bytes,bytes)` keeps its selector —
+the signature rides inside `proofPayload`, whose layout changes from `| 32 bytes attestationId | proofData |` to
+`| 32 bytes attestationId | 65 bytes signature | proofData |`. Nothing about the call shape changes, so a version-skewed
+call is accepted and only then found to be wrong.
+
+**What it looks like when it happens.** An old-format payload reaching a v2.15.0 hub has the first 65 bytes of its proof
+data consumed as a signature, leaving the remainder shifted by 65 bytes. `_decodeInput` strips those bytes, and
+`_executeVerificationFlow` hands the shifted remainder to `_decodeVcAndDiscloseProof`, which is a plain
+`abi.decode(data, (GenericProofStruct))`. That is evaluated as an argument to `_basicVerification`, so it runs _before_
+the body reaches `_verifyProverSignature`. A shifted ABI blob has broken offsets, so the call reverts inside
+`abi.decode` — **with no reason string and no custom error at all**, not with `UnauthorizedProverSigner`.
+
+So during a rollout, read the two symptoms in opposite directions:
+
+| Symptom                      | Most likely cause                                                    |
+| ---------------------------- | -------------------------------------------------------------------- |
+| revert with no reason string | version skew — the relayer is sending the old `proofPayload` layout  |
+| `InvalidDataFormat`          | payload shorter than 98 bytes, i.e. no room for the signature at all |
+| `UnauthorizedProverSigner`   | a genuine prover-key problem: unregistered, revoked, or wrong signer |
+
+Only the third is about prover keys. Reaching it requires a payload that decoded cleanly, which a shifted one will not.
+
+That makes the relayer and the hub a **mutually exclusive pair** for both flows, and it is why the ordering below is a
+cutover rather than a sequence. A relayer sending 4-argument register calldata to the v2.14.0 hub matches no function
+and the proxy reverts; a relayer still sending 3-argument calldata after the upgrade reverts the same way; and the
+disclose payloads fail in whichever direction the skew runs. There is no ordering of "upgrade the hub" and "deploy the
+relayer" in which both are briefly true, so register and disclose are unavailable for the window between the two
+transactions. Plan for that window rather than trying to order it away.
+
+Steps 1–4 are ordinary prerequisites and each must be verified before the next. Steps 5 and 6 are the cutover and should
+be executed back to back by the same operator, in a scheduled window, with rollback ready.
 
 1. Prover config set on the currently-deployed hub, per (c).
 2. Prover image digests registered in the prover-only `PCR0Manager`, per (b).
 3. `tee-prover-server` deployed with the `chain` feature enabled and its bare-nonce build, per the prerequisite above.
-4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address.
-5. Relayer + db-relayer deployed with the signature pipeline for **both flows** (register calldata and the disclose
-   `proofPayload`), and real (non-zero) signatures observed reaching the chain.
-6. **Only then** upgrade the hub implementation to v2.15.0.
+4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address. Verify
+   this **before** the cutover: a hub that enforces signatures with no registered key rejects every register and
+   disclose call, and step 4 is the only step that can be validated while the old formats are still live.
+5. **Cutover begins.** Upgrade the hub implementation to v2.15.0. Register and disclose are both unavailable from this
+   transaction.
+6. **Cutover ends.** Deploy relayer + db-relayer with the signature pipeline for **both flows** — the 4-argument
+   register calldata and the disclose `proofPayload` carrying its 65-byte signature. Confirm real (non-zero) signatures
+   reaching the chain on each, and one successful registration and one successful disclosure. Both flows are restored.
+
+Rolling back mid-cutover means reverting the hub to the previous implementation (see Rollback below), which restores the
+3-argument selectors and the old `proofPayload` layout, and therefore the old relayer. Do not roll back the hub after
+the new relayer is live without also reverting the relayer.
+
+An earlier revision of this guide placed the relayer deploy at step 5 and the hub upgrade at step 6, on the reasoning
+that real signatures should be observed flowing before enforcement went live. That ordering cannot execute. For
+register, those signatures can only reach the hub through the 4-argument selector, which does not exist until step 6.
+For disclose, an old hub reads the 65 signature bytes as the first bytes of proof data and fails proof verification.
+Observing signatures pre-upgrade would require an intermediate hub release that accepts them and ignores them — that
+release does not exist, since both the parameter and its enforcement ship together in v2.15.0. If a zero-downtime
+rollout is required, that intermediate release is the way to get it, and it must be built and deployed first.
 
 Keys are ephemeral per enclave boot: every reboot mints a new key that must be registered before its proofs are
 accepted, and `revokeProverKey` (SECURITY_ROLE) retires a compromised one immediately — revoking the only registered key

--- a/contracts/contracts/IdentityVerificationHubImplV2.sol
+++ b/contracts/contracts/IdentityVerificationHubImplV2.sol
@@ -248,7 +248,7 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
     error CrossChainIsNotSupportedYet();
 
     /// @notice Thrown when the input data is too short for decoding.
-    /// @dev The input data must be at least 97 bytes (1 + 31 + 32 + 32 + 1 minimum).
+    /// @dev The input data must be at least 162 bytes (1 + 31 + 32 + 32 + 65 + 1 minimum).
     error InputTooShort();
 
     /// @notice Thrown when the provided signature is not exactly 65 bytes.
@@ -994,6 +994,9 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
         bytes calldata userContextData,
         uint256 userIdentifier
     ) internal returns (bytes memory output) {
+        // Scope 0: The proof must carry a signature from a registered TEE prover key
+        _verifyProverSignature(vcAndDiscloseProof, header.signature);
+
         // Scope 1: Basic checks (scope and user identifier)
         CircuitConstantsV2.DiscloseIndices memory indices = CircuitConstantsV2.getDiscloseIndices(header.attestationId);
         {
@@ -1245,13 +1248,20 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
         uint256[2][2] memory b,
         uint256[2] memory c,
         uint256[] memory pubSignals,
-        bytes calldata signature
+        bytes memory signature
     ) internal view {
         bytes32 digest = keccak256(abi.encode(a, b, c, pubSignals));
         (address signer, ECDSA.RecoverError err, ) = ECDSA.tryRecover(digest, signature);
         if (err != ECDSA.RecoverError.NoError || !_getProverStorage()._isRegisteredProverKey[signer]) {
             revert UnauthorizedProverSigner();
         }
+    }
+
+    /**
+     * @notice Struct-taking convenience overload of _verifyProverSignature.
+     */
+    function _verifyProverSignature(GenericProofStruct memory proof, bytes memory signature) internal view {
+        _verifyProverSignature(proof.a, proof.b, proof.c, proof.pubSignals, signature);
     }
 
     // ====================================================

--- a/contracts/contracts/IdentityVerificationHubImplV2.sol
+++ b/contracts/contracts/IdentityVerificationHubImplV2.sol
@@ -23,7 +23,8 @@ import {RootCheckLib} from "./libraries/RootCheckLib.sol";
 import {OfacCheckLib} from "./libraries/OfacCheckLib.sol";
 import {GCPJWTHelper} from "./libraries/GCPJWTHelper.sol";
 import {IGCPJWTVerifier, IPCR0Manager} from "./registry/IdentityRegistryKycImplV1.sol";
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {ProverSignatureLib} from "./libraries/ProverSignatureLib.sol";
+import {ProverAttestationLib} from "./libraries/ProverAttestationLib.sol";
 import {console} from "hardhat/console.sol";
 
 /**
@@ -694,47 +695,16 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
     ) external virtual onlyProxy onlyProverTEE {
         IdentityVerificationHubProverStorage storage $ = _getProverStorage();
 
-        // An unset verifier must never be read as "skip verification".
-        if ($._gcpJwtVerifier == address(0) || $._pcr0Manager == address(0) || $._gcpRootCAPubkeyHash == 0) {
-            revert ProverConfigNotSet();
-        }
-
-        // Check if the proof is valid
-        if (!IGCPJWTVerifier($._gcpJwtVerifier).verifyProof(pA, pB, pC, pubSignals)) revert InvalidProverProof();
-
-        // Check if the root CA pubkey hash is valid
-        if (pubSignals[0] != $._gcpRootCAPubkeyHash) revert InvalidProverRootCA();
-
-        // Check if the TEE image hash is valid
-        bytes memory imageHash = GCPJWTHelper.unpackAndConvertImageHash(pubSignals[5], pubSignals[6], pubSignals[7]);
-        if (!IPCR0Manager($._pcr0Manager).isPCR0Set(imageHash)) revert InvalidProverImage();
-
-        // The circuit always emits 4 nonce chunks; a 40-char address fills only 2. The nonce's
-        // declared length is a circuit input, not a public signal, so asserting the trailing
-        // chunks are empty is the only on-chain bound on what else the nonce carried.
-        if (pubSignals[3] != 0 || pubSignals[4] != 0) revert InvalidProverNoncePadding();
-
-        uint256 currentYear = 2000 + pubSignals[8] * 10 + pubSignals[9];
-        uint256 currentMonth = pubSignals[10] * 10 + pubSignals[11];
-        uint256 currentDay = pubSignals[12] * 10 + pubSignals[13];
-        uint256 currentHour = pubSignals[14] * 10 + pubSignals[15];
-        uint256 currentMinute = pubSignals[16] * 10 + pubSignals[17];
-        uint256 currentSecond = pubSignals[18] * 10 + pubSignals[19];
-        uint256 currentTimestamp = Formatter.toTimeStampWithSeconds(
-            currentYear,
-            currentMonth,
-            currentDay,
-            currentHour,
-            currentMinute,
-            currentSecond
+        address proverKey = ProverAttestationLib.validateAndDecode(
+            $._gcpJwtVerifier,
+            $._pcr0Manager,
+            $._gcpRootCAPubkeyHash,
+            pA,
+            pB,
+            pC,
+            pubSignals
         );
 
-        if (currentTimestamp + 1 hours < block.timestamp) revert InvalidProverTimestamp(); //1 hour in the past
-        if (currentTimestamp > block.timestamp + 1 hours) revert InvalidProverTimestamp(); //1 hour in the future
-
-        // Unpack the address and register it
-        address proverKey = GCPJWTHelper.unpackAndDecodeAddress(pubSignals[1], pubSignals[2]);
-        if (proverKey == address(0)) revert InvalidProverAddress();
         $._isRegisteredProverKey[proverKey] = true;
 
         emit ProverKeyRegistered(proverKey);
@@ -1250,9 +1220,8 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
         uint256[] memory pubSignals,
         bytes memory signature
     ) internal view {
-        bytes32 digest = keccak256(abi.encode(a, b, c, pubSignals));
-        (address signer, ECDSA.RecoverError err, ) = ECDSA.tryRecover(digest, signature);
-        if (err != ECDSA.RecoverError.NoError || !_getProverStorage()._isRegisteredProverKey[signer]) {
+        (address signer, bool ok) = ProverSignatureLib.recoverProverSigner(a, b, c, pubSignals, signature);
+        if (!ok || !_getProverStorage()._isRegisteredProverKey[signer]) {
             revert UnauthorizedProverSigner();
         }
     }
@@ -1261,7 +1230,10 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
      * @notice Struct-taking convenience overload of _verifyProverSignature.
      */
     function _verifyProverSignature(GenericProofStruct memory proof, bytes memory signature) internal view {
-        _verifyProverSignature(proof.a, proof.b, proof.c, proof.pubSignals, signature);
+        (address signer, bool ok) = ProverSignatureLib.recoverProverSignerFromProof(proof, signature);
+        if (!ok || !_getProverStorage()._isRegisteredProverKey[signer]) {
+            revert UnauthorizedProverSigner();
+        }
     }
 
     // ====================================================

--- a/contracts/contracts/IdentityVerificationHubImplV2.sol
+++ b/contracts/contracts/IdentityVerificationHubImplV2.sol
@@ -1267,13 +1267,14 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
     function _decodeInput(
         bytes calldata baseVerificationInput
     ) internal pure returns (SelfStructs.HubInputHeader memory header, bytes calldata proofData) {
-        if (baseVerificationInput.length < 97) {
+        if (baseVerificationInput.length < 162) {
             revert InputTooShort();
         }
         header.contractVersion = uint8(baseVerificationInput[0]);
         header.scope = uint256(bytes32(baseVerificationInput[32:64]));
         header.attestationId = bytes32(baseVerificationInput[64:96]);
-        proofData = baseVerificationInput[96:];
+        header.signature = bytes(baseVerificationInput[96:161]);
+        proofData = baseVerificationInput[161:];
     }
 
     /**

--- a/contracts/contracts/abstract/SelfVerificationRoot.sol
+++ b/contracts/contracts/abstract/SelfVerificationRoot.sol
@@ -83,11 +83,11 @@ abstract contract SelfVerificationRoot is ISelfVerificationRoot {
     /**
      * @notice Verifies a self-proof using the bytes-based interface
      * @dev Parses relayer data format and validates against contract settings before calling hub V2
-     * @param proofPayload Packed data from relayer in format: | 32 bytes attestationId | proof data |
+     * @param proofPayload Packed data from relayer in format: | 32 bytes attestationId | 65 bytes signature | proofData |
      * @param userContextData User-defined data in format: | 32 bytes destChainId | 32 bytes userIdentifier | data |
      * @custom:data-format proofPayload = | 32 bytes attestationId | 65 bytes signature | proofData |
      * @custom:data-format userContextData = | 32 bytes destChainId | 32 bytes userIdentifier | data |
-     * @custom:data-format hubData = | 1 bytes contract version | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | proofData |
+     * @custom:data-format hubData = | 1 bytes contract version | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | 65 bytes signature | proofData |
      */
     function verifySelfProof(bytes calldata proofPayload, bytes calldata userContextData) public {
         // Minimum expected length for proofData: 32 bytes attestationId + proof data
@@ -112,7 +112,7 @@ abstract contract SelfVerificationRoot is ISelfVerificationRoot {
 
         bytes32 configId = getConfigId(destinationChainId, userIdentifier, userDefinedData);
 
-        // Hub data should be | 1 byte contractVersion | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | proof data
+        // Hub data should be | 1 byte contractVersion | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | 65 bytes signature | proofData
         bytes memory baseVerificationInput = abi.encodePacked(
             // 1 byte contractVersion
             CONTRACT_VERSION,

--- a/contracts/contracts/abstract/SelfVerificationRoot.sol
+++ b/contracts/contracts/abstract/SelfVerificationRoot.sol
@@ -85,7 +85,7 @@ abstract contract SelfVerificationRoot is ISelfVerificationRoot {
      * @dev Parses relayer data format and validates against contract settings before calling hub V2
      * @param proofPayload Packed data from relayer in format: | 32 bytes attestationId | proof data |
      * @param userContextData User-defined data in format: | 32 bytes destChainId | 32 bytes userIdentifier | data |
-     * @custom:data-format proofPayload = | 32 bytes attestationId | proofData |
+     * @custom:data-format proofPayload = | 32 bytes attestationId | 65 bytes signature | proofData |
      * @custom:data-format userContextData = | 32 bytes destChainId | 32 bytes userIdentifier | data |
      * @custom:data-format hubData = | 1 bytes contract version | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | proofData |
      */

--- a/contracts/contracts/abstract/SelfVerificationRoot.sol
+++ b/contracts/contracts/abstract/SelfVerificationRoot.sol
@@ -90,8 +90,18 @@ abstract contract SelfVerificationRoot is ISelfVerificationRoot {
      * @custom:data-format hubData = | 1 bytes contract version | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | 65 bytes signature | proofData |
      */
     function verifySelfProof(bytes calldata proofPayload, bytes calldata userContextData) public {
-        // Minimum expected length for proofData: 32 bytes attestationId + proof data
-        if (proofPayload.length < 32) {
+        // 32 bytes attestationId + 65 bytes signature + at least 1 byte of
+        // proof data. Derived from the hub's own floor rather than chosen
+        // here: the hub requires baseVerificationInput >= 162
+        // (1 + 31 + 32 + 32 + 65 + 1), and this function prepends 64 bytes
+        // (contractVersion + buffer + scope) to proofPayload, so 162 - 64 = 98.
+        //
+        // Kept in step with that floor deliberately. This check previously read
+        // `< 32`, the minimum for the pre-signature layout, so every payload
+        // between 32 and 97 bytes was forwarded and rejected by the hub instead
+        // -- an opaque error from a contract the caller never named, rather than
+        // InvalidDataFormat from the one whose documented format was violated.
+        if (proofPayload.length < 98) {
             revert InvalidDataFormat();
         }
 

--- a/contracts/contracts/abstract/SelfVerificationRootUpgradeable.sol
+++ b/contracts/contracts/abstract/SelfVerificationRootUpgradeable.sol
@@ -131,11 +131,11 @@ abstract contract SelfVerificationRootUpgradeable is Initializable, ContextUpgra
     /**
      * @notice Verifies a self-proof using the bytes-based interface
      * @dev Parses relayer data format and validates against contract settings before calling hub V2
-     * @param proofPayload Packed data from relayer in format: | 32 bytes attestationId | proof data |
+     * @param proofPayload Packed data from relayer in format: | 32 bytes attestationId | 65 bytes signature | proofData |
      * @param userContextData User-defined data in format: | 32 bytes destChainId | 32 bytes userIdentifier | data |
-     * @custom:data-format proofPayload = | 32 bytes attestationId | proofData |
+     * @custom:data-format proofPayload = | 32 bytes attestationId | 65 bytes signature | proofData |
      * @custom:data-format userContextData = | 32 bytes destChainId | 32 bytes userIdentifier | data |
-     * @custom:data-format hubData = | 1 bytes contract version | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | proofData |
+     * @custom:data-format hubData = | 1 bytes contract version | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | 65 bytes signature | proofData |
      */
     function verifySelfProof(bytes calldata proofPayload, bytes calldata userContextData) public {
         SelfVerificationRootStorage storage $ = _getSelfVerificationRootStorage();
@@ -162,7 +162,7 @@ abstract contract SelfVerificationRootUpgradeable is Initializable, ContextUpgra
 
         bytes32 configId = getConfigId(destinationChainId, userIdentifier, userDefinedData);
 
-        // Hub data should be | 1 byte contractVersion | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | proof data
+        // Hub data should be | 1 byte contractVersion | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | 65 bytes signature | proofData
         bytes memory baseVerificationInput = abi.encodePacked(
             // 1 byte contractVersion
             CONTRACT_VERSION,

--- a/contracts/contracts/abstract/SelfVerificationRootUpgradeable.sol
+++ b/contracts/contracts/abstract/SelfVerificationRootUpgradeable.sol
@@ -140,8 +140,18 @@ abstract contract SelfVerificationRootUpgradeable is Initializable, ContextUpgra
     function verifySelfProof(bytes calldata proofPayload, bytes calldata userContextData) public {
         SelfVerificationRootStorage storage $ = _getSelfVerificationRootStorage();
 
-        // Minimum expected length for proofData: 32 bytes attestationId + proof data
-        if (proofPayload.length < 32) {
+        // 32 bytes attestationId + 65 bytes signature + at least 1 byte of
+        // proof data. Derived from the hub's own floor rather than chosen
+        // here: the hub requires baseVerificationInput >= 162
+        // (1 + 31 + 32 + 32 + 65 + 1), and this function prepends 64 bytes
+        // (contractVersion + buffer + scope) to proofPayload, so 162 - 64 = 98.
+        //
+        // Kept in step with that floor deliberately. This check previously read
+        // `< 32`, the minimum for the pre-signature layout, so every payload
+        // between 32 and 97 bytes was forwarded and rejected by the hub instead
+        // -- an opaque error from a contract the caller never named, rather than
+        // InvalidDataFormat from the one whose documented format was violated.
+        if (proofPayload.length < 98) {
             revert InvalidDataFormat();
         }
 

--- a/contracts/contracts/interfaces/IIdentityVerificationHubV2.sol
+++ b/contracts/contracts/interfaces/IIdentityVerificationHubV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IRegisterCircuitVerifier} from "./IRegisterCircuitVerifier.sol";
+import {GenericProofStruct} from "./IRegisterCircuitVerifier.sol";
 import {IDscCircuitVerifier} from "./IDscCircuitVerifier.sol";
 import {SelfStructs} from "../libraries/SelfStructs.sol";
 
@@ -26,7 +26,7 @@ interface IIdentityVerificationHubV2 {
     function registerCommitment(
         bytes32 attestationId,
         uint256 registerCircuitVerifierId,
-        IRegisterCircuitVerifier.RegisterCircuitProof memory registerCircuitProof,
+        GenericProofStruct memory registerCircuitProof,
         bytes calldata signature
     ) external;
 

--- a/contracts/contracts/interfaces/ISelfVerificationRoot.sol
+++ b/contracts/contracts/interfaces/ISelfVerificationRoot.sol
@@ -58,7 +58,7 @@ interface ISelfVerificationRoot {
     /**
      * @notice Verifies a self-proof using the bytes-based interface
      * @dev Parses relayer data format and validates against contract settings before calling hub V2
-     * @param proofPayload Packed data from relayer in format: | 32 bytes attestationId | proof data |
+     * @param proofPayload Packed data from relayer in format: | 32 bytes attestationId | 65 bytes signature | proofData |
      * @param userContextData User-defined data in format: | 32 bytes configId | 32 bytes destChainId | 32 bytes userIdentifier | data |
      */
     function verifySelfProof(bytes calldata proofPayload, bytes calldata userContextData) external;

--- a/contracts/contracts/libraries/ProverAttestationLib.sol
+++ b/contracts/contracts/libraries/ProverAttestationLib.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {GCPJWTHelper} from "./GCPJWTHelper.sol";
+import {Formatter} from "./Formatter.sol";
+import {IGCPJWTVerifier, IPCR0Manager} from "../registry/IdentityRegistryKycImplV1.sol";
+
+/**
+ * @title ProverAttestationLib
+ * @notice Validates a GCP JWT attestation and returns the prover key it attests to.
+ * @dev EXTERNAL, so its code is DELEGATECALL'd from a separately deployed
+ *      address rather than inlined. An `internal` library would be inlined and
+ *      save the hub nothing; moving bytes out of the hub's EIP-170 budget is
+ *      the entire reason this exists.
+ *
+ *      Every check here is stateless: config values arrive as arguments and the
+ *      attested address comes back as a return value, leaving the hub to write
+ *      it. This is a cold path -- one call per enclave boot -- so the added
+ *      DELEGATECALL is paid rarely, which is what makes it the right code to
+ *      move out rather than anything on the disclose or register hot paths.
+ *
+ *      Errors are declared here because reverts originate here. The hub keeps
+ *      its own declarations of the same names so they stay in its ABI: the
+ *      selector is derived from the signature, not the declaring contract, so
+ *      a caller matching on the hub's ABI still matches these reverts.
+ */
+library ProverAttestationLib {
+    /// @notice Thrown when the prover verifier, PCR0 manager, or root CA hash is unset.
+    error ProverConfigNotSet();
+    /// @notice Thrown when the attestation proof fails verification.
+    error InvalidProverProof();
+    /// @notice Thrown when the attested root CA hash is not the configured one.
+    error InvalidProverRootCA();
+    /// @notice Thrown when the attested image hash is not registered in the PCR0 manager.
+    error InvalidProverImage();
+    /// @notice Thrown when the eat_nonce carries data beyond the two address chunks.
+    error InvalidProverNoncePadding();
+    /// @notice Thrown when the attested timestamp is more than an hour from block time.
+    error InvalidProverTimestamp();
+    /// @notice Thrown when the attested address decodes to the zero address.
+    error InvalidProverAddress();
+
+    /**
+     * @notice Verifies a GCP JWT attestation proof and decodes the attested prover address.
+     * @param gcpJwtVerifier The configured attestation proof verifier.
+     * @param pcr0Manager The prover-only PCR0 manager holding permitted image digests.
+     * @param gcpRootCAPubkeyHash The configured GCP root CA pubkey hash.
+     * @param pA Groth16 proof element A.
+     * @param pB Groth16 proof element B.
+     * @param pC Groth16 proof element C.
+     * @param pubSignals [rootCAHash, eatNonce[0-3], imageHash[0-2], currentDate[0-11]].
+     * @return proverKey The attested address, guaranteed non-zero.
+     */
+    function validateAndDecode(
+        address gcpJwtVerifier,
+        address pcr0Manager,
+        uint256 gcpRootCAPubkeyHash,
+        uint256[2] calldata pA,
+        uint256[2][2] calldata pB,
+        uint256[2] calldata pC,
+        uint256[20] calldata pubSignals
+    ) external view returns (address proverKey) {
+        // An unset verifier must never be read as "skip verification".
+        if (gcpJwtVerifier == address(0) || pcr0Manager == address(0) || gcpRootCAPubkeyHash == 0) {
+            revert ProverConfigNotSet();
+        }
+
+        if (!IGCPJWTVerifier(gcpJwtVerifier).verifyProof(pA, pB, pC, pubSignals)) revert InvalidProverProof();
+
+        if (pubSignals[0] != gcpRootCAPubkeyHash) revert InvalidProverRootCA();
+
+        bytes memory imageHash = GCPJWTHelper.unpackAndConvertImageHash(pubSignals[5], pubSignals[6], pubSignals[7]);
+        if (!IPCR0Manager(pcr0Manager).isPCR0Set(imageHash)) revert InvalidProverImage();
+
+        // The circuit always emits 4 nonce chunks; a 40-char address fills only 2. The nonce's
+        // declared length is a circuit input, not a public signal, so asserting the trailing
+        // chunks are empty is the only on-chain bound on what else the nonce carried.
+        if (pubSignals[3] != 0 || pubSignals[4] != 0) revert InvalidProverNoncePadding();
+
+        uint256 currentTimestamp = Formatter.toTimeStampWithSeconds(
+            2000 + pubSignals[8] * 10 + pubSignals[9],
+            pubSignals[10] * 10 + pubSignals[11],
+            pubSignals[12] * 10 + pubSignals[13],
+            pubSignals[14] * 10 + pubSignals[15],
+            pubSignals[16] * 10 + pubSignals[17],
+            pubSignals[18] * 10 + pubSignals[19]
+        );
+
+        if (currentTimestamp + 1 hours < block.timestamp) revert InvalidProverTimestamp(); //1 hour in the past
+        if (currentTimestamp > block.timestamp + 1 hours) revert InvalidProverTimestamp(); //1 hour in the future
+
+        proverKey = GCPJWTHelper.unpackAndDecodeAddress(pubSignals[1], pubSignals[2]);
+        if (proverKey == address(0)) revert InvalidProverAddress();
+    }
+}

--- a/contracts/contracts/libraries/ProverSignatureLib.sol
+++ b/contracts/contracts/libraries/ProverSignatureLib.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {GenericProofStruct} from "../interfaces/IRegisterCircuitVerifier.sol";
+
+/**
+ * @title ProverSignatureLib
+ * @notice Recovers the TEE prover key that signed a proof.
+ * @dev Deliberately an EXTERNAL library, so its code is DELEGATECALL'd from a
+ *      separately deployed address rather than inlined into the hub. An
+ *      `internal` library would be inlined by the compiler and save the hub
+ *      nothing -- the point of this extraction is the hub's EIP-170 budget, and
+ *      only external linkage moves bytes out of it.
+ *
+ *      Recovery is `pure` and returns the signer instead of checking whether it
+ *      is registered. Authorization stays in the hub, where the prover-key
+ *      mapping lives: a library holding the check would need the storage
+ *      pointer passed in, which both widens its contract and puts the decision
+ *      one DELEGATECALL away from the state it decides on.
+ */
+library ProverSignatureLib {
+    /**
+     * @notice Recovers the address that signed a Groth16 proof.
+     * @dev The digest mirrors the TEE prover byte-for-byte:
+     *      keccak256(abi.encode(a, b, c, pubSignals)) with pubSignals as a
+     *      dynamic array, signed raw-prehash -- no EIP-191 prefix, v in {27, 28}.
+     *      `pubSignals` is dynamic for every caller, including the DSC path
+     *      whose circuit takes a fixed uint256[2]; widening happens before this
+     *      call so one digest definition serves every flow.
+     * @param a Groth16 proof point A.
+     * @param b Groth16 proof point B.
+     * @param c Groth16 proof point C.
+     * @param pubSignals Public signals, as a dynamic array.
+     * @param signature 65-byte secp256k1 signature over the digest.
+     * @return signer The recovered address, meaningless unless `ok` is true.
+     * @return ok False when the signature is malformed, has a high s-value, or
+     *         otherwise fails to recover -- callers must treat it as a rejection
+     *         rather than comparing `signer` against anything.
+     */
+    function recoverProverSigner(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[] memory pubSignals,
+        bytes memory signature
+    ) external pure returns (address signer, bool ok) {
+        bytes32 digest = keccak256(abi.encode(a, b, c, pubSignals));
+        ECDSA.RecoverError err;
+        (signer, err, ) = ECDSA.tryRecover(digest, signature);
+        ok = err == ECDSA.RecoverError.NoError;
+    }
+
+    /**
+     * @notice Struct-taking form of `recoverProverSigner`.
+     */
+    function recoverProverSignerFromProof(
+        GenericProofStruct memory proof,
+        bytes memory signature
+    ) external pure returns (address signer, bool ok) {
+        bytes32 digest = keccak256(abi.encode(proof.a, proof.b, proof.c, proof.pubSignals));
+        ECDSA.RecoverError err;
+        (signer, err, ) = ECDSA.tryRecover(digest, signature);
+        ok = err == ECDSA.RecoverError.NoError;
+    }
+}

--- a/contracts/contracts/libraries/SelfStructs.sol
+++ b/contracts/contracts/libraries/SelfStructs.sol
@@ -17,6 +17,7 @@ library SelfStructs {
         uint8 contractVersion;
         uint256 scope;
         bytes32 attestationId;
+        bytes signature;
     }
 
     /**

--- a/contracts/ignition/modules/hub/deployHubV2.ts
+++ b/contracts/ignition/modules/hub/deployHubV2.ts
@@ -87,6 +87,8 @@ export default buildModule("DeployHubV2", (m) => {
   const dscProofVerifierLib = m.library("DscProofVerifierLib");
   const rootCheckLib = m.library("RootCheckLib");
   const ofacCheckLib = m.library("OfacCheckLib");
+  const proverSignatureLib = m.library("ProverSignatureLib");
+  const proverAttestationLib = m.library("ProverAttestationLib");
 
   // Deploy the implementation contract with all library linkages
   const identityVerificationHubImplV2 = m.contract("IdentityVerificationHubImplV2", [], {
@@ -98,6 +100,8 @@ export default buildModule("DeployHubV2", (m) => {
       DscProofVerifierLib: dscProofVerifierLib,
       RootCheckLib: rootCheckLib,
       OfacCheckLib: ofacCheckLib,
+      ProverSignatureLib: proverSignatureLib,
+      ProverAttestationLib: proverAttestationLib,
     },
   });
 

--- a/contracts/ignition/modules/upgrade/deployNewHubAndUpgrade.ts
+++ b/contracts/ignition/modules/upgrade/deployNewHubAndUpgrade.ts
@@ -28,6 +28,8 @@ export default buildModule("DeployNewHubAndUpgradee", (m) => {
   const dscProofVerifierLib = m.library("DscProofVerifierLib");
   const rootCheckLib = m.library("RootCheckLib");
   const ofacCheckLib = m.library("OfacCheckLib");
+  const proverSignatureLib = m.library("ProverSignatureLib");
+  const proverAttestationLib = m.library("ProverAttestationLib");
 
   // Deploy new implementation with all library linkages
   const identityVerificationHubImplV2 = m.contract("IdentityVerificationHubImplV2", [], {
@@ -39,6 +41,8 @@ export default buildModule("DeployNewHubAndUpgradee", (m) => {
       DscProofVerifierLib: dscProofVerifierLib,
       RootCheckLib: rootCheckLib,
       OfacCheckLib: ofacCheckLib,
+      ProverSignatureLib: proverSignatureLib,
+      ProverAttestationLib: proverAttestationLib,
     },
   });
 

--- a/contracts/test/utils/deploymentV2.ts
+++ b/contracts/test/utils/deploymentV2.ts
@@ -168,7 +168,9 @@ export async function deploySystemFixturesV2(): Promise<DeployedActorsV2> {
     outputFormatterLib: any,
     proofVerifierLib: any,
     registerProofVerifierLib: any,
-    rootCheckLib: any;
+    rootCheckLib: any,
+    proverSignatureLib: any,
+    proverAttestationLib: any;
   {
     // Deploy PoseidonT3
     poseidonT3Factory = await ethers.getContractFactory("PoseidonT3");
@@ -219,6 +221,14 @@ export async function deploySystemFixturesV2(): Promise<DeployedActorsV2> {
     const RootCheckLibFactory = await ethers.getContractFactory("RootCheckLib");
     rootCheckLib = await RootCheckLibFactory.connect(owner).deploy();
     await rootCheckLib.waitForDeployment();
+
+    const ProverSignatureLibFactory = await ethers.getContractFactory("ProverSignatureLib");
+    proverSignatureLib = await ProverSignatureLibFactory.connect(owner).deploy();
+    await proverSignatureLib.waitForDeployment();
+
+    const ProverAttestationLibFactory = await ethers.getContractFactory("ProverAttestationLib");
+    proverAttestationLib = await ProverAttestationLibFactory.connect(owner).deploy();
+    await proverAttestationLib.waitForDeployment();
   }
 
   // Deploy IdentityRegistryImplV1 (same registry as V1)
@@ -280,6 +290,8 @@ export async function deploySystemFixturesV2(): Promise<DeployedActorsV2> {
         ProofVerifierLib: proofVerifierLib.target,
         RegisterProofVerifierLib: registerProofVerifierLib.target,
         RootCheckLib: rootCheckLib.target,
+        ProverSignatureLib: proverSignatureLib.target,
+        ProverAttestationLib: proverAttestationLib.target,
       },
     });
     identityVerificationHubImplV2 = await IdentityVerificationHubImplV2Factory.connect(owner).deploy();

--- a/contracts/test/utils/proverSignature.ts
+++ b/contracts/test/utils/proverSignature.ts
@@ -75,24 +75,40 @@ const DUMMY_PROOF = {
 
 // Registers wallet.address as a prover key on the hub via the mocked GCP attestation path.
 // Overwrites the hub's prover config with the mock verifier and this fixture's constants.
+//
+// Deploys a PCR0Manager dedicated to the prover rather than reusing
+// deployedActors.pcr0Manager, which deploymentV2.ts also wires into
+// IdentityRegistryKycImplV1. UPGRADE_GUIDE section (b) forbids pointing both
+// contracts at one instance and forbids adding prover digests to the KYC
+// registry's instance -- and since this helper is the shared fixture for the
+// passport, ID, Aadhaar and KYC register suites, reusing it would bake that
+// configuration into every one of them.
+//
+// Separate instances are also what gives the fixture its teeth: if the hub
+// ever consulted the KYC registry's PCR0Manager for a prover image, the
+// digest would not be found there and registerProverKey would revert, which
+// is exactly the regression a shared instance cannot detect.
 export async function registerProverWallet(
   deployedActors: DeployedActorsV2,
   wallet: Wallet | HDNodeWallet,
 ): Promise<void> {
-  const { hub, pcr0Manager, owner } = deployedActors;
+  const { hub, owner } = deployedActors;
 
   const mockVerifier = await (await ethers.getContractFactory("MockGCPJWTVerifier")).deploy();
   await mockVerifier.waitForDeployment();
 
+  const proverPCR0Manager = await (await ethers.getContractFactory("PCR0Manager")).connect(owner).deploy();
+  await proverPCR0Manager.waitForDeployment();
+
   await hub.updateProverGCPJWTVerifier(await mockVerifier.getAddress());
-  await hub.updateProverPCR0Manager(await pcr0Manager.getAddress());
+  await hub.updateProverPCR0Manager(await proverPCR0Manager.getAddress());
   await hub.updateProverGCPRootCAPubkeyHash(ROOT_CA_HASH);
   await hub.updateProverTEE(await owner.getAddress());
 
   // addPCR0 takes the 32-byte digest; isPCR0Set requires the internally padded 48-byte form.
   const padded48 = ethers.getBytes("0x" + "00".repeat(16) + IMAGE.digestHex);
-  if (!(await pcr0Manager.isPCR0Set(padded48))) {
-    await pcr0Manager.addPCR0(ethers.getBytes("0x" + IMAGE.digestHex));
+  if (!(await proverPCR0Manager.isPCR0Set(padded48))) {
+    await proverPCR0Manager.addPCR0(ethers.getBytes("0x" + IMAGE.digestHex));
   }
 
   const [n0, n1] = packAscii(wallet.address.slice(2).toLowerCase());

--- a/contracts/test/utils/proverSignature.ts
+++ b/contracts/test/utils/proverSignature.ts
@@ -17,6 +17,16 @@ export function signProofDigest(
   return wallet.signingKey.sign(digest).serialized;
 }
 
+// Signs the exact proof a test submits: decodes the abi-encoded GenericProofStruct tuple the
+// disclose tests pack into proofPayload, so tampered proofs get signatures over the tampered bytes.
+export function signEncodedProof(wallet: Wallet | HDNodeWallet, encodedProof: string): string {
+  const [[a, b, c, pubSignals]] = ethers.AbiCoder.defaultAbiCoder().decode(
+    ["tuple(uint256[2] a, uint256[2][2] b, uint256[2] c, uint256[] pubSignals)"],
+    encodedProof,
+  );
+  return signProofDigest(wallet, { a, b, c, pubSignals });
+}
+
 // <=31 ASCII bytes per field element, little-endian within each chunk (PackBytes layout).
 function packAscii(s: string): bigint[] {
   const bytes = Buffer.from(s, "ascii");

--- a/contracts/test/v2/discloseAadhaar.test.ts
+++ b/contracts/test/v2/discloseAadhaar.test.ts
@@ -375,8 +375,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const differentScopeProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, differentScopeEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signEncodedProof(proverWallet, differentScopeEncodedProof), differentScopeEncodedProof],
       );
 
       await expect(
@@ -477,8 +477,12 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const modifiedVcAndDiscloseProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, modifiedVcAndDiscloseEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [
+          attestationId,
+          signEncodedProof(proverWallet, modifiedVcAndDiscloseEncodedProof),
+          modifiedVcAndDiscloseEncodedProof,
+        ],
       );
 
       await expect(
@@ -555,8 +559,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const differentScopeProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, differentScopeEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signEncodedProof(proverWallet, differentScopeEncodedProof), differentScopeEncodedProof],
       );
 
       await expect(
@@ -633,8 +637,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const differentScopeProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, differentScopeEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signEncodedProof(proverWallet, differentScopeEncodedProof), differentScopeEncodedProof],
       );
 
       // Note: When currentDay - 1 results in 0, the Formatter library throws InvalidDayRange
@@ -688,8 +692,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const invalidGrothProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, invalidGrothProofEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signEncodedProof(proverWallet, invalidGrothProofEncodedProof), invalidGrothProofEncodedProof],
       );
 
       await expect(

--- a/contracts/test/v2/discloseAadhaar.test.ts
+++ b/contracts/test/v2/discloseAadhaar.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { generateVcAndDiscloseAadhaarProof, getSMTs } from "../utils/generateProof";
-import { PLACEHOLDER_SIGNATURE } from "../utils/constants";
+import { registerProverWallet, signEncodedProof } from "../utils/proverSignature";
 import { poseidon2 } from "poseidon-lite";
 import { BigNumberish } from "ethers";
 import { getPackedForbiddenCountries } from "@selfxyz/new-common/src/blockchain/forbiddenCountries";
@@ -28,6 +28,7 @@ const privateKeyPem = fs.readFileSync(
 
 describe("Self Verification Flow V2 - Aadhaar", () => {
   let deployedActors: DeployedActorsV2;
+  let proverWallet: ReturnType<typeof ethers.Wallet.createRandom>;
   let snapshotId: string;
   let baseVcAndDiscloseProof: any;
   let registerSecret: any;
@@ -51,6 +52,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
   before(async () => {
     deployedActors = await deploySystemFixturesV2();
+    proverWallet = ethers.Wallet.createRandom();
+    await registerProverWallet(deployedActors, proverWallet);
     snapshotId = await ethers.provider.send("evm_snapshot", []);
 
     const hashFunction = (a: bigint, b: bigint) => poseidon2([a, b]);
@@ -175,7 +178,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -235,7 +238,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -296,7 +299,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -423,7 +426,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -734,7 +737,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [invalidAttestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [invalidAttestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -787,7 +790,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -835,7 +838,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -888,7 +891,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -968,7 +971,7 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // Note: The proof is generated with a different merkle root (for chain 31338),

--- a/contracts/test/v2/discloseAadhaar.test.ts
+++ b/contracts/test/v2/discloseAadhaar.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { generateVcAndDiscloseAadhaarProof, getSMTs } from "../utils/generateProof";
+import { PLACEHOLDER_SIGNATURE } from "../utils/constants";
 import { poseidon2 } from "poseidon-lite";
 import { BigNumberish } from "ethers";
 import { getPackedForbiddenCountries } from "@selfxyz/new-common/src/blockchain/forbiddenCountries";
@@ -172,7 +173,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -229,7 +233,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -287,7 +294,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, invalidUserContextData),
@@ -411,7 +421,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, invalidUserContextData),
@@ -719,7 +732,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [invalidAttestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [invalidAttestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -769,7 +785,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -814,7 +833,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -864,7 +886,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -941,7 +966,10 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
         [[newProof.a, newProof.b, newProof.c, newProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // Note: The proof is generated with a different merkle root (for chain 31338),
       // so InvalidIdentityCommitmentRoot is thrown before CrossChainIsNotSupportedYet

--- a/contracts/test/v2/discloseId.test.ts
+++ b/contracts/test/v2/discloseId.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { generateVcAndDiscloseIdProof, getSMTs } from "../utils/generateProof";
+import { PLACEHOLDER_SIGNATURE } from "../utils/constants";
 import { poseidon2 } from "poseidon-lite";
 import { generateCommitment } from "@selfxyz/new-common/src/documents/passport/commitment";
 import { BigNumberish } from "ethers";
@@ -174,7 +175,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -211,7 +215,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -247,7 +254,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.setVerificationConfig(verificationConfigV2);
 
@@ -330,7 +340,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[differentScopeProof.a, differentScopeProof.b, differentScopeProof.c, differentScopeProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with ScopeMismatch because the proof has a different scope
       await expect(
@@ -367,7 +380,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with InvalidUserIdentifierInProof because the userContextData doesn't match the proof
       await expect(
@@ -418,7 +434,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -476,7 +495,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with CurrentDateNotInValidRange because the date is in the future
       await expect(
@@ -535,7 +557,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with CurrentDateNotInValidRange because the date is in the past
       await expect(
@@ -586,7 +611,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[invalidGrothProof.a, invalidGrothProof.b, invalidGrothProof.c, invalidGrothProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with InvalidVcAndDiscloseProof because the groth16 proof is invalid
       await expect(
@@ -627,7 +655,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [invalidAttestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [invalidAttestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -687,7 +718,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[ofacFailingProof.a, ofacFailingProof.b, ofacFailingProof.c, ofacFailingProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -747,7 +781,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[forbiddenCountryProof.a, forbiddenCountryProof.b, forbiddenCountryProof.c, forbiddenCountryProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail because the forbidden countries list in the proof doesn't match the config
       await expect(
@@ -808,7 +845,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[youngerAgeProof.a, youngerAgeProof.b, youngerAgeProof.c, youngerAgeProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail because age 20 is less than required 25
       await expect(
@@ -869,7 +909,10 @@ describe("Self Verification Flow V2 - ID Card", () => {
         [[validProof.a, validProof.b, validProof.c, validProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with CrossChainIsNotSupportedYet because destChainId (999999) != block.chainid (31337)
       await expect(

--- a/contracts/test/v2/discloseId.test.ts
+++ b/contracts/test/v2/discloseId.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { generateVcAndDiscloseIdProof, getSMTs } from "../utils/generateProof";
-import { PLACEHOLDER_SIGNATURE } from "../utils/constants";
+import { registerProverWallet, signEncodedProof } from "../utils/proverSignature";
 import { poseidon2 } from "poseidon-lite";
 import { generateCommitment } from "@selfxyz/new-common/src/documents/passport/commitment";
 import { BigNumberish } from "ethers";
@@ -26,6 +26,7 @@ function calculateUserIdentifierHash(userContextData: string): string {
 
 describe("Self Verification Flow V2 - ID Card", () => {
   let deployedActors: DeployedActorsV2;
+  let proverWallet: ReturnType<typeof ethers.Wallet.createRandom>;
   let snapshotId: string;
   let baseVcAndDiscloseProof: any;
   let pristineBaseVcAndDiscloseProof: any;
@@ -44,6 +45,8 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
   before(async () => {
     deployedActors = await deploySystemFixturesV2();
+    proverWallet = ethers.Wallet.createRandom();
+    await registerProverWallet(deployedActors, proverWallet);
     snapshotId = await ethers.provider.send("evm_snapshot", []);
 
     // Generate mock ID card data
@@ -177,7 +180,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -217,7 +220,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -256,7 +259,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.setVerificationConfig(verificationConfigV2);
@@ -342,7 +345,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with ScopeMismatch because the proof has a different scope
@@ -382,7 +385,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with InvalidUserIdentifierInProof because the userContextData doesn't match the proof
@@ -436,7 +439,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -497,7 +500,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with CurrentDateNotInValidRange because the date is in the future
@@ -559,7 +562,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with CurrentDateNotInValidRange because the date is in the past
@@ -613,7 +616,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with InvalidVcAndDiscloseProof because the groth16 proof is invalid
@@ -657,7 +660,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [invalidAttestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [invalidAttestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -720,7 +723,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -783,7 +786,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail because the forbidden countries list in the proof doesn't match the config
@@ -847,7 +850,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail because age 20 is less than required 25
@@ -911,7 +914,7 @@ describe("Self Verification Flow V2 - ID Card", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with CrossChainIsNotSupportedYet because destChainId (999999) != block.chainid (31337)

--- a/contracts/test/v2/discloseKyc.test.ts
+++ b/contracts/test/v2/discloseKyc.test.ts
@@ -10,6 +10,7 @@ import { expect } from "chai";
 import { generateKycDiscloseInputFromDummy } from "@selfxyz/new-common/src/circuits/inputs/disclose-kyc";
 import { getSMTs } from "../utils/generateProof";
 import { PLACEHOLDER_SIGNATURE } from "../utils/constants";
+import { registerProverWallet, signEncodedProof } from "../utils/proverSignature";
 import { getPackedForbiddenCountries } from "@selfxyz/new-common/src/blockchain/forbiddenCountries";
 import { BigNumberish } from "ethers";
 import { generateVcAndDiscloseKycProof } from "../utils/generateProof";
@@ -22,6 +23,7 @@ const KYC_CURRENT_DATE_INDEX = 21;
 
 describe("Self Verification Flow V2 - KYC", () => {
   let deployedActors: DeployedActorsV2;
+  let proverWallet: ReturnType<typeof ethers.Wallet.createRandom>;
   let snapshotId: string;
   let nullifier: any;
   let tree: any;
@@ -37,6 +39,8 @@ describe("Self Verification Flow V2 - KYC", () => {
 
   before(async () => {
     deployedActors = await deploySystemFixturesV2();
+    proverWallet = ethers.Wallet.createRandom();
+    await registerProverWallet(deployedActors, proverWallet);
 
     const expectedScopeFromHash = hashEndpointWithScope(
       deployedActors.testSelfVerificationRoot.target.toString().toLowerCase(),
@@ -151,7 +155,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -219,7 +223,7 @@ describe("Self Verification Flow V2 - KYC", () => {
       );
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -271,7 +275,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -332,7 +336,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -379,7 +383,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -387,6 +391,74 @@ describe("Self Verification Flow V2 - KYC", () => {
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
       ).to.be.revertedWithCustomError(deployedActors.hubImplV2, "ScopeMismatch");
+    });
+
+    function encodeBaseProof(pubSignals?: unknown): string {
+      return ethers.AbiCoder.defaultAbiCoder().encode(
+        ["tuple(uint256[2] a, uint256[2][2] b, uint256[2] c, uint256[] pubSignals)"],
+        [
+          [
+            baseVcAndDiscloseProof.a,
+            baseVcAndDiscloseProof.b,
+            baseVcAndDiscloseProof.c,
+            pubSignals ?? baseVcAndDiscloseProof.pubSignals,
+          ],
+        ],
+      );
+    }
+
+    async function buildProofPayload(signature: string): Promise<{ proofData: string; userContextData: string }> {
+      const destChainId = ethers.zeroPadValue(ethers.toBeHex(31337), 32);
+      const user1Address = await deployedActors.user1.getAddress();
+      const userData = ethers.toUtf8Bytes("test-user-data-for-verification");
+      const userContextData = ethers.solidityPacked(
+        ["bytes32", "bytes32", "bytes"],
+        [destChainId, ethers.zeroPadValue(user1Address, 32), userData],
+      );
+      const attestationId = ethers.zeroPadValue(ethers.toBeHex(BigInt(KYC_ATTESTATION_ID)), 32);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signature, encodeBaseProof()],
+      );
+      return { proofData, userContextData };
+    }
+
+    it("should fail with UnauthorizedProverSigner for an all-zero signature", async () => {
+      const { proofData, userContextData } = await buildProofPayload(PLACEHOLDER_SIGNATURE);
+      await deployedActors.testSelfVerificationRoot.resetTestState();
+      await expect(
+        deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
+      ).to.be.revertedWithCustomError(deployedActors.hubImplV2, "UnauthorizedProverSigner");
+    });
+
+    it("should fail with UnauthorizedProverSigner when the signer is not a registered prover key", async () => {
+      const stranger = ethers.Wallet.createRandom();
+      const { proofData, userContextData } = await buildProofPayload(signEncodedProof(stranger, encodeBaseProof()));
+      await deployedActors.testSelfVerificationRoot.resetTestState();
+      await expect(
+        deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
+      ).to.be.revertedWithCustomError(deployedActors.hubImplV2, "UnauthorizedProverSigner");
+    });
+
+    it("should fail with UnauthorizedProverSigner when the signature covers a different proof", async () => {
+      const tamperedPubSignals = structuredClone(baseVcAndDiscloseProof.pubSignals);
+      tamperedPubSignals[0] = 12345n;
+      const { proofData, userContextData } = await buildProofPayload(
+        signEncodedProof(proverWallet, encodeBaseProof(tamperedPubSignals)),
+      );
+      await deployedActors.testSelfVerificationRoot.resetTestState();
+      await expect(
+        deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
+      ).to.be.revertedWithCustomError(deployedActors.hubImplV2, "UnauthorizedProverSigner");
+    });
+
+    it("should fail with UnauthorizedProverSigner after the prover key is revoked", async () => {
+      await deployedActors.hub.revokeProverKey(proverWallet.address);
+      const { proofData, userContextData } = await buildProofPayload(signEncodedProof(proverWallet, encodeBaseProof()));
+      await deployedActors.testSelfVerificationRoot.resetTestState();
+      await expect(
+        deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
+      ).to.be.revertedWithCustomError(deployedActors.hubImplV2, "UnauthorizedProverSigner");
     });
 
     it("should fail with invalid user identifier", async () => {
@@ -428,7 +500,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -478,7 +550,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -529,7 +601,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -583,7 +655,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -632,7 +704,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [invalidAttestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [invalidAttestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -681,7 +753,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // The proof validation fails before reaching custom verifier checks
@@ -724,7 +796,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // The proof validation fails before reaching custom verifier checks
@@ -772,7 +844,7 @@ describe("Self Verification Flow V2 - KYC", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // The proof validation fails before reaching custom verifier checks
@@ -835,7 +907,7 @@ describe("Self Verification Flow V2 - KYC", () => {
       );
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // The proof validation fails before reaching cross-chain checks

--- a/contracts/test/v2/discloseKyc.test.ts
+++ b/contracts/test/v2/discloseKyc.test.ts
@@ -9,6 +9,7 @@ import { ethers } from "hardhat";
 import { expect } from "chai";
 import { generateKycDiscloseInputFromDummy } from "@selfxyz/new-common/src/circuits/inputs/disclose-kyc";
 import { getSMTs } from "../utils/generateProof";
+import { PLACEHOLDER_SIGNATURE } from "../utils/constants";
 import { getPackedForbiddenCountries } from "@selfxyz/new-common/src/blockchain/forbiddenCountries";
 import { BigNumberish } from "ethers";
 import { generateVcAndDiscloseKycProof } from "../utils/generateProof";
@@ -148,7 +149,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -213,7 +217,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ["tuple(uint256[2] a, uint256[2][2] b, uint256[2] c, uint256[] pubSignals)"],
         [[fcProof.a, fcProof.b, fcProof.c, fcProof.pubSignals]],
       );
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -262,7 +269,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -320,7 +330,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, invalidUserContextData),
@@ -364,7 +377,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         [[baseVcAndDiscloseProof.a, baseVcAndDiscloseProof.b, baseVcAndDiscloseProof.c, clonedPubSignal]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -410,7 +426,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         [[baseVcAndDiscloseProof.a, baseVcAndDiscloseProof.b, baseVcAndDiscloseProof.c, clonedPubSignal]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -457,7 +476,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         [[baseVcAndDiscloseProof.a, baseVcAndDiscloseProof.b, baseVcAndDiscloseProof.c, clonedPubSignal]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -505,7 +527,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         [[baseVcAndDiscloseProof.a, baseVcAndDiscloseProof.b, baseVcAndDiscloseProof.c, clonedPubSignal]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -556,7 +581,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         [[clonedGrothProof.a, clonedGrothProof.b, clonedGrothProof.c, clonedGrothProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -602,7 +630,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [invalidAttestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [invalidAttestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -648,7 +679,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // The proof validation fails before reaching custom verifier checks
       await expect(deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData)).to.be.reverted;
@@ -688,7 +722,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // The proof validation fails before reaching custom verifier checks
       await expect(deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData)).to.be.reverted;
@@ -733,7 +770,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // The proof validation fails before reaching custom verifier checks
       await expect(deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData)).to.be.reverted;
@@ -793,7 +833,10 @@ describe("Self Verification Flow V2 - KYC", () => {
         ["tuple(uint256[2] a, uint256[2][2] b, uint256[2] c, uint256[] pubSignals)"],
         [[newProof.a, newProof.b, newProof.c, newProof.pubSignals]],
       );
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // The proof validation fails before reaching cross-chain checks
       await expect(deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData)).to.be.reverted;

--- a/contracts/test/v2/disclosePassport.test.ts
+++ b/contracts/test/v2/disclosePassport.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { ATTESTATION_ID, PLACEHOLDER_SIGNATURE } from "../utils/constants";
+import { ATTESTATION_ID } from "../utils/constants";
+import { registerProverWallet, signEncodedProof } from "../utils/proverSignature";
 import { generateVcAndDiscloseProof, getSMTs } from "../utils/generateProof";
 import { poseidon2 } from "poseidon-lite";
 import { generateCommitment } from "@selfxyz/new-common/src/documents/passport/commitment";
@@ -23,6 +24,7 @@ function formatDateForPassport(date: Date): string {
 
 describe("Self Verification Flow V2", () => {
   let deployedActors: DeployedActorsV2;
+  let proverWallet: ReturnType<typeof ethers.Wallet.createRandom>;
   let snapshotId: string;
   let baseVcAndDiscloseProof: any;
   let pristineBaseVcAndDiscloseProof: any;
@@ -47,6 +49,8 @@ describe("Self Verification Flow V2", () => {
 
   before(async () => {
     deployedActors = await deploySystemFixturesV2();
+    proverWallet = ethers.Wallet.createRandom();
+    await registerProverWallet(deployedActors, proverWallet);
 
     // Take snapshot after deployment and balance setting
     snapshotId = await ethers.provider.send("evm_snapshot", []);
@@ -166,7 +170,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -206,7 +210,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
@@ -244,7 +248,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // Create userContextData with less than 96 bytes (invalid)
@@ -327,7 +331,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with ScopeMismatch because the proof has a different scope
@@ -369,7 +373,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with InvalidUserIdentifierInProof because the userContextData doesn't match the proof
@@ -449,7 +453,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -511,7 +515,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with CurrentDateNotInValidRange because the date is in the future
@@ -574,7 +578,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with CurrentDateNotInValidRange because the date is in the past
@@ -629,7 +633,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with InvalidVcAndDiscloseProof because the groth16 proof is invalid
@@ -674,7 +678,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [invalidAttestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [invalidAttestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -737,7 +741,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       await expect(
@@ -809,7 +813,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail because the forbidden countries list in the proof doesn't match the config
@@ -869,7 +873,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail because age 20 is less than required 25
@@ -929,7 +933,7 @@ describe("Self Verification Flow V2", () => {
 
       const proofData = ethers.solidityPacked(
         ["bytes32", "bytes", "bytes"],
-        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+        [attestationId, signEncodedProof(proverWallet, encodedProof), encodedProof],
       );
 
       // This should fail with CrossChainIsNotSupportedYet because destChainId (999999) != block.chainid (31337)

--- a/contracts/test/v2/disclosePassport.test.ts
+++ b/contracts/test/v2/disclosePassport.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { ATTESTATION_ID } from "../utils/constants";
+import { ATTESTATION_ID, PLACEHOLDER_SIGNATURE } from "../utils/constants";
 import { generateVcAndDiscloseProof, getSMTs } from "../utils/generateProof";
 import { poseidon2 } from "poseidon-lite";
 import { generateCommitment } from "@selfxyz/new-common/src/documents/passport/commitment";
@@ -164,7 +164,10 @@ describe("Self Verification Flow V2", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -201,7 +204,10 @@ describe("Self Verification Flow V2", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await deployedActors.testSelfVerificationRoot.resetTestState();
 
@@ -236,7 +242,10 @@ describe("Self Verification Flow V2", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // Create userContextData with less than 96 bytes (invalid)
       const invalidUserContextData = ethers.toUtf8Bytes("short_data"); // Only 10 bytes
@@ -316,7 +325,10 @@ describe("Self Verification Flow V2", () => {
         [[differentScopeProof.a, differentScopeProof.b, differentScopeProof.c, differentScopeProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with ScopeMismatch because the proof has a different scope
       await expect(
@@ -355,7 +367,10 @@ describe("Self Verification Flow V2", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with InvalidUserIdentifierInProof because the userContextData doesn't match the proof
       await expect(
@@ -432,7 +447,10 @@ describe("Self Verification Flow V2", () => {
         [[differentRootProof.a, differentRootProof.b, differentRootProof.c, differentRootProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -491,7 +509,10 @@ describe("Self Verification Flow V2", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with CurrentDateNotInValidRange because the date is in the future
       await expect(
@@ -551,7 +572,10 @@ describe("Self Verification Flow V2", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with CurrentDateNotInValidRange because the date is in the past
       await expect(
@@ -603,7 +627,10 @@ describe("Self Verification Flow V2", () => {
         [[invalidGrothProof.a, invalidGrothProof.b, invalidGrothProof.c, invalidGrothProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with InvalidVcAndDiscloseProof because the groth16 proof is invalid
       await expect(
@@ -645,7 +672,10 @@ describe("Self Verification Flow V2", () => {
         [[vcAndDiscloseProof.a, vcAndDiscloseProof.b, vcAndDiscloseProof.c, vcAndDiscloseProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [invalidAttestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [invalidAttestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -705,7 +735,10 @@ describe("Self Verification Flow V2", () => {
         [[ofacFailingProof.a, ofacFailingProof.b, ofacFailingProof.c, ofacFailingProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       await expect(
         deployedActors.testSelfVerificationRoot.verifySelfProof(proofData, userContextData),
@@ -774,7 +807,10 @@ describe("Self Verification Flow V2", () => {
         [[forbiddenCountryProof.a, forbiddenCountryProof.b, forbiddenCountryProof.c, forbiddenCountryProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail because the forbidden countries list in the proof doesn't match the config
       await expect(
@@ -831,7 +867,10 @@ describe("Self Verification Flow V2", () => {
         [[youngerAgeProof.a, youngerAgeProof.b, youngerAgeProof.c, youngerAgeProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail because age 20 is less than required 25
       await expect(
@@ -888,7 +927,10 @@ describe("Self Verification Flow V2", () => {
         [[validProof.a, validProof.b, validProof.c, validProof.pubSignals]],
       );
 
-      const proofData = ethers.solidityPacked(["bytes32", "bytes"], [attestationId, encodedProof]);
+      const proofData = ethers.solidityPacked(
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, PLACEHOLDER_SIGNATURE, encodedProof],
+      );
 
       // This should fail with CrossChainIsNotSupportedYet because destChainId (999999) != block.chainid (31337)
       await expect(

--- a/error-selectors.json
+++ b/error-selectors.json
@@ -264,10 +264,22 @@
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
   },
   {
+    "name": "InvalidProverProof",
+    "signature": "InvalidProverProof()",
+    "selector": "0x29a48461",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
+  },
+  {
     "name": "InvalidProverTimestamp",
     "signature": "InvalidProverTimestamp()",
     "selector": "0x341da467",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "InvalidProverTimestamp",
+    "signature": "InvalidProverTimestamp()",
+    "selector": "0x341da467",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "InvalidRootsHash",
@@ -304,6 +316,12 @@
     "signature": "InvalidProverRootCA()",
     "selector": "0x3ee21b16",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "InvalidProverRootCA",
+    "signature": "InvalidProverRootCA()",
+    "selector": "0x3ee21b16",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "InvalidPubkey",
@@ -370,6 +388,12 @@
     "signature": "InvalidProverNoncePadding()",
     "selector": "0x50cbea7b",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "InvalidProverNoncePadding",
+    "signature": "InvalidProverNoncePadding()",
+    "selector": "0x50cbea7b",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "INVALID_COMMITMENT_ROOT",
@@ -714,6 +738,12 @@
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
   },
   {
+    "name": "InvalidProverAddress",
+    "signature": "InvalidProverAddress()",
+    "selector": "0xcb0d7cda",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
+  },
+  {
     "name": "CurrentDateNotInValidRange",
     "signature": "CurrentDateNotInValidRange()",
     "selector": "0xcf46551c",
@@ -724,6 +754,12 @@
     "signature": "InvalidProverImage()",
     "selector": "0xd095b6cb",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "InvalidProverImage",
+    "signature": "InvalidProverImage()",
+    "selector": "0xd095b6cb",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "UnauthorizedProverSigner",
@@ -772,6 +808,12 @@
     "signature": "ProverConfigNotSet()",
     "selector": "0xe2ffd388",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "ProverConfigNotSet",
+    "signature": "ProverConfigNotSet()",
+    "selector": "0xe2ffd388",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "ScopeMismatch",


### PR DESCRIPTION
Adds the 65-byte TEE prover signature to the disclose `proofPayload` wire format and verifies it on-chain. **Stacked on #2267** (base = `feat/add-signature-to-register`); retarget to `dev` after #2267 merges — GitHub does this automatically.

## Changes

**Wire format** (`1436621`, rebased): `proofPayload = | 32B attestationId | 65B signature | proofData |`. `_decodeInput` parses the signature into `header.signature`; the minimum-length guard grows 97 → 162. `SelfVerificationRoot` forwards the payload unchanged (pass-through — the relayer constructs it).

**Verification** (`1436621`): the disclose flow enforces unconditionally, same scheme as the register flow in #2267:

- `_verifyProverSignature(proof, header.signature)` at the top of `_basicVerification`, before scope/root/date/groth16 checks. (Placed there rather than in `_executeVerificationFlow` to avoid stack-too-deep; new struct-taking overload of the #2267 helper, whose signature param loosens `calldata` → `memory`.)
- Digest is byte-matched to the TEE: `keccak256(abi.encode(a, b, c, pubSignals))`, raw prehash, no EIP-191 prefix. Reverts `UnauthorizedProverSigner` unless the signer is a registered prover key (#2268 registry).
- No storage changes, no new errors, no version bump — this deploys together with #2267 as the single 2.15.0 upgrade.

**Tests**: all disclose call sites sign the exact proof they submit via a new `signEncodedProof` helper (decodes the packed tuple, so tampered-proof negatives keep hitting their downstream errors); four new `UnauthorizedProverSigner` negatives (zero sig, unregistered signer, signature over a different proof, revoked key).

**Docs**: `UPGRADE_GUIDE.md` §(d) now covers both flows.

## Deploy coupling

Same hard ordering as #2267 (`UPGRADE_GUIDE.md` §(d)), now with the disclose relayer path included: the self-infra-revamp disclose-signature deployment must be live and emitting real signatures before the hub upgrade — placeholder zeros brick disclose with `UnauthorizedProverSigner` from the upgrade block.

## Validation

- `discloseKyc`: 20 passing — real KYC disclose proof through the full enforcement path, plus the four negatives.
- `registerKyc` + `registerProverKey`: 57 passing — no regression from the helper change.
- `disclosePassport`/`Id`/`Aadhaar` lack local circuit artifacts — compile/typecheck-validated; CI is their first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
