### PR TITLE
fix #2266: resolve base conflict, fix the disclose payload floor, fit EIP-170

### DIFF
--- a/contracts/UPGRADE_GUIDE.md
+++ b/contracts/UPGRADE_GUIDE.md
@@ -257,15 +257,43 @@ to recover (via `keccak256(abi.encode(a, b, c, pubSignals))`, raw prehash, no EI
 key. There is no toggle and no storage change — enforcement is live from the upgrade block, and a relayer still sending
 placeholder zeros bricks the entire register flow with `UnauthorizedProverSigner`.
 
-Hard ordering, each step verified before the next:
+**Adding the `signature` parameter changes both function selectors.** There is no overload: the 3-argument functions
+cease to exist at the upgrade block.
+
+| Function                   | v2.14.0 (3-arg) | v2.15.0 (4-arg) |
+| -------------------------- | --------------- | --------------- |
+| `registerCommitment`       | `0xf2ea431c`    | `0x848cd73b`    |
+| `registerDscKeyCommitment` | `0x8322963f`    | `0xed9b4fd7`    |
+
+That makes the relayer and the hub a **mutually exclusive pair**, and it is why the ordering below is a cutover rather
+than a sequence. A relayer sending 4-argument calldata to the v2.14.0 hub matches no function and the proxy reverts; a
+relayer still sending 3-argument calldata after the upgrade reverts the same way. There is no ordering of "upgrade the
+hub" and "deploy the relayer" in which both are briefly true, so register is unavailable for the window between the two
+transactions. Plan for that window rather than trying to order it away.
+
+Steps 1–4 are ordinary prerequisites and each must be verified before the next. Steps 5 and 6 are the cutover and should
+be executed back to back by the same operator, in a scheduled window, with rollback ready.
 
 1. Prover config set on the currently-deployed hub, per (c).
 2. Prover image digests registered in the prover-only `PCR0Manager`, per (b).
 3. `tee-prover-server` deployed with the `chain` feature enabled and its bare-nonce build, per the prerequisite above.
-4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address.
-5. Relayer + db-relayer deployed with the signature pipeline, and real (non-zero) signatures observed reaching
-   `verifySelfProof`/register calldata.
-6. **Only then** upgrade the hub implementation to v2.15.0.
+4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address. Verify
+   this **before** the cutover: a hub that enforces signatures with no registered key rejects every register call, and
+   step 4 is the only step that can be validated while the old selector is still live.
+5. **Cutover begins.** Upgrade the hub implementation to v2.15.0. Register is unavailable from this transaction.
+6. **Cutover ends.** Deploy relayer + db-relayer with the signature pipeline. Confirm real (non-zero) signatures in
+   register calldata and a successful registration. Register is restored.
+
+Rolling back mid-cutover means reverting the hub to the previous implementation (see Rollback below), which restores the
+3-argument selectors and therefore the old relayer. Do not roll back the hub after the new relayer is live without also
+reverting the relayer.
+
+An earlier revision of this guide placed the relayer deploy at step 5 and the hub upgrade at step 6, on the reasoning
+that real signatures should be observed flowing before enforcement went live. That ordering cannot execute: those
+signatures can only reach the hub through the 4-argument selector, which does not exist until step 6. Observing
+signatures pre-upgrade would require an intermediate hub release that accepts the `signature` parameter and ignores it —
+that release does not exist, since the parameter and its enforcement ship together in v2.15.0. If a zero-downtime
+rollout is required, that intermediate release is the way to get it, and it must be built and deployed first.
 
 Keys are ephemeral per enclave boot: every reboot mints a new key that must be registered before its proofs are
 accepted, and `revokeProverKey` (SECURITY_ROLE) retires a compromised one immediately — revoking the only registered key

--- a/contracts/UPGRADE_GUIDE.md
+++ b/contracts/UPGRADE_GUIDE.md
@@ -258,15 +258,55 @@ embedded in `proofPayload`) **unconditionally** require their 65-byte signature 
 toggle and no storage change — enforcement is live from the upgrade block, and a relayer still sending placeholder zeros
 bricks both the register and disclose flows with `UnauthorizedProverSigner`.
 
-Hard ordering, each step verified before the next:
+**Adding the `signature` parameter changes both function selectors.** There is no overload: the 3-argument functions
+cease to exist at the upgrade block.
+
+| Function                   | v2.14.0 (3-arg) | v2.15.0 (4-arg) |
+| -------------------------- | --------------- | --------------- |
+| `registerCommitment`       | `0xf2ea431c`    | `0x848cd73b`    |
+| `registerDscKeyCommitment` | `0x8322963f`    | `0xed9b4fd7`    |
+
+**The disclose flow breaks the same way for a different reason.** `verifySelfProof(bytes,bytes)` keeps its selector —
+the signature rides inside `proofPayload`, whose layout changes from `| 32 bytes attestationId | proofData |` to
+`| 32 bytes attestationId | 65 bytes signature | proofData |`. Nothing about the call shape changes, so a version-skewed
+call is accepted and then misread: an old-format payload sent to a v2.15.0 hub has the first 65 bytes of its proof data
+interpreted as a signature and the remainder shifted by 65 bytes, which surfaces as `UnauthorizedProverSigner` rather
+than as a format error. Do not read that error as a prover-key problem during a rollout — check the relayer's payload
+layout first.
+
+That makes the relayer and the hub a **mutually exclusive pair** for both flows, and it is why the ordering below is a
+cutover rather than a sequence. A relayer sending 4-argument register calldata to the v2.14.0 hub matches no function
+and the proxy reverts; a relayer still sending 3-argument calldata after the upgrade reverts the same way; and the
+disclose payloads fail in whichever direction the skew runs. There is no ordering of "upgrade the hub" and "deploy the
+relayer" in which both are briefly true, so register and disclose are unavailable for the window between the two
+transactions. Plan for that window rather than trying to order it away.
+
+Steps 1–4 are ordinary prerequisites and each must be verified before the next. Steps 5 and 6 are the cutover and should
+be executed back to back by the same operator, in a scheduled window, with rollback ready.
 
 1. Prover config set on the currently-deployed hub, per (c).
 2. Prover image digests registered in the prover-only `PCR0Manager`, per (b).
 3. `tee-prover-server` deployed with the `chain` feature enabled and its bare-nonce build, per the prerequisite above.
-4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address.
-5. Relayer + db-relayer deployed with the signature pipeline for **both flows** (register calldata and the disclose
-   `proofPayload`), and real (non-zero) signatures observed reaching the chain.
-6. **Only then** upgrade the hub implementation to v2.15.0.
+4. `registerProverKey` succeeded on-chain — confirm `ProverKeyRegistered` fired for the live enclave's address. Verify
+   this **before** the cutover: a hub that enforces signatures with no registered key rejects every register and
+   disclose call, and step 4 is the only step that can be validated while the old formats are still live.
+5. **Cutover begins.** Upgrade the hub implementation to v2.15.0. Register and disclose are both unavailable from this
+   transaction.
+6. **Cutover ends.** Deploy relayer + db-relayer with the signature pipeline for **both flows** — the 4-argument
+   register calldata and the disclose `proofPayload` carrying its 65-byte signature. Confirm real (non-zero) signatures
+   reaching the chain on each, and one successful registration and one successful disclosure. Both flows are restored.
+
+Rolling back mid-cutover means reverting the hub to the previous implementation (see Rollback below), which restores the
+3-argument selectors and the old `proofPayload` layout, and therefore the old relayer. Do not roll back the hub after
+the new relayer is live without also reverting the relayer.
+
+An earlier revision of this guide placed the relayer deploy at step 5 and the hub upgrade at step 6, on the reasoning
+that real signatures should be observed flowing before enforcement went live. That ordering cannot execute. For
+register, those signatures can only reach the hub through the 4-argument selector, which does not exist until step 6.
+For disclose, an old hub reads the 65 signature bytes as the first bytes of proof data and fails proof verification.
+Observing signatures pre-upgrade would require an intermediate hub release that accepts them and ignores them — that
+release does not exist, since both the parameter and its enforcement ship together in v2.15.0. If a zero-downtime
+rollout is required, that intermediate release is the way to get it, and it must be built and deployed first.
 
 Keys are ephemeral per enclave boot: every reboot mints a new key that must be registered before its proofs are
 accepted, and `revokeProverKey` (SECURITY_ROLE) retires a compromised one immediately — revoking the only registered key

--- a/contracts/UPGRADE_GUIDE.md
+++ b/contracts/UPGRADE_GUIDE.md
@@ -256,7 +256,7 @@ From v2.15.0, `registerCommitment`, `registerDscKeyCommitment`, and the disclose
 embedded in `proofPayload`) **unconditionally** require their 65-byte signature to recover (via
 `keccak256(abi.encode(a, b, c, pubSignals))`, raw prehash, no EIP-191 prefix) to a registered prover key. There is no
 toggle and no storage change — enforcement is live from the upgrade block, and a relayer still sending placeholder zeros
-bricks both the register and disclose flows with `UnauthorizedProverSigner`.
+bricks both the register and disclose flows.
 
 **Adding the `signature` parameter changes both function selectors.** There is no overload: the 3-argument functions
 cease to exist at the upgrade block.
@@ -269,10 +269,24 @@ cease to exist at the upgrade block.
 **The disclose flow breaks the same way for a different reason.** `verifySelfProof(bytes,bytes)` keeps its selector —
 the signature rides inside `proofPayload`, whose layout changes from `| 32 bytes attestationId | proofData |` to
 `| 32 bytes attestationId | 65 bytes signature | proofData |`. Nothing about the call shape changes, so a version-skewed
-call is accepted and then misread: an old-format payload sent to a v2.15.0 hub has the first 65 bytes of its proof data
-interpreted as a signature and the remainder shifted by 65 bytes, which surfaces as `UnauthorizedProverSigner` rather
-than as a format error. Do not read that error as a prover-key problem during a rollout — check the relayer's payload
-layout first.
+call is accepted and only then found to be wrong.
+
+**What it looks like when it happens.** An old-format payload reaching a v2.15.0 hub has the first 65 bytes of its proof
+data consumed as a signature, leaving the remainder shifted by 65 bytes. `_decodeInput` strips those bytes, and
+`_executeVerificationFlow` hands the shifted remainder to `_decodeVcAndDiscloseProof`, which is a plain
+`abi.decode(data, (GenericProofStruct))`. That is evaluated as an argument to `_basicVerification`, so it runs _before_
+the body reaches `_verifyProverSignature`. A shifted ABI blob has broken offsets, so the call reverts inside
+`abi.decode` — **with no reason string and no custom error at all**, not with `UnauthorizedProverSigner`.
+
+So during a rollout, read the two symptoms in opposite directions:
+
+| Symptom                      | Most likely cause                                                    |
+| ---------------------------- | -------------------------------------------------------------------- |
+| revert with no reason string | version skew — the relayer is sending the old `proofPayload` layout  |
+| `InvalidDataFormat`          | payload shorter than 98 bytes, i.e. no room for the signature at all |
+| `UnauthorizedProverSigner`   | a genuine prover-key problem: unregistered, revoked, or wrong signer |
+
+Only the third is about prover keys. Reaching it requires a payload that decoded cleanly, which a shifted one will not.
 
 That makes the relayer and the hub a **mutually exclusive pair** for both flows, and it is why the ordering below is a
 cutover rather than a sequence. A relayer sending 4-argument register calldata to the v2.14.0 hub matches no function

--- a/contracts/contracts/IdentityVerificationHubImplV2.sol
+++ b/contracts/contracts/IdentityVerificationHubImplV2.sol
@@ -23,7 +23,8 @@ import {RootCheckLib} from "./libraries/RootCheckLib.sol";
 import {OfacCheckLib} from "./libraries/OfacCheckLib.sol";
 import {GCPJWTHelper} from "./libraries/GCPJWTHelper.sol";
 import {IGCPJWTVerifier, IPCR0Manager} from "./registry/IdentityRegistryKycImplV1.sol";
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {ProverSignatureLib} from "./libraries/ProverSignatureLib.sol";
+import {ProverAttestationLib} from "./libraries/ProverAttestationLib.sol";
 import {console} from "hardhat/console.sol";
 
 /**
@@ -694,47 +695,16 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
     ) external virtual onlyProxy onlyProverTEE {
         IdentityVerificationHubProverStorage storage $ = _getProverStorage();
 
-        // An unset verifier must never be read as "skip verification".
-        if ($._gcpJwtVerifier == address(0) || $._pcr0Manager == address(0) || $._gcpRootCAPubkeyHash == 0) {
-            revert ProverConfigNotSet();
-        }
-
-        // Check if the proof is valid
-        if (!IGCPJWTVerifier($._gcpJwtVerifier).verifyProof(pA, pB, pC, pubSignals)) revert InvalidProverProof();
-
-        // Check if the root CA pubkey hash is valid
-        if (pubSignals[0] != $._gcpRootCAPubkeyHash) revert InvalidProverRootCA();
-
-        // Check if the TEE image hash is valid
-        bytes memory imageHash = GCPJWTHelper.unpackAndConvertImageHash(pubSignals[5], pubSignals[6], pubSignals[7]);
-        if (!IPCR0Manager($._pcr0Manager).isPCR0Set(imageHash)) revert InvalidProverImage();
-
-        // The circuit always emits 4 nonce chunks; a 40-char address fills only 2. The nonce's
-        // declared length is a circuit input, not a public signal, so asserting the trailing
-        // chunks are empty is the only on-chain bound on what else the nonce carried.
-        if (pubSignals[3] != 0 || pubSignals[4] != 0) revert InvalidProverNoncePadding();
-
-        uint256 currentYear = 2000 + pubSignals[8] * 10 + pubSignals[9];
-        uint256 currentMonth = pubSignals[10] * 10 + pubSignals[11];
-        uint256 currentDay = pubSignals[12] * 10 + pubSignals[13];
-        uint256 currentHour = pubSignals[14] * 10 + pubSignals[15];
-        uint256 currentMinute = pubSignals[16] * 10 + pubSignals[17];
-        uint256 currentSecond = pubSignals[18] * 10 + pubSignals[19];
-        uint256 currentTimestamp = Formatter.toTimeStampWithSeconds(
-            currentYear,
-            currentMonth,
-            currentDay,
-            currentHour,
-            currentMinute,
-            currentSecond
+        address proverKey = ProverAttestationLib.validateAndDecode(
+            $._gcpJwtVerifier,
+            $._pcr0Manager,
+            $._gcpRootCAPubkeyHash,
+            pA,
+            pB,
+            pC,
+            pubSignals
         );
 
-        if (currentTimestamp + 1 hours < block.timestamp) revert InvalidProverTimestamp(); //1 hour in the past
-        if (currentTimestamp > block.timestamp + 1 hours) revert InvalidProverTimestamp(); //1 hour in the future
-
-        // Unpack the address and register it
-        address proverKey = GCPJWTHelper.unpackAndDecodeAddress(pubSignals[1], pubSignals[2]);
-        if (proverKey == address(0)) revert InvalidProverAddress();
         $._isRegisteredProverKey[proverKey] = true;
 
         emit ProverKeyRegistered(proverKey);
@@ -1250,9 +1220,8 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
         uint256[] memory pubSignals,
         bytes memory signature
     ) internal view {
-        bytes32 digest = keccak256(abi.encode(a, b, c, pubSignals));
-        (address signer, ECDSA.RecoverError err, ) = ECDSA.tryRecover(digest, signature);
-        if (err != ECDSA.RecoverError.NoError || !_getProverStorage()._isRegisteredProverKey[signer]) {
+        (address signer, bool ok) = ProverSignatureLib.recoverProverSigner(a, b, c, pubSignals, signature);
+        if (!ok || !_getProverStorage()._isRegisteredProverKey[signer]) {
             revert UnauthorizedProverSigner();
         }
     }
@@ -1261,7 +1230,10 @@ contract IdentityVerificationHubImplV2 is ImplRoot {
      * @notice Struct-taking convenience overload of _verifyProverSignature.
      */
     function _verifyProverSignature(GenericProofStruct memory proof, bytes memory signature) internal view {
-        _verifyProverSignature(proof.a, proof.b, proof.c, proof.pubSignals, signature);
+        (address signer, bool ok) = ProverSignatureLib.recoverProverSignerFromProof(proof, signature);
+        if (!ok || !_getProverStorage()._isRegisteredProverKey[signer]) {
+            revert UnauthorizedProverSigner();
+        }
     }
 
     // ====================================================

--- a/contracts/contracts/abstract/SelfVerificationRoot.sol
+++ b/contracts/contracts/abstract/SelfVerificationRoot.sol
@@ -90,8 +90,18 @@ abstract contract SelfVerificationRoot is ISelfVerificationRoot {
      * @custom:data-format hubData = | 1 bytes contract version | 31 bytes buffer | 32 bytes scope | 32 bytes attestationId | 65 bytes signature | proofData |
      */
     function verifySelfProof(bytes calldata proofPayload, bytes calldata userContextData) public {
-        // Minimum expected length for proofData: 32 bytes attestationId + proof data
-        if (proofPayload.length < 32) {
+        // 32 bytes attestationId + 65 bytes signature + at least 1 byte of
+        // proof data. Derived from the hub's own floor rather than chosen
+        // here: the hub requires baseVerificationInput >= 162
+        // (1 + 31 + 32 + 32 + 65 + 1), and this function prepends 64 bytes
+        // (contractVersion + buffer + scope) to proofPayload, so 162 - 64 = 98.
+        //
+        // Kept in step with that floor deliberately. This check previously read
+        // `< 32`, the minimum for the pre-signature layout, so every payload
+        // between 32 and 97 bytes was forwarded and rejected by the hub instead
+        // -- an opaque error from a contract the caller never named, rather than
+        // InvalidDataFormat from the one whose documented format was violated.
+        if (proofPayload.length < 98) {
             revert InvalidDataFormat();
         }
 

--- a/contracts/contracts/abstract/SelfVerificationRootUpgradeable.sol
+++ b/contracts/contracts/abstract/SelfVerificationRootUpgradeable.sol
@@ -140,8 +140,18 @@ abstract contract SelfVerificationRootUpgradeable is Initializable, ContextUpgra
     function verifySelfProof(bytes calldata proofPayload, bytes calldata userContextData) public {
         SelfVerificationRootStorage storage $ = _getSelfVerificationRootStorage();
 
-        // Minimum expected length for proofData: 32 bytes attestationId + proof data
-        if (proofPayload.length < 32) {
+        // 32 bytes attestationId + 65 bytes signature + at least 1 byte of
+        // proof data. Derived from the hub's own floor rather than chosen
+        // here: the hub requires baseVerificationInput >= 162
+        // (1 + 31 + 32 + 32 + 65 + 1), and this function prepends 64 bytes
+        // (contractVersion + buffer + scope) to proofPayload, so 162 - 64 = 98.
+        //
+        // Kept in step with that floor deliberately. This check previously read
+        // `< 32`, the minimum for the pre-signature layout, so every payload
+        // between 32 and 97 bytes was forwarded and rejected by the hub instead
+        // -- an opaque error from a contract the caller never named, rather than
+        // InvalidDataFormat from the one whose documented format was violated.
+        if (proofPayload.length < 98) {
             revert InvalidDataFormat();
         }
 

--- a/contracts/contracts/interfaces/IIdentityVerificationHubV2.sol
+++ b/contracts/contracts/interfaces/IIdentityVerificationHubV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IRegisterCircuitVerifier} from "./IRegisterCircuitVerifier.sol";
+import {GenericProofStruct} from "./IRegisterCircuitVerifier.sol";
 import {IDscCircuitVerifier} from "./IDscCircuitVerifier.sol";
 import {SelfStructs} from "../libraries/SelfStructs.sol";
 
@@ -26,7 +26,7 @@ interface IIdentityVerificationHubV2 {
     function registerCommitment(
         bytes32 attestationId,
         uint256 registerCircuitVerifierId,
-        IRegisterCircuitVerifier.RegisterCircuitProof memory registerCircuitProof,
+        GenericProofStruct memory registerCircuitProof,
         bytes calldata signature
     ) external;
 

--- a/contracts/contracts/libraries/ProverAttestationLib.sol
+++ b/contracts/contracts/libraries/ProverAttestationLib.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {GCPJWTHelper} from "./GCPJWTHelper.sol";
+import {Formatter} from "./Formatter.sol";
+import {IGCPJWTVerifier, IPCR0Manager} from "../registry/IdentityRegistryKycImplV1.sol";
+
+/**
+ * @title ProverAttestationLib
+ * @notice Validates a GCP JWT attestation and returns the prover key it attests to.
+ * @dev EXTERNAL, so its code is DELEGATECALL'd from a separately deployed
+ *      address rather than inlined. An `internal` library would be inlined and
+ *      save the hub nothing; moving bytes out of the hub's EIP-170 budget is
+ *      the entire reason this exists.
+ *
+ *      Every check here is stateless: config values arrive as arguments and the
+ *      attested address comes back as a return value, leaving the hub to write
+ *      it. This is a cold path -- one call per enclave boot -- so the added
+ *      DELEGATECALL is paid rarely, which is what makes it the right code to
+ *      move out rather than anything on the disclose or register hot paths.
+ *
+ *      Errors are declared here because reverts originate here. The hub keeps
+ *      its own declarations of the same names so they stay in its ABI: the
+ *      selector is derived from the signature, not the declaring contract, so
+ *      a caller matching on the hub's ABI still matches these reverts.
+ */
+library ProverAttestationLib {
+    /// @notice Thrown when the prover verifier, PCR0 manager, or root CA hash is unset.
+    error ProverConfigNotSet();
+    /// @notice Thrown when the attestation proof fails verification.
+    error InvalidProverProof();
+    /// @notice Thrown when the attested root CA hash is not the configured one.
+    error InvalidProverRootCA();
+    /// @notice Thrown when the attested image hash is not registered in the PCR0 manager.
+    error InvalidProverImage();
+    /// @notice Thrown when the eat_nonce carries data beyond the two address chunks.
+    error InvalidProverNoncePadding();
+    /// @notice Thrown when the attested timestamp is more than an hour from block time.
+    error InvalidProverTimestamp();
+    /// @notice Thrown when the attested address decodes to the zero address.
+    error InvalidProverAddress();
+
+    /**
+     * @notice Verifies a GCP JWT attestation proof and decodes the attested prover address.
+     * @param gcpJwtVerifier The configured attestation proof verifier.
+     * @param pcr0Manager The prover-only PCR0 manager holding permitted image digests.
+     * @param gcpRootCAPubkeyHash The configured GCP root CA pubkey hash.
+     * @param pA Groth16 proof element A.
+     * @param pB Groth16 proof element B.
+     * @param pC Groth16 proof element C.
+     * @param pubSignals [rootCAHash, eatNonce[0-3], imageHash[0-2], currentDate[0-11]].
+     * @return proverKey The attested address, guaranteed non-zero.
+     */
+    function validateAndDecode(
+        address gcpJwtVerifier,
+        address pcr0Manager,
+        uint256 gcpRootCAPubkeyHash,
+        uint256[2] calldata pA,
+        uint256[2][2] calldata pB,
+        uint256[2] calldata pC,
+        uint256[20] calldata pubSignals
+    ) external view returns (address proverKey) {
+        // An unset verifier must never be read as "skip verification".
+        if (gcpJwtVerifier == address(0) || pcr0Manager == address(0) || gcpRootCAPubkeyHash == 0) {
+            revert ProverConfigNotSet();
+        }
+
+        if (!IGCPJWTVerifier(gcpJwtVerifier).verifyProof(pA, pB, pC, pubSignals)) revert InvalidProverProof();
+
+        if (pubSignals[0] != gcpRootCAPubkeyHash) revert InvalidProverRootCA();
+
+        bytes memory imageHash = GCPJWTHelper.unpackAndConvertImageHash(pubSignals[5], pubSignals[6], pubSignals[7]);
+        if (!IPCR0Manager(pcr0Manager).isPCR0Set(imageHash)) revert InvalidProverImage();
+
+        // The circuit always emits 4 nonce chunks; a 40-char address fills only 2. The nonce's
+        // declared length is a circuit input, not a public signal, so asserting the trailing
+        // chunks are empty is the only on-chain bound on what else the nonce carried.
+        if (pubSignals[3] != 0 || pubSignals[4] != 0) revert InvalidProverNoncePadding();
+
+        uint256 currentTimestamp = Formatter.toTimeStampWithSeconds(
+            2000 + pubSignals[8] * 10 + pubSignals[9],
+            pubSignals[10] * 10 + pubSignals[11],
+            pubSignals[12] * 10 + pubSignals[13],
+            pubSignals[14] * 10 + pubSignals[15],
+            pubSignals[16] * 10 + pubSignals[17],
+            pubSignals[18] * 10 + pubSignals[19]
+        );
+
+        if (currentTimestamp + 1 hours < block.timestamp) revert InvalidProverTimestamp(); //1 hour in the past
+        if (currentTimestamp > block.timestamp + 1 hours) revert InvalidProverTimestamp(); //1 hour in the future
+
+        proverKey = GCPJWTHelper.unpackAndDecodeAddress(pubSignals[1], pubSignals[2]);
+        if (proverKey == address(0)) revert InvalidProverAddress();
+    }
+}

--- a/contracts/contracts/libraries/ProverSignatureLib.sol
+++ b/contracts/contracts/libraries/ProverSignatureLib.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {GenericProofStruct} from "../interfaces/IRegisterCircuitVerifier.sol";
+
+/**
+ * @title ProverSignatureLib
+ * @notice Recovers the TEE prover key that signed a proof.
+ * @dev Deliberately an EXTERNAL library, so its code is DELEGATECALL'd from a
+ *      separately deployed address rather than inlined into the hub. An
+ *      `internal` library would be inlined by the compiler and save the hub
+ *      nothing -- the point of this extraction is the hub's EIP-170 budget, and
+ *      only external linkage moves bytes out of it.
+ *
+ *      Recovery is `pure` and returns the signer instead of checking whether it
+ *      is registered. Authorization stays in the hub, where the prover-key
+ *      mapping lives: a library holding the check would need the storage
+ *      pointer passed in, which both widens its contract and puts the decision
+ *      one DELEGATECALL away from the state it decides on.
+ */
+library ProverSignatureLib {
+    /**
+     * @notice Recovers the address that signed a Groth16 proof.
+     * @dev The digest mirrors the TEE prover byte-for-byte:
+     *      keccak256(abi.encode(a, b, c, pubSignals)) with pubSignals as a
+     *      dynamic array, signed raw-prehash -- no EIP-191 prefix, v in {27, 28}.
+     *      `pubSignals` is dynamic for every caller, including the DSC path
+     *      whose circuit takes a fixed uint256[2]; widening happens before this
+     *      call so one digest definition serves every flow.
+     * @param a Groth16 proof point A.
+     * @param b Groth16 proof point B.
+     * @param c Groth16 proof point C.
+     * @param pubSignals Public signals, as a dynamic array.
+     * @param signature 65-byte secp256k1 signature over the digest.
+     * @return signer The recovered address, meaningless unless `ok` is true.
+     * @return ok False when the signature is malformed, has a high s-value, or
+     *         otherwise fails to recover -- callers must treat it as a rejection
+     *         rather than comparing `signer` against anything.
+     */
+    function recoverProverSigner(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[] memory pubSignals,
+        bytes memory signature
+    ) external pure returns (address signer, bool ok) {
+        bytes32 digest = keccak256(abi.encode(a, b, c, pubSignals));
+        ECDSA.RecoverError err;
+        (signer, err, ) = ECDSA.tryRecover(digest, signature);
+        ok = err == ECDSA.RecoverError.NoError;
+    }
+
+    /**
+     * @notice Struct-taking form of `recoverProverSigner`.
+     */
+    function recoverProverSignerFromProof(
+        GenericProofStruct memory proof,
+        bytes memory signature
+    ) external pure returns (address signer, bool ok) {
+        bytes32 digest = keccak256(abi.encode(proof.a, proof.b, proof.c, proof.pubSignals));
+        ECDSA.RecoverError err;
+        (signer, err, ) = ECDSA.tryRecover(digest, signature);
+        ok = err == ECDSA.RecoverError.NoError;
+    }
+}

--- a/contracts/ignition/modules/hub/deployHubV2.ts
+++ b/contracts/ignition/modules/hub/deployHubV2.ts
@@ -87,6 +87,8 @@ export default buildModule("DeployHubV2", (m) => {
   const dscProofVerifierLib = m.library("DscProofVerifierLib");
   const rootCheckLib = m.library("RootCheckLib");
   const ofacCheckLib = m.library("OfacCheckLib");
+  const proverSignatureLib = m.library("ProverSignatureLib");
+  const proverAttestationLib = m.library("ProverAttestationLib");
 
   // Deploy the implementation contract with all library linkages
   const identityVerificationHubImplV2 = m.contract("IdentityVerificationHubImplV2", [], {
@@ -98,6 +100,8 @@ export default buildModule("DeployHubV2", (m) => {
       DscProofVerifierLib: dscProofVerifierLib,
       RootCheckLib: rootCheckLib,
       OfacCheckLib: ofacCheckLib,
+      ProverSignatureLib: proverSignatureLib,
+      ProverAttestationLib: proverAttestationLib,
     },
   });
 

--- a/contracts/ignition/modules/upgrade/deployNewHubAndUpgrade.ts
+++ b/contracts/ignition/modules/upgrade/deployNewHubAndUpgrade.ts
@@ -28,6 +28,8 @@ export default buildModule("DeployNewHubAndUpgradee", (m) => {
   const dscProofVerifierLib = m.library("DscProofVerifierLib");
   const rootCheckLib = m.library("RootCheckLib");
   const ofacCheckLib = m.library("OfacCheckLib");
+  const proverSignatureLib = m.library("ProverSignatureLib");
+  const proverAttestationLib = m.library("ProverAttestationLib");
 
   // Deploy new implementation with all library linkages
   const identityVerificationHubImplV2 = m.contract("IdentityVerificationHubImplV2", [], {
@@ -39,6 +41,8 @@ export default buildModule("DeployNewHubAndUpgradee", (m) => {
       DscProofVerifierLib: dscProofVerifierLib,
       RootCheckLib: rootCheckLib,
       OfacCheckLib: ofacCheckLib,
+      ProverSignatureLib: proverSignatureLib,
+      ProverAttestationLib: proverAttestationLib,
     },
   });
 

--- a/contracts/test/utils/deploymentV2.ts
+++ b/contracts/test/utils/deploymentV2.ts
@@ -168,7 +168,9 @@ export async function deploySystemFixturesV2(): Promise<DeployedActorsV2> {
     outputFormatterLib: any,
     proofVerifierLib: any,
     registerProofVerifierLib: any,
-    rootCheckLib: any;
+    rootCheckLib: any,
+    proverSignatureLib: any,
+    proverAttestationLib: any;
   {
     // Deploy PoseidonT3
     poseidonT3Factory = await ethers.getContractFactory("PoseidonT3");
@@ -219,6 +221,14 @@ export async function deploySystemFixturesV2(): Promise<DeployedActorsV2> {
     const RootCheckLibFactory = await ethers.getContractFactory("RootCheckLib");
     rootCheckLib = await RootCheckLibFactory.connect(owner).deploy();
     await rootCheckLib.waitForDeployment();
+
+    const ProverSignatureLibFactory = await ethers.getContractFactory("ProverSignatureLib");
+    proverSignatureLib = await ProverSignatureLibFactory.connect(owner).deploy();
+    await proverSignatureLib.waitForDeployment();
+
+    const ProverAttestationLibFactory = await ethers.getContractFactory("ProverAttestationLib");
+    proverAttestationLib = await ProverAttestationLibFactory.connect(owner).deploy();
+    await proverAttestationLib.waitForDeployment();
   }
 
   // Deploy IdentityRegistryImplV1 (same registry as V1)
@@ -280,6 +290,8 @@ export async function deploySystemFixturesV2(): Promise<DeployedActorsV2> {
         ProofVerifierLib: proofVerifierLib.target,
         RegisterProofVerifierLib: registerProofVerifierLib.target,
         RootCheckLib: rootCheckLib.target,
+        ProverSignatureLib: proverSignatureLib.target,
+        ProverAttestationLib: proverAttestationLib.target,
       },
     });
     identityVerificationHubImplV2 = await IdentityVerificationHubImplV2Factory.connect(owner).deploy();

--- a/contracts/test/utils/proverSignature.ts
+++ b/contracts/test/utils/proverSignature.ts
@@ -75,24 +75,40 @@ const DUMMY_PROOF = {
 
 // Registers wallet.address as a prover key on the hub via the mocked GCP attestation path.
 // Overwrites the hub's prover config with the mock verifier and this fixture's constants.
+//
+// Deploys a PCR0Manager dedicated to the prover rather than reusing
+// deployedActors.pcr0Manager, which deploymentV2.ts also wires into
+// IdentityRegistryKycImplV1. UPGRADE_GUIDE section (b) forbids pointing both
+// contracts at one instance and forbids adding prover digests to the KYC
+// registry's instance -- and since this helper is the shared fixture for the
+// passport, ID, Aadhaar and KYC register suites, reusing it would bake that
+// configuration into every one of them.
+//
+// Separate instances are also what gives the fixture its teeth: if the hub
+// ever consulted the KYC registry's PCR0Manager for a prover image, the
+// digest would not be found there and registerProverKey would revert, which
+// is exactly the regression a shared instance cannot detect.
 export async function registerProverWallet(
   deployedActors: DeployedActorsV2,
   wallet: Wallet | HDNodeWallet,
 ): Promise<void> {
-  const { hub, pcr0Manager, owner } = deployedActors;
+  const { hub, owner } = deployedActors;
 
   const mockVerifier = await (await ethers.getContractFactory("MockGCPJWTVerifier")).deploy();
   await mockVerifier.waitForDeployment();
 
+  const proverPCR0Manager = await (await ethers.getContractFactory("PCR0Manager")).connect(owner).deploy();
+  await proverPCR0Manager.waitForDeployment();
+
   await hub.updateProverGCPJWTVerifier(await mockVerifier.getAddress());
-  await hub.updateProverPCR0Manager(await pcr0Manager.getAddress());
+  await hub.updateProverPCR0Manager(await proverPCR0Manager.getAddress());
   await hub.updateProverGCPRootCAPubkeyHash(ROOT_CA_HASH);
   await hub.updateProverTEE(await owner.getAddress());
 
   // addPCR0 takes the 32-byte digest; isPCR0Set requires the internally padded 48-byte form.
   const padded48 = ethers.getBytes("0x" + "00".repeat(16) + IMAGE.digestHex);
-  if (!(await pcr0Manager.isPCR0Set(padded48))) {
-    await pcr0Manager.addPCR0(ethers.getBytes("0x" + IMAGE.digestHex));
+  if (!(await proverPCR0Manager.isPCR0Set(padded48))) {
+    await proverPCR0Manager.addPCR0(ethers.getBytes("0x" + IMAGE.digestHex));
   }
 
   const [n0, n1] = packAscii(wallet.address.slice(2).toLowerCase());

--- a/contracts/test/utils/proverSignature.ts
+++ b/contracts/test/utils/proverSignature.ts
@@ -65,24 +65,40 @@ const DUMMY_PROOF = {
 
 // Registers wallet.address as a prover key on the hub via the mocked GCP attestation path.
 // Overwrites the hub's prover config with the mock verifier and this fixture's constants.
+//
+// Deploys a PCR0Manager dedicated to the prover rather than reusing
+// deployedActors.pcr0Manager, which deploymentV2.ts also wires into
+// IdentityRegistryKycImplV1. UPGRADE_GUIDE section (b) forbids pointing both
+// contracts at one instance and forbids adding prover digests to the KYC
+// registry's instance -- and since this helper is the shared fixture for the
+// passport, ID, Aadhaar and KYC register suites, reusing it would bake that
+// configuration into every one of them.
+//
+// Separate instances are also what gives the fixture its teeth: if the hub
+// ever consulted the KYC registry's PCR0Manager for a prover image, the
+// digest would not be found there and registerProverKey would revert, which
+// is exactly the regression a shared instance cannot detect.
 export async function registerProverWallet(
   deployedActors: DeployedActorsV2,
   wallet: Wallet | HDNodeWallet,
 ): Promise<void> {
-  const { hub, pcr0Manager, owner } = deployedActors;
+  const { hub, owner } = deployedActors;
 
   const mockVerifier = await (await ethers.getContractFactory("MockGCPJWTVerifier")).deploy();
   await mockVerifier.waitForDeployment();
 
+  const proverPCR0Manager = await (await ethers.getContractFactory("PCR0Manager")).connect(owner).deploy();
+  await proverPCR0Manager.waitForDeployment();
+
   await hub.updateProverGCPJWTVerifier(await mockVerifier.getAddress());
-  await hub.updateProverPCR0Manager(await pcr0Manager.getAddress());
+  await hub.updateProverPCR0Manager(await proverPCR0Manager.getAddress());
   await hub.updateProverGCPRootCAPubkeyHash(ROOT_CA_HASH);
   await hub.updateProverTEE(await owner.getAddress());
 
   // addPCR0 takes the 32-byte digest; isPCR0Set requires the internally padded 48-byte form.
   const padded48 = ethers.getBytes("0x" + "00".repeat(16) + IMAGE.digestHex);
-  if (!(await pcr0Manager.isPCR0Set(padded48))) {
-    await pcr0Manager.addPCR0(ethers.getBytes("0x" + IMAGE.digestHex));
+  if (!(await proverPCR0Manager.isPCR0Set(padded48))) {
+    await proverPCR0Manager.addPCR0(ethers.getBytes("0x" + IMAGE.digestHex));
   }
 
   const [n0, n1] = packAscii(wallet.address.slice(2).toLowerCase());

--- a/contracts/test/v2/discloseAadhaar.test.ts
+++ b/contracts/test/v2/discloseAadhaar.test.ts
@@ -375,8 +375,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const differentScopeProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, differentScopeEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signEncodedProof(proverWallet, differentScopeEncodedProof), differentScopeEncodedProof],
       );
 
       await expect(
@@ -477,8 +477,12 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const modifiedVcAndDiscloseProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, modifiedVcAndDiscloseEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [
+          attestationId,
+          signEncodedProof(proverWallet, modifiedVcAndDiscloseEncodedProof),
+          modifiedVcAndDiscloseEncodedProof,
+        ],
       );
 
       await expect(
@@ -555,8 +559,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const differentScopeProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, differentScopeEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signEncodedProof(proverWallet, differentScopeEncodedProof), differentScopeEncodedProof],
       );
 
       await expect(
@@ -633,8 +637,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const differentScopeProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, differentScopeEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signEncodedProof(proverWallet, differentScopeEncodedProof), differentScopeEncodedProof],
       );
 
       // Note: When currentDay - 1 results in 0, the Formatter library throws InvalidDayRange
@@ -688,8 +692,8 @@ describe("Self Verification Flow V2 - Aadhaar", () => {
       );
 
       const invalidGrothProofData = ethers.solidityPacked(
-        ["bytes32", "bytes"],
-        [attestationId, invalidGrothProofEncodedProof],
+        ["bytes32", "bytes", "bytes"],
+        [attestationId, signEncodedProof(proverWallet, invalidGrothProofEncodedProof), invalidGrothProofEncodedProof],
       );
 
       await expect(

--- a/error-selectors.json
+++ b/error-selectors.json
@@ -264,10 +264,22 @@
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
   },
   {
+    "name": "InvalidProverProof",
+    "signature": "InvalidProverProof()",
+    "selector": "0x29a48461",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
+  },
+  {
     "name": "InvalidProverTimestamp",
     "signature": "InvalidProverTimestamp()",
     "selector": "0x341da467",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "InvalidProverTimestamp",
+    "signature": "InvalidProverTimestamp()",
+    "selector": "0x341da467",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "InvalidRootsHash",
@@ -304,6 +316,12 @@
     "signature": "InvalidProverRootCA()",
     "selector": "0x3ee21b16",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "InvalidProverRootCA",
+    "signature": "InvalidProverRootCA()",
+    "selector": "0x3ee21b16",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "InvalidPubkey",
@@ -370,6 +388,12 @@
     "signature": "InvalidProverNoncePadding()",
     "selector": "0x50cbea7b",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "InvalidProverNoncePadding",
+    "signature": "InvalidProverNoncePadding()",
+    "selector": "0x50cbea7b",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "INVALID_COMMITMENT_ROOT",
@@ -714,6 +738,12 @@
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
   },
   {
+    "name": "InvalidProverAddress",
+    "signature": "InvalidProverAddress()",
+    "selector": "0xcb0d7cda",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
+  },
+  {
     "name": "CurrentDateNotInValidRange",
     "signature": "CurrentDateNotInValidRange()",
     "selector": "0xcf46551c",
@@ -724,6 +754,12 @@
     "signature": "InvalidProverImage()",
     "selector": "0xd095b6cb",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "InvalidProverImage",
+    "signature": "InvalidProverImage()",
+    "selector": "0xd095b6cb",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "UnauthorizedProverSigner",
@@ -772,6 +808,12 @@
     "signature": "ProverConfigNotSet()",
     "selector": "0xe2ffd388",
     "file": "contracts/contracts/IdentityVerificationHubImplV2.sol"
+  },
+  {
+    "name": "ProverConfigNotSet",
+    "signature": "ProverConfigNotSet()",
+    "selector": "0xe2ffd388",
+    "file": "contracts/contracts/libraries/ProverAttestationLib.sol"
   },
   {
     "name": "ScopeMismatch",


### PR DESCRIPTION
Makes #2266 both **mergeable** and **deployable**. Targets `feat/add-signature-proofPayload` and fast-forwards it.

Three things, in the order I found them.

## 1. The conflict

The base moved: #2269 landed on `feat/add-signature-to-register` as `19b7e83f5`. One conflict, in `UPGRADE_GUIDE` section (d) — this branch extended step 5 to cover both flows while keeping the relayer-then-hub ordering; the base had replaced that ordering with a cutover. Kept the cutover, folded in the both-flows point.

**Disclose breaks the same way for a different reason, and the section now says so.** `verifySelfProof(bytes,bytes)` keeps its selector — the signature rides inside `proofPayload`:

```
old: | 32 bytes attestationId |                     proofData |
new: | 32 bytes attestationId | 65 bytes signature | proofData |
```

Nothing about the call shape changes, so a version-skewed call is accepted and only then found to be wrong.

**Corrected after Codex review:** an earlier revision of this PR said that surfaces as `UnauthorizedProverSigner`. It does not. `_decodeVcAndDiscloseProof` is a plain `abi.decode`, evaluated as an *argument* to `_basicVerification`, so it runs before the body reaches `_verifyProverSignature`. A payload shifted by 65 bytes has broken ABI offsets and reverts inside `abi.decode` with **no reason string at all**. This branch's own evidence said so — the four repaired tests were each failing with "reverted without a reason" — and the guide contradicted it. The rollout section now lists all three symptoms and which cause each points to.

## 2. Two correctness fixes

**The payload floor was left at the pre-signature value.** `SelfVerificationRoot` and `SelfVerificationRootUpgradeable` still required `proofPayload.length >= 32` while their own `@custom:data-format` docs had been updated. The hub's floor was raised correctly (97 → 162 on `baseVerificationInput`); these prepend 64 bytes of header, so the matching floor is `162 − 64 = 98`. Without it, payloads between 32 and 97 bytes were forwarded and rejected by the hub — an opaque error from a contract the caller never named.

**`discloseAadhaar.test.ts` built five payloads in the old layout.** Four negative-path tests failed, each reverting *without a reason* instead of the error it asserted — the misparse above, demonstrated by this branch's own tests. The fifth was **passing**, which is worse: an old-format payload can't reach the assertion it claims to make, so it was green for the wrong reason. Verified these predate this merge by re-running with the length-guard reverted.

## 3. The contract was 15 bytes over EIP-170

`IdentityVerificationHubImplV2` measured **24,591** bytes against the 24,576 limit — **undeployable**. `hardhat.config.ts:47` sets `allowUnlimitedContractSize`, so all 68 disclose tests passed on a contract that cannot be deployed. Measured with `forge build --sizes` and confirmed against `deployedBytecode` in the artifact.

Fixed structurally, with two external libraries alongside the seven this contract already links:

| | |
| --- | --- |
| `ProverSignatureLib` | recovers the signer from a proof digest |
| `ProverAttestationLib` | validates a GCP JWT attestation, returns the address |

| Step | Runtime | Margin |
| --- | --- | --- |
| #2266 as-is | 24,591 | **−15** |
| + `ProverSignatureLib` | 24,495 | +81 |
| + `ProverAttestationLib` | **22,473** | **+2,103** |

That is more headroom than `dev` had (1,203) before any of this work.

**Both are `external`, not `internal`** — an internal library is inlined and saves nothing; only external linkage moves code out of the contract's own budget. Both are stateless: config arrives as arguments, results come back as return values, and every storage write stays in the hub, so authorization is never a `DELEGATECALL` away from the state it decides on.

The attestation extraction is where the room is, and it's the right code to move on its own terms: `registerProverKey` runs once per enclave boot, so the added `DELEGATECALL` is paid on the coldest path in the contract, never on disclose or register.

A digest-only variant was tried and **rejected**: passing `bytes32 + bytes` instead of the proof arrays left both the `abi.encode` and the call plumbing in the hub and measured 24,659 — worse than doing nothing. The saving comes from moving the encoding out, not the `ecrecover`; `ECDSA.tryRecover` is only 715 bytes.

Errors are declared in the libraries, where the reverts now originate, and kept in the hub so they stay in its ABI. Selectors derive from the signature rather than the declaring contract, so callers matching on the hub's ABI still match — the 32 `registerProverKey` tests exercise every moved error path and pass unchanged. `error-selectors.json` is regenerated; the delta is purely additive.

Linked at all three deployment sites — the ignition hub and upgrade modules and the test fixture. The remaining `m.contractAt` callers attach to a deployed address and need no linkage.

## Tests

| Suite | Result |
| --- | --- |
| `registerProverKey` | 32 passing |
| disclose passport / id / aadhaar / kyc | 68 passing (was 64 passing / 4 failing) |
| registerPassport / registerId / registerAadhaar | 35 passing |

**135 passing, 0 failing.**

## Worth doing separately

Nothing in CI measures contract size, so the next overrun lands exactly the way this one did — green tests, undeployable artifact. A `forge build --sizes` gate is a few lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
