### PR TITLE
fix(contracts): review findings on the prover signature PR

### DIFF
--- a/contracts/UPGRADE_GUIDE.md
+++ b/contracts/UPGRADE_GUIDE.md
@@ -257,15 +257,43 @@ to recover (via `keccak256(abi.encode(a, b, c, pubSignals))`, raw prehash, no EI
 key. There is no toggle and no storage change — enforcement is live from the upgrade block, and a relayer still sending
 placeholder zeros bricks the entire register flow with `UnauthorizedProverSigner`.
 
-Hard ordering, each step verified before the next:
+**Adding the `signature` parameter changes both function selectors.** There is no overload: the 3-argument functions
+cease to exist at the upgrade block.
+
+| Function                   | v2.14.0 (3-arg) | v2.15.0 (4-arg) |
+| -------------------------- | --------------- | --------------- |
+| `registerCommitment`       | `0xf2ea431c`    | `0x848cd73b`    |
+| `registerDscKeyCommitment` | `0x8322963f`    | `0xed9b4fd7`    |
+
+That makes the relayer and the hub a **mutually exclusive pair**, and it is why the ordering below is a cutover rather
+than a sequence. A relayer sending 4-argument calldata to the v2.14.0 hub matches no function and the proxy reverts; a
+relayer still sending 3-argument calldata after the upgrade reverts the same way. There is no ordering of "upgrade the
+hub" and "deploy the relayer" in which both are briefly true, so register is unavailable for the window between the two
+transactions. Plan for that window rather than trying to order it away.
+
+Steps 1–4 are ordinary prerequisites and each must be verified before the next. Steps 5 and 6 are the cutover and should
+be executed back to back by the same operator, in a scheduled window, with rollback ready.
 
 1. Prover config set on the currently-deployed hub, per (c).
 2. Prover image digests registered in the prover-only `PCR0Manager`, per (b).
 3. `tee-prover-server` deployed with the `chain` feature enabled and its bare-nonce build, per the prerequisite above.
-4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address.
-5. Relayer + db-relayer deployed with the signature pipeline, and real (non-zero) signatures observed reaching
-   `verifySelfProof`/register calldata.
-6. **Only then** upgrade the hub implementation to v2.15.0.
+4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address. Verify
+   this **before** the cutover: a hub that enforces signatures with no registered key rejects every register call, and
+   step 4 is the only step that can be validated while the old selector is still live.
+5. **Cutover begins.** Upgrade the hub implementation to v2.15.0. Register is unavailable from this transaction.
+6. **Cutover ends.** Deploy relayer + db-relayer with the signature pipeline. Confirm real (non-zero) signatures in
+   register calldata and a successful registration. Register is restored.
+
+Rolling back mid-cutover means reverting the hub to the previous implementation (see Rollback below), which restores the
+3-argument selectors and therefore the old relayer. Do not roll back the hub after the new relayer is live without also
+reverting the relayer.
+
+An earlier revision of this guide placed the relayer deploy at step 5 and the hub upgrade at step 6, on the reasoning
+that real signatures should be observed flowing before enforcement went live. That ordering cannot execute: those
+signatures can only reach the hub through the 4-argument selector, which does not exist until step 6. Observing
+signatures pre-upgrade would require an intermediate hub release that accepts the `signature` parameter and ignores it —
+that release does not exist, since the parameter and its enforcement ship together in v2.15.0. If a zero-downtime
+rollout is required, that intermediate release is the way to get it, and it must be built and deployed first.
 
 Keys are ephemeral per enclave boot: every reboot mints a new key that must be registered before its proofs are
 accepted, and `revokeProverKey` (SECURITY_ROLE) retires a compromised one immediately — revoking the only registered key

--- a/contracts/contracts/interfaces/IIdentityVerificationHubV2.sol
+++ b/contracts/contracts/interfaces/IIdentityVerificationHubV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IRegisterCircuitVerifier} from "./IRegisterCircuitVerifier.sol";
+import {GenericProofStruct} from "./IRegisterCircuitVerifier.sol";
 import {IDscCircuitVerifier} from "./IDscCircuitVerifier.sol";
 import {SelfStructs} from "../libraries/SelfStructs.sol";
 
@@ -26,7 +26,7 @@ interface IIdentityVerificationHubV2 {
     function registerCommitment(
         bytes32 attestationId,
         uint256 registerCircuitVerifierId,
-        IRegisterCircuitVerifier.RegisterCircuitProof memory registerCircuitProof,
+        GenericProofStruct memory registerCircuitProof,
         bytes calldata signature
     ) external;
 

--- a/contracts/test/utils/proverSignature.ts
+++ b/contracts/test/utils/proverSignature.ts
@@ -65,24 +65,40 @@ const DUMMY_PROOF = {
 
 // Registers wallet.address as a prover key on the hub via the mocked GCP attestation path.
 // Overwrites the hub's prover config with the mock verifier and this fixture's constants.
+//
+// Deploys a PCR0Manager dedicated to the prover rather than reusing
+// deployedActors.pcr0Manager, which deploymentV2.ts also wires into
+// IdentityRegistryKycImplV1. UPGRADE_GUIDE section (b) forbids pointing both
+// contracts at one instance and forbids adding prover digests to the KYC
+// registry's instance -- and since this helper is the shared fixture for the
+// passport, ID, Aadhaar and KYC register suites, reusing it would bake that
+// configuration into every one of them.
+//
+// Separate instances are also what gives the fixture its teeth: if the hub
+// ever consulted the KYC registry's PCR0Manager for a prover image, the
+// digest would not be found there and registerProverKey would revert, which
+// is exactly the regression a shared instance cannot detect.
 export async function registerProverWallet(
   deployedActors: DeployedActorsV2,
   wallet: Wallet | HDNodeWallet,
 ): Promise<void> {
-  const { hub, pcr0Manager, owner } = deployedActors;
+  const { hub, owner } = deployedActors;
 
   const mockVerifier = await (await ethers.getContractFactory("MockGCPJWTVerifier")).deploy();
   await mockVerifier.waitForDeployment();
 
+  const proverPCR0Manager = await (await ethers.getContractFactory("PCR0Manager")).connect(owner).deploy();
+  await proverPCR0Manager.waitForDeployment();
+
   await hub.updateProverGCPJWTVerifier(await mockVerifier.getAddress());
-  await hub.updateProverPCR0Manager(await pcr0Manager.getAddress());
+  await hub.updateProverPCR0Manager(await proverPCR0Manager.getAddress());
   await hub.updateProverGCPRootCAPubkeyHash(ROOT_CA_HASH);
   await hub.updateProverTEE(await owner.getAddress());
 
   // addPCR0 takes the 32-byte digest; isPCR0Set requires the internally padded 48-byte form.
   const padded48 = ethers.getBytes("0x" + "00".repeat(16) + IMAGE.digestHex);
-  if (!(await pcr0Manager.isPCR0Set(padded48))) {
-    await pcr0Manager.addPCR0(ethers.getBytes("0x" + IMAGE.digestHex));
+  if (!(await proverPCR0Manager.isPCR0Set(padded48))) {
+    await proverPCR0Manager.addPCR0(ethers.getBytes("0x" + IMAGE.digestHex));
   }
 
   const [n0, n1] = packAscii(wallet.address.slice(2).toLowerCase());


### PR DESCRIPTION
Targets `feat/add-signature-to-register` rather than `dev`, so it lands inside #2267 rather than racing it. Three independent fixes from a review of that PR.

## 1. Interface/implementation selector mismatch

`IIdentityVerificationHubV2.registerCommitment` declared `pubSignals` as `IRegisterCircuitVerifier.RegisterCircuitProof` (`uint256[3]`); the implementation takes `GenericProofStruct` (`uint256[]`). Different selectors:

| | selector |
| --- | --- |
| interface (`uint256[3]`) | `0x3c31dfd7` |
| implementation | `0x848cd73b` |

Any contract calling through the interface reverts on the proxy. The divergence predates this PR and has no in-repo caller (`SelfVerificationRoot` / `SelfVerificationRootUpgradeable` import the interface but never call these functions), so nothing was failing — but this PR edits that exact declaration to add `signature`, which carries the wrong shape into the new docs. `registerDscKeyCommitment` already matched and is untouched.

## 2. Test fixture used the KYC registry's `PCR0Manager`

`registerProverWallet` pointed the hub's prover `PCR0Manager` at `deployedActors.pcr0Manager` — which `deploymentV2.ts:331` also wires into `IdentityRegistryKycImplV1` — and then added a prover image digest to it. `UPGRADE_GUIDE` section (b) forbids both. Since this helper is the shared fixture for the passport, ID, Aadhaar and KYC register suites, all four were exercising the forbidden configuration.

The helper now deploys its own `PCR0Manager`. That also gives the fixture teeth it lacked: if the hub ever consulted the KYC registry's manager for a prover image, the digest wouldn't be there and `registerProverKey` would revert. With a shared instance both lookups succeed, so the regression is undetectable.

## 3. `UPGRADE_GUIDE` section (d) documented an impossible rollout

The guide put the signature-sending relayer at step 5 and the hub upgrade at step 6, so real signatures could be observed before enforcement. That can't execute. Adding `signature` changes both selectors with no overload retained:

| Function | v2.14.0 | v2.15.0 |
| --- | --- | --- |
| `registerCommitment` | `0xf2ea431c` | `0x848cd73b` |
| `registerDscKeyCommitment` | `0x8322963f` | `0xed9b4fd7` |

A relayer sending 4-argument calldata to the v2.14.0 hub matches no function and reverts; a relayer still on 3-argument calldata after the upgrade reverts too. They're mutually exclusive, so register is unavailable between the two transactions no matter how you order them. The section now documents that as a scheduled cutover, says why the old order was impossible, and names the intermediate accept-and-ignore release as the only path to zero downtime.

## Tests

| Suite | Result |
| --- | --- |
| `registerProverKey` | 32 passing |
| `registerPassport` | 14 passing |
| `registerId` + `registerAadhaar` | 21 passing |
| `registerKyc` | 14 passing / 1 failing |

The `registerKyc` failure is in its `before` hook — `Invalid witness length. Circuit: 14530, witness: 14671`, a stale local circuit artifact. It fails identically without these changes.

---

## Two review findings that were raised and then resolved as no-change

Recording these so they aren't re-raised.

**Digest domain separation — keeping `keccak256(abi.encode(a, b, c, pubSignals))` as-is.** Two concerns were raised against it:

- *DSC/register signature collision.* Not reachable. It needs a register proof with exactly 2 public signals; register verifiers take `uint256[3]` (and `uint256[4]` for the ID/Aadhaar variants) while DSC takes `uint256[2]`. A DSC-signed digest replayed into `registerCommitment` carries 2 signals and the register verifier rejects it. The arities never overlap.
- *Cross-chain replay.* Real, but operational rather than structural: it requires the same enclave key registered on two hubs. Keys are minted per enclave boot and staging/prod run separate enclaves, so distinct keys arise naturally. The mitigation is a runbook rule — never register a staging enclave's key on the prod hub — not a preimage change. Binding chain id and hub address would additionally require `tee-prover-server` to know its target chain and hub at signing time, which is not in a proof request today.

**Prover key rotation — no grace period, by decision, and none is needed.** The concern was that ephemeral per-boot keys halt registration on every enclave restart. That does not happen, for two independent reasons:

- `_isRegisteredProverKey` is a `mapping(address => bool)`. `registerProverKey` only ever sets `true`; the sole `= false` is in `revokeProverKey`. Registering a new key does **not** retire the previous one, so the outgoing key stays valid indefinitely.
- In `tee-prover-server`, `register_prover_key` runs between attestation bootstrap and `server.start`, and panics on failure. The enclave cannot accept a single request before its key is registered, so it never signs with a key the hub would reject.

The second point depended on the `chain` feature actually shipping, which it did not — neither image passed it to `cargo build`. That is fixed separately in `tee-prover-server` (both images now build with `chain`, and CI tests with it). The consequence worth tracking is the inverse of the original concern: registered keys **accumulate**, since nothing prunes keys from previous boots. That is a revocation-lifecycle question, not a rotation-outage one.

## Still open

**Contract size.** `IdentityVerificationHubImplV2` is **24,411 bytes** on this PR, **165 under** the EIP-170 limit (`dev` is 23,373). Fine as-is, but `hardhat.config.ts:47` sets `allowUnlimitedContractSize: true`, so the suite won't catch the next change that crosses. Only `forge build --sizes` will, and nothing runs it in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)