### PR TITLE
docs: correct the deployed hub version on celo-sepolia

### DIFF
--- a/contracts/UPGRADE_GUIDE.md
+++ b/contracts/UPGRADE_GUIDE.md
@@ -296,9 +296,9 @@ relayer" in which both are briefly true, so register and disclose are unavailabl
 transactions. Plan for that window rather than trying to order it away.
 
 **v2.14.0 must be deployed first, and it is the reason this rollout has no unavoidable gap.** `registerProverKey`,
-`revokeProverKey` and the four `updateProver…` setters ship in v2.14.0; the deployed hubs are older (celo 2.13.0,
-celo-sepolia 2.12.0), so none of those functions exist on-chain today. Steps 2–5 below cannot be executed against the
-currently-deployed hub at all.
+`revokeProverKey` and the four `updateProver…` setters ship in v2.14.0; both deployed hubs are older — celo and
+celo-sepolia are each on 2.13.0 — so none of those functions exist on-chain today. Steps 2–5 below cannot be executed
+against the currently-deployed hub at all.
 
 v2.14.0 is a drop-in for that purpose: it keeps the 3-argument `registerCommitment` and the pre-signature `proofPayload`
 layout, adds no enforcement, and therefore changes nothing the relayer sees. It is the intermediate compatibility


### PR DESCRIPTION
The rollout section added in #2267 says celo-sepolia is on **2.12.0**. It's on **2.13.0**, same as celo.

## Where the error came from

`deployments/registry.json` records this in two places that disagree:

| Block | celo | celo-sepolia |
| --- | --- | --- |
| `versions.IdentityVerificationHub.*.deployments` | 2.13.0 | **2.12.0** (no 2.13.0 entry) |
| `networks.<net>.deployments` | 2.13.0 | **2.13.0** |

The second is what records what's *currently* deployed:

```
celo-sepolia  proxy 0x16ECBA51e18a4a7e61fdC417f0d47AFEeDfbed74
              currentVersion 2.13.0
              impl  0x244c93516Abd58E1952452d3D8C4Ce7D454776B8
```

The blocks disagree because the sepolia 2.13.0 deploy was never added to the versions history. I read the first one.

## What this does and doesn't change

The section's claim is unaffected — **no v2.14.0 exists on either chain**, so `registerProverKey` and the four `updateProver…` setters are callable on neither, which is exactly why v2.14.0 has to be deployed before the prover-config steps.

Only the number was wrong. But a version number in a deploy runbook is something an operator checks against rather than derives, so it's worth being right — an engineer reading "sepolia is on 2.12.0" might reasonably plan two upgrades where one is needed.

Worth a separate look: the `versions` block is missing the sepolia 2.13.0 entry entirely. Not fixed here since it's generated deployment metadata rather than docs, but it's what made the mistake available to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the v2.14.0 upgrade prerequisites to reflect the current versions of Celo and Celo Sepolia.
  - Clarified that prover-key functions and setters are not currently available on either deployed hub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->