### PR TITLE
fix(app): fetch protocol trees before the recovery registration check

### DIFF
--- a/app/src/proving/alternativeCSCA.ts
+++ b/app/src/proving/alternativeCSCA.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { DocumentCategory } from '@selfxyz/common/types';
+import type { AlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
+import type { SelfClient } from '@selfxyz/mobile-sdk-alpha';
+
+/**
+ * Helper function to get alternative CSCA or public keys for a document category.
+ * For Aadhaar documents, returns public keys. For passports/ID cards, returns alternative CSCAs.
+ *
+ * Kept free of analytics and storage imports so it can be used from any layer.
+ */
+export function getAlternativeCSCA(
+  useProtocolStore: SelfClient['useProtocolStore'],
+  docCategory: DocumentCategory,
+): AlternativeCSCA {
+  if (docCategory === 'aadhaar' || docCategory === 'kyc') {
+    const publicKeys = useProtocolStore.getState()[docCategory].public_keys;
+    // Convert string[] to Record<string, string> format expected by AlternativeCSCA
+    return publicKeys
+      ? Object.fromEntries(
+          publicKeys.map((key, index) => [`public_key_${index}`, key]),
+        )
+      : {};
+  }
+  return useProtocolStore.getState()[docCategory].alternative_csca;
+}

--- a/app/src/proving/checkRestoredDocumentRegistration.ts
+++ b/app/src/proving/checkRestoredDocumentRegistration.ts
@@ -67,13 +67,16 @@ function serializeCommitmentTree(tree: unknown): string | null {
  * `fetch_alternative_csca` consumes the authority key identifier. Without one
  * there is nothing to look up at `/ski-pems/`, so fetch just the commitment tree
  * and let the caller fall back to the document's own stored keys.
+ *
+ * @returns the failure that was swallowed, if any, so a later missing-tree error
+ * can attribute its cause.
  */
 async function fetchProtocolData(
   selfClient: SelfClient,
   document: IDDocument,
   documentCategory: DocumentCategory,
   environment: Environment,
-): Promise<void> {
+): Promise<unknown> {
   const protocolState = selfClient.getProtocolState();
 
   if (documentCategory === 'passport' || documentCategory === 'id_card') {
@@ -85,18 +88,26 @@ async function fetchProtocolData(
         environment,
         authorityKeyIdentifier,
       );
-      return;
+      return undefined;
     }
     await protocolState[documentCategory].fetch_identity_tree(environment);
-    return;
+    return undefined;
   }
 
-  // Unlike passport/id_card, these reject instead of resolving with null fields.
+  // Unlike passport/id_card these reject, and they reject for the whole batch —
+  // including deployed circuits, DNS mapping and OFAC, none of which this check
+  // needs. Let the commitment tree decide rather than blocking recovery on an
+  // unrelated endpoint.
   try {
     await protocolState[documentCategory].fetch_all(environment);
   } catch (error) {
-    throw new ProtocolDataUnavailableError(documentCategory, { cause: error });
+    console.warn(
+      `Protocol fetch for ${documentCategory} did not complete in full:`,
+      error,
+    );
+    return error;
   }
+  return undefined;
 }
 
 /**
@@ -122,14 +133,19 @@ export async function checkRestoredDocumentRegistration(
   const environment: Environment = document.mock ? 'stg' : 'prod';
   const { useProtocolStore } = selfClient;
 
-  await fetchProtocolData(selfClient, document, documentCategory, environment);
+  const fetchError = await fetchProtocolData(
+    selfClient,
+    document,
+    documentCategory,
+    environment,
+  );
 
   const readCommitmentTree = (category: DocumentCategory) => {
     const serialized = serializeCommitmentTree(
       getCommitmentTree(selfClient, category),
     );
     if (!serialized) {
-      throw new ProtocolDataUnavailableError(category);
+      throw new ProtocolDataUnavailableError(category, { cause: fetchError });
     }
     return serialized;
   };
@@ -144,10 +160,10 @@ export async function checkRestoredDocumentRegistration(
   const isMrzDocument =
     documentCategory === 'passport' || documentCategory === 'id_card';
 
-  // Aadhaar and KYC seed their own key material inside the validator, so they
-  // run the check even when the store holds no public keys. For passport and
-  // id_card an empty map yields an empty commitment list, which would report a
-  // registered document as unregistered.
+  // Aadhaar and KYC always attempt the check — the validator handles their key
+  // material itself, and the fallback below covers the cases where it bails out.
+  // For passport and id_card an empty map yields an empty commitment list, which
+  // would report a registered document as unregistered.
   const hasAlternativeCSCA =
     Object.keys(readAlternativeCSCA(documentCategory)).length > 0;
 
@@ -161,13 +177,23 @@ export async function checkRestoredDocumentRegistration(
       },
     );
     if (isRegistered) {
-      return { isRegistered: true, csca: csca ?? null };
+      // For aadhaar the matched value is a public key, not a CSCA certificate.
+      // Callers re-store the document from this field, so it must stay null for
+      // anything that is not an MRZ document.
+      return {
+        isRegistered: true,
+        csca: isMrzDocument ? (csca ?? null) : null,
+      };
     }
   }
 
-  // Falls back to the commitment built from the document's own DSC and CSCA,
-  // which covers a stale or incomplete `/ski-pems/` response.
-  if (isMrzDocument) {
+  // Falls back to the commitment built from the document's own keys. For MRZ
+  // documents that covers a stale or incomplete `/ski-pems/` response; for
+  // aadhaar it covers an empty public key list, which makes the validator bail
+  // out before it can seed the document's own key.
+  //
+  // kyc needs no fallback: the validator already routes it to isUserRegistered.
+  if (documentCategory !== 'kyc') {
     const isRegistered = await isUserRegistered(
       document,
       secret,

--- a/app/src/proving/checkRestoredDocumentRegistration.ts
+++ b/app/src/proving/checkRestoredDocumentRegistration.ts
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { DocumentCategory } from '@selfxyz/common/types';
+import {
+  isUserRegistered,
+  isUserRegisteredWithAlternativeCSCA,
+} from '@selfxyz/common/utils/passports/validate';
+import type { IDDocument } from '@selfxyz/common/utils/types';
+import type { SelfClient } from '@selfxyz/mobile-sdk-alpha';
+import {
+  fetchAllTreesAndCircuits,
+  getCommitmentTree,
+} from '@selfxyz/mobile-sdk-alpha/stores';
+
+import { getAlternativeCSCA } from '@/proving/alternativeCSCA';
+
+type Environment = 'prod' | 'stg';
+
+export interface RestoredDocumentRegistration {
+  isRegistered: boolean;
+  csca: string | null;
+}
+
+/**
+ * Raised when the protocol data required to answer "is this document registered?"
+ * could not be obtained. The commitment tree is the only universally required
+ * input, so this always means the tree is missing — never that the document is
+ * unregistered. Callers must offer a retry rather than telling the user their
+ * document or recovery phrase is wrong.
+ */
+export class ProtocolDataUnavailableError extends Error {
+  readonly documentCategory: DocumentCategory;
+
+  constructor(
+    documentCategory: DocumentCategory,
+    options?: { cause?: unknown },
+  ) {
+    super(`Protocol data for ${documentCategory} documents is unavailable`);
+    this.name = 'ProtocolDataUnavailableError';
+    this.documentCategory = documentCategory;
+    if (options?.cause) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+/**
+ * `LeanIMT.import` requires the serialized tree as a string, and the endpoint
+ * returns it that way today, but the store types the field `any`. Serialize a
+ * structured value rather than rejecting it as missing — a schema change should
+ * not surface to the user as "check your connection".
+ */
+function serializeCommitmentTree(tree: unknown): string | null {
+  if (typeof tree === 'string') {
+    return tree.length > 0 ? tree : null;
+  }
+  if (tree !== null && typeof tree === 'object') {
+    return JSON.stringify(tree);
+  }
+  return null;
+}
+
+/**
+ * Of the seven fetchers behind passport/id_card `fetch_all`, only
+ * `fetch_alternative_csca` consumes the authority key identifier. Without one
+ * there is nothing to look up at `/ski-pems/`, so fetch just the commitment tree
+ * and let the caller fall back to the document's own stored keys.
+ */
+async function fetchProtocolData(
+  selfClient: SelfClient,
+  document: IDDocument,
+  documentCategory: DocumentCategory,
+  environment: Environment,
+): Promise<void> {
+  const protocolState = selfClient.getProtocolState();
+
+  if (documentCategory === 'passport' || documentCategory === 'id_card') {
+    const authorityKeyIdentifier = document.dsc_parsed?.authorityKeyIdentifier;
+    if (authorityKeyIdentifier) {
+      await fetchAllTreesAndCircuits(
+        selfClient,
+        documentCategory,
+        environment,
+        authorityKeyIdentifier,
+      );
+      return;
+    }
+    await protocolState[documentCategory].fetch_identity_tree(environment);
+    return;
+  }
+
+  // Unlike passport/id_card, these reject instead of resolving with null fields.
+  try {
+    await protocolState[documentCategory].fetch_all(environment);
+  } catch (error) {
+    throw new ProtocolDataUnavailableError(documentCategory, { cause: error });
+  }
+}
+
+/**
+ * Answers whether a document recovered from a backup is registered onchain,
+ * fetching the protocol data the check depends on first.
+ *
+ * The screens that restore an account used to read `commitment_tree` and
+ * `alternative_csca` straight out of the protocol store without ever fetching
+ * them. Nothing else warms the store on those paths, so both were null and the
+ * check either threw or reported a registered document as unregistered.
+ *
+ * @returns `csca` is the alternative CSCA that matched, or null when the
+ * document's own stored keys were sufficient — callers should only re-store the
+ * document when it is non-null.
+ * @throws ProtocolDataUnavailableError when the commitment tree is unavailable.
+ */
+export async function checkRestoredDocumentRegistration(
+  selfClient: SelfClient,
+  document: IDDocument,
+  secret: string,
+): Promise<RestoredDocumentRegistration> {
+  const documentCategory = document.documentCategory;
+  const environment: Environment = document.mock ? 'stg' : 'prod';
+  const { useProtocolStore } = selfClient;
+
+  await fetchProtocolData(selfClient, document, documentCategory, environment);
+
+  const readCommitmentTree = (category: DocumentCategory) => {
+    const serialized = serializeCommitmentTree(
+      getCommitmentTree(selfClient, category),
+    );
+    if (!serialized) {
+      throw new ProtocolDataUnavailableError(category);
+    }
+    return serialized;
+  };
+  const readAlternativeCSCA = (category: DocumentCategory) =>
+    getAlternativeCSCA(useProtocolStore, category);
+
+  // passport/id_card fetchers swallow their errors and null the field, so a
+  // resolved fetch is not proof the tree arrived. Check before running any
+  // commitment maths so a missing tree can never read as "not registered".
+  readCommitmentTree(documentCategory);
+
+  const isMrzDocument =
+    documentCategory === 'passport' || documentCategory === 'id_card';
+
+  // Aadhaar and KYC seed their own key material inside the validator, so they
+  // run the check even when the store holds no public keys. For passport and
+  // id_card an empty map yields an empty commitment list, which would report a
+  // registered document as unregistered.
+  const hasAlternativeCSCA =
+    Object.keys(readAlternativeCSCA(documentCategory)).length > 0;
+
+  if (!isMrzDocument || hasAlternativeCSCA) {
+    const { isRegistered, csca } = await isUserRegisteredWithAlternativeCSCA(
+      document,
+      secret,
+      {
+        getCommitmentTree: readCommitmentTree,
+        getAltCSCA: readAlternativeCSCA,
+      },
+    );
+    if (isRegistered) {
+      return { isRegistered: true, csca: csca ?? null };
+    }
+  }
+
+  // Falls back to the commitment built from the document's own DSC and CSCA,
+  // which covers a stale or incomplete `/ski-pems/` response.
+  if (isMrzDocument) {
+    const isRegistered = await isUserRegistered(
+      document,
+      secret,
+      readCommitmentTree,
+    );
+    return { isRegistered, csca: null };
+  }
+
+  return { isRegistered: false, csca: null };
+}

--- a/app/src/proving/validateDocument.ts
+++ b/app/src/proving/validateDocument.ts
@@ -2,11 +2,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import type { DocumentCategory, PassportData } from '@selfxyz/common/types';
-import {
-  type AlternativeCSCA,
-  isUserRegisteredWithAlternativeCSCA,
-} from '@selfxyz/common/utils/passports/validate';
+import type { PassportData } from '@selfxyz/common/types';
+import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
 import type {
   PassportValidationCallbacks,
   SelfClient,
@@ -27,6 +24,7 @@ import {
   storePassportData,
   updateDocumentRegistrationState,
 } from '@/providers/passportDataProvider';
+import { getAlternativeCSCA } from '@/proving/alternativeCSCA';
 import { trackEvent } from '@/services/analytics';
 
 /**
@@ -194,25 +192,7 @@ export async function checkAndUpdateRegistrationStates(
   if (__DEV__) console.log('Registration state check and update completed');
 }
 
-/**
- * Helper function to get alternative CSCA or public keys for a document category.
- * For Aadhaar documents, returns public keys. For passports/ID cards, returns alternative CSCAs.
- */
-export function getAlternativeCSCA(
-  useProtocolStore: SelfClient['useProtocolStore'],
-  docCategory: DocumentCategory,
-): AlternativeCSCA {
-  if (docCategory === 'aadhaar' || docCategory === 'kyc') {
-    const publicKeys = useProtocolStore.getState()[docCategory].public_keys;
-    // Convert string[] to Record<string, string> format expected by AlternativeCSCA
-    return publicKeys
-      ? Object.fromEntries(
-          publicKeys.map((key, index) => [`public_key_${index}`, key]),
-        )
-      : {};
-  }
-  return useProtocolStore.getState()[docCategory].alternative_csca;
-}
+export { getAlternativeCSCA };
 
 // UNUSED?
 

--- a/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
@@ -7,7 +7,6 @@ import { Separator, View, XStack, YStack } from 'tamagui';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
 import {
   markCurrentDocumentAsRegistered,
   useSelfClient,
@@ -37,6 +36,10 @@ import {
   loadPassportData,
   reStorePassportDataWithRightCSCA,
 } from '@/providers/passportDataProvider';
+import {
+  checkRestoredDocumentRegistration,
+  ProtocolDataUnavailableError,
+} from '@/proving/checkRestoredDocumentRegistration';
 import { recoveryCopy } from '@/screens/account/recovery/recoveryCopy';
 import { useBackupMnemonic } from '@/services/cloud-backup';
 import { useSettingStore } from '@/stores/settingStore';
@@ -44,7 +47,6 @@ import type { Mnemonic } from '@/types/mnemonic';
 
 const AccountRecoveryChoiceScreen: React.FC = () => {
   const selfClient = useSelfClient();
-  const { useProtocolStore } = selfClient;
   const { trackEvent } = useSelfClient();
   const { restoreAccountFromMnemonic } = useAuth();
   // DISABLED FOR NOW: Turnkey functionality
@@ -82,7 +84,9 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
 
         if (!result) {
           console.warn('Failed to restore account');
-          trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN);
+          trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN, {
+            reason: 'restore_failed',
+          });
           setRestoring(false);
           return false;
         }
@@ -107,33 +111,11 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
         const passportDataParsed = JSON.parse(passportData);
         const secret = getPrivateKeyFromMnemonic(mnemonic.phrase);
 
-        const { isRegistered, csca } =
-          await isUserRegisteredWithAlternativeCSCA(
-            passportDataParsed,
-            secret as string,
-            {
-              getCommitmentTree(docCategory) {
-                return useProtocolStore.getState()[docCategory].commitment_tree;
-              },
-              getAltCSCA(docCategory) {
-                if (docCategory === 'kyc') {
-                  //TODO
-                  throw new Error('KYC is not supported yet');
-                }
-                if (docCategory === 'aadhaar') {
-                  const publicKeys =
-                    useProtocolStore.getState().aadhaar.public_keys;
-                  // Convert string[] to Record<string, string> format expected by AlternativeCSCA
-                  return publicKeys
-                    ? Object.fromEntries(publicKeys.map(key => [key, key]))
-                    : {};
-                }
-
-                return useProtocolStore.getState()[docCategory]
-                  .alternative_csca;
-              },
-            },
-          );
+        const { isRegistered, csca } = await checkRestoredDocumentRegistration(
+          selfClient,
+          passportDataParsed,
+          secret as string,
+        );
         if (!isRegistered) {
           console.warn(
             'Secret provided did not match a registered ID. Please try again.',
@@ -151,10 +133,9 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
         if (isCloudRestore && !cloudBackupEnabled) {
           toggleCloudBackupEnabled();
         }
-        await reStorePassportDataWithRightCSCA(
-          passportDataParsed,
-          csca as string,
-        );
+        if (csca) {
+          await reStorePassportDataWithRightCSCA(passportDataParsed, csca);
+        }
         await markCurrentDocumentAsRegistered(selfClient);
         trackEvent(BackupEvents.CLOUD_RESTORE_SUCCESS);
         trackEvent(BackupEvents.ACCOUNT_RECOVERY_COMPLETED);
@@ -166,7 +147,13 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
           'Restore account error:',
           e instanceof Error ? e.message : 'Unknown error',
         );
-        trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN);
+        trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN, {
+          reason:
+            e instanceof ProtocolDataUnavailableError
+              ? 'protocol_data_unavailable'
+              : 'unexpected_error',
+          error: e instanceof Error ? e.name : 'unknown',
+        });
         setRestoring(false);
         return false;
       }
@@ -178,7 +165,6 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
       onRestoreFromCloudNext,
       navigation,
       toggleCloudBackupEnabled,
-      useProtocolStore,
       selfClient,
     ],
   );
@@ -222,7 +208,10 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
         'Cloud restore error:',
         error instanceof Error ? error.message : 'Unknown error',
       );
-      trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN);
+      trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN, {
+        reason: 'backup_download_failed',
+        error: error instanceof Error ? error.name : 'unknown',
+      });
       setRestoringFromCloud(false);
     }
   }, [download, restoreAccountFlow, trackEvent]);

--- a/app/src/screens/account/recovery/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/account/recovery/RecoverWithPhraseScreen.tsx
@@ -10,7 +10,6 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
 import {
   markCurrentDocumentAsRegistered,
   useSelfClient,
@@ -37,12 +36,17 @@ import {
   loadPassportData,
   reStorePassportDataWithRightCSCA,
 } from '@/providers/passportDataProvider';
+import {
+  checkRestoredDocumentRegistration,
+  ProtocolDataUnavailableError,
+} from '@/proving/checkRestoredDocumentRegistration';
 import { recoveryCopy } from '@/screens/account/recovery/recoveryCopy';
 
 type RecoveryError =
   | 'invalid_mnemonic'
   | 'restore_failed'
   | 'not_registered'
+  | 'network_error'
   | 'unexpected_error';
 
 const ERROR_MESSAGES: Record<RecoveryError, string> = {
@@ -52,6 +56,8 @@ const ERROR_MESSAGES: Record<RecoveryError, string> = {
     'We couldn’t restore your account with this phrase. Please double-check and try again.',
   not_registered:
     'This recovery phrase doesn’t match a registered ID. If you registered with a different phrase, try that one instead.',
+  network_error:
+    'We couldn’t reach the Self network to verify your ID. Check your connection and try again.',
   unexpected_error: 'Something went wrong. Please try again.',
 };
 
@@ -59,7 +65,6 @@ const RecoverWithPhraseScreen: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const selfClient = useSelfClient();
-  const { useProtocolStore } = selfClient;
   const { restoreAccountFromMnemonic } = useAuth();
   const { trackEvent } = useSelfClient();
   const [mnemonic, setMnemonic] = useState<string>();
@@ -117,30 +122,10 @@ const RecoverWithPhraseScreen: React.FC = () => {
       const passportDataParsed = JSON.parse(passportData);
       const secret = getPrivateKeyFromMnemonic(slimMnemonic);
 
-      const { isRegistered, csca } = await isUserRegisteredWithAlternativeCSCA(
+      const { isRegistered, csca } = await checkRestoredDocumentRegistration(
+        selfClient,
         passportDataParsed,
         secret as string,
-        {
-          getCommitmentTree(docCategory) {
-            return useProtocolStore.getState()[docCategory].commitment_tree;
-          },
-          getAltCSCA(docCategory) {
-            if (docCategory === 'kyc') {
-              //TODO
-              throw new Error('KYC is not supported yet');
-            }
-            if (docCategory === 'aadhaar') {
-              const publicKeys =
-                useProtocolStore.getState().aadhaar.public_keys;
-              // Convert string[] to Record<string, string> format expected by AlternativeCSCA
-              return publicKeys
-                ? Object.fromEntries(publicKeys.map(key => [key, key]))
-                : {};
-            }
-
-            return useProtocolStore.getState()[docCategory].alternative_csca;
-          },
-        },
       );
       if (!isRegistered) {
         console.warn(
@@ -164,11 +149,17 @@ const RecoverWithPhraseScreen: React.FC = () => {
       trackEvent(BackupEvents.ACCOUNT_RECOVERY_COMPLETED);
       navigation.navigate('AccountVerifiedSuccess');
     } catch (restoreError) {
+      const isProtocolDataUnavailable =
+        restoreError instanceof ProtocolDataUnavailableError;
       trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN, {
-        reason: 'unexpected_error',
+        reason: isProtocolDataUnavailable
+          ? 'protocol_data_unavailable'
+          : 'unexpected_error',
         error: restoreError instanceof Error ? restoreError.name : 'unknown',
       });
-      setError('unexpected_error');
+      setError(
+        isProtocolDataUnavailable ? 'network_error' : 'unexpected_error',
+      );
       setRestoring(false);
     }
   }, [
@@ -177,7 +168,6 @@ const RecoverWithPhraseScreen: React.FC = () => {
     restoreAccountFromMnemonic,
     selfClient,
     trackEvent,
-    useProtocolStore,
   ]);
 
   return (

--- a/app/tests/src/proving/checkRestoredDocumentRegistration.test.ts
+++ b/app/tests/src/proving/checkRestoredDocumentRegistration.test.ts
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { IDDocument } from '@selfxyz/common/utils/types';
+import type { SelfClient } from '@selfxyz/mobile-sdk-alpha';
+
+import {
+  checkRestoredDocumentRegistration,
+  ProtocolDataUnavailableError,
+} from '@/proving/checkRestoredDocumentRegistration';
+
+jest.mock('@/services/analytics', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  trackEvent: jest.fn(),
+  trackScreenView: jest.fn(),
+  flush: jest.fn(),
+}));
+
+jest.mock('@/providers/passportDataProvider', () => ({
+  getAllDocumentsDirectlyFromKeychain: jest.fn(),
+  loadPassportDataAndSecret: jest.fn(),
+  loadSelectedDocumentDirectlyFromKeychain: jest.fn(),
+  reStorePassportDataWithRightCSCA: jest.fn(),
+  setSelectedDocument: jest.fn(),
+  storePassportData: jest.fn(),
+  updateDocumentRegistrationState: jest.fn(),
+}));
+
+const mockFetchAllTreesAndCircuits = jest.fn();
+const mockGetCommitmentTree = jest.fn();
+
+jest.mock('@selfxyz/mobile-sdk-alpha/stores', () => ({
+  useProtocolStore: { getState: jest.fn() },
+  fetchAllTreesAndCircuits: jest.fn((...args: unknown[]) =>
+    mockFetchAllTreesAndCircuits(...args),
+  ),
+  getCommitmentTree: jest.fn((...args: unknown[]) =>
+    mockGetCommitmentTree(...args),
+  ),
+}));
+
+const mockIsUserRegisteredWithAlternativeCSCA = jest.fn();
+const mockIsUserRegistered = jest.fn();
+
+jest.mock('@selfxyz/common/utils/passports/validate', () => ({
+  isUserRegisteredWithAlternativeCSCA: jest.fn((...args: unknown[]) =>
+    mockIsUserRegisteredWithAlternativeCSCA(...args),
+  ),
+  isUserRegistered: jest.fn((...args: unknown[]) =>
+    mockIsUserRegistered(...args),
+  ),
+}));
+
+const TREE = 'serialized_tree';
+
+let callOrder: string[];
+let protocolState: Record<string, Record<string, unknown>>;
+let selfClient: SelfClient;
+
+function mrzSlice() {
+  return {
+    commitment_tree: null as string | null,
+    alternative_csca: {} as Record<string, string>,
+    fetch_all: jest.fn(),
+    fetch_identity_tree: jest.fn(),
+  };
+}
+
+function keySlice() {
+  return {
+    commitment_tree: null as string | null,
+    public_keys: null as string[] | null,
+    fetch_all: jest.fn(),
+  };
+}
+
+/** Mirrors the real store: the fetchers are what put data in place. */
+function populates(category: string) {
+  return jest.fn(async () => {
+    callOrder.push('fetch');
+    protocolState[category].commitment_tree = TREE;
+  });
+}
+
+function documentFixture(overrides: Record<string, unknown> = {}): IDDocument {
+  return {
+    documentCategory: 'passport',
+    mock: false,
+    dsc_parsed: { authorityKeyIdentifier: 'aki-123' },
+    ...overrides,
+  } as unknown as IDDocument;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  callOrder = [];
+  protocolState = {
+    passport: mrzSlice(),
+    id_card: mrzSlice(),
+    aadhaar: keySlice(),
+    kyc: keySlice(),
+  };
+  selfClient = {
+    getProtocolState: () => protocolState,
+    useProtocolStore: { getState: () => protocolState },
+  } as unknown as SelfClient;
+
+  mockGetCommitmentTree.mockImplementation(
+    (_client: unknown, category: string) =>
+      protocolState[category].commitment_tree,
+  );
+  mockFetchAllTreesAndCircuits.mockImplementation(async () => {
+    callOrder.push('fetch');
+    protocolState.passport.commitment_tree = TREE;
+  });
+  mockIsUserRegisteredWithAlternativeCSCA.mockImplementation(async () => {
+    callOrder.push('check');
+    return { isRegistered: true, csca: 'matched-csca' };
+  });
+  mockIsUserRegistered.mockImplementation(async () => {
+    callOrder.push('fallback');
+    return true;
+  });
+});
+
+describe('checkRestoredDocumentRegistration', () => {
+  it('fetches protocol data before running the registration check', async () => {
+    protocolState.passport.alternative_csca = { a: 'pem' };
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture(),
+      'secret',
+    );
+
+    expect(mockFetchAllTreesAndCircuits).toHaveBeenCalledWith(
+      selfClient,
+      'passport',
+      'prod',
+      'aki-123',
+    );
+    // The check must see the fetched tree, not the null it started with.
+    expect(callOrder).toEqual(['fetch', 'check']);
+    expect(result).toEqual({ isRegistered: true, csca: 'matched-csca' });
+  });
+
+  it('passes the fetched tree through to the validator', async () => {
+    protocolState.passport.alternative_csca = { a: 'pem' };
+
+    await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture(),
+      'secret',
+    );
+
+    const callbacks = mockIsUserRegisteredWithAlternativeCSCA.mock.calls[0][2];
+    expect(callbacks.getCommitmentTree('passport')).toBe(TREE);
+  });
+
+  it('serializes a structured tree rather than rejecting it', async () => {
+    // The endpoint returns `data` as a JSON string today and LeanIMT.import
+    // requires that, but the store types the field `any`. An already-parsed
+    // tree must not read as "missing".
+    const parsedTree = [['1', '2'], ['3']];
+    protocolState.passport.alternative_csca = { a: 'pem' };
+    mockFetchAllTreesAndCircuits.mockImplementation(async () => {
+      protocolState.passport.commitment_tree = parsedTree;
+    });
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture(),
+      'secret',
+    );
+
+    const callbacks = mockIsUserRegisteredWithAlternativeCSCA.mock.calls[0][2];
+    expect(callbacks.getCommitmentTree('passport')).toBe(
+      JSON.stringify(parsedTree),
+    );
+    expect(result).toEqual({ isRegistered: true, csca: 'matched-csca' });
+  });
+
+  it('throws ProtocolDataUnavailableError when the tree is still missing after fetching', async () => {
+    // The real passport fetchers swallow their errors and null the field, so a
+    // resolved fetch is not proof the tree arrived.
+    mockFetchAllTreesAndCircuits.mockResolvedValue(undefined);
+
+    await expect(
+      checkRestoredDocumentRegistration(
+        selfClient,
+        documentFixture(),
+        'secret',
+      ),
+    ).rejects.toBeInstanceOf(ProtocolDataUnavailableError);
+
+    expect(mockIsUserRegisteredWithAlternativeCSCA).not.toHaveBeenCalled();
+    expect(mockIsUserRegistered).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['an empty string', ''],
+    ['a number', 42],
+    ['a boolean', true],
+  ])('rejects %s as a commitment tree', async (_label, value) => {
+    mockFetchAllTreesAndCircuits.mockImplementation(async () => {
+      protocolState.passport.commitment_tree = value;
+    });
+
+    await expect(
+      checkRestoredDocumentRegistration(
+        selfClient,
+        documentFixture(),
+        'secret',
+      ),
+    ).rejects.toBeInstanceOf(ProtocolDataUnavailableError);
+  });
+
+  it('falls back to the document own keys when alternative CSCA is empty', async () => {
+    protocolState.passport.alternative_csca = {};
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture(),
+      'secret',
+    );
+
+    expect(mockIsUserRegisteredWithAlternativeCSCA).not.toHaveBeenCalled();
+    expect(mockIsUserRegistered).toHaveBeenCalled();
+    expect(result).toEqual({ isRegistered: true, csca: null });
+  });
+
+  it('falls back when the alternative CSCA sweep reports not registered', async () => {
+    protocolState.passport.alternative_csca = { a: 'pem' };
+    mockIsUserRegisteredWithAlternativeCSCA.mockResolvedValue({
+      isRegistered: false,
+      csca: null,
+    });
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture(),
+      'secret',
+    );
+
+    expect(result).toEqual({ isRegistered: true, csca: null });
+  });
+
+  it('reports not registered when neither path matches', async () => {
+    protocolState.passport.alternative_csca = { a: 'pem' };
+    mockIsUserRegisteredWithAlternativeCSCA.mockResolvedValue({
+      isRegistered: false,
+      csca: null,
+    });
+    mockIsUserRegistered.mockResolvedValue(false);
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture(),
+      'secret',
+    );
+
+    expect(result).toEqual({ isRegistered: false, csca: null });
+  });
+
+  it('fetches only the identity tree when the document has no authority key identifier', async () => {
+    protocolState.passport.fetch_identity_tree = populates('passport');
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ dsc_parsed: undefined }),
+      'secret',
+    );
+
+    expect(mockFetchAllTreesAndCircuits).not.toHaveBeenCalled();
+    expect(protocolState.passport.fetch_identity_tree).toHaveBeenCalledWith(
+      'prod',
+    );
+    expect(result).toEqual({ isRegistered: true, csca: null });
+  });
+
+  it('treats an empty authority key identifier as missing', async () => {
+    protocolState.passport.fetch_identity_tree = populates('passport');
+
+    await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ dsc_parsed: { authorityKeyIdentifier: '' } }),
+      'secret',
+    );
+
+    expect(mockFetchAllTreesAndCircuits).not.toHaveBeenCalled();
+    expect(protocolState.passport.fetch_identity_tree).toHaveBeenCalledWith(
+      'prod',
+    );
+  });
+
+  it('uses the staging environment for mock documents', async () => {
+    protocolState.passport.alternative_csca = { a: 'pem' };
+
+    await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ mock: true }),
+      'secret',
+    );
+
+    expect(mockFetchAllTreesAndCircuits).toHaveBeenCalledWith(
+      selfClient,
+      'passport',
+      'stg',
+      'aki-123',
+    );
+  });
+
+  it('checks aadhaar documents without an AKI and without stored public keys', async () => {
+    // The validator seeds the document own public key, so a null public_keys
+    // list must not block the check.
+    protocolState.aadhaar.fetch_all = populates('aadhaar');
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ documentCategory: 'aadhaar', dsc_parsed: undefined }),
+      'secret',
+    );
+
+    expect(protocolState.aadhaar.fetch_all).toHaveBeenCalledWith('prod');
+    expect(protocolState.aadhaar.fetch_all).toHaveBeenCalledTimes(1);
+    expect(mockFetchAllTreesAndCircuits).not.toHaveBeenCalled();
+    expect(mockIsUserRegisteredWithAlternativeCSCA).toHaveBeenCalled();
+    expect(result).toEqual({ isRegistered: true, csca: 'matched-csca' });
+  });
+
+  it('checks kyc documents even though public keys are always null', async () => {
+    protocolState.kyc.fetch_all = populates('kyc');
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ documentCategory: 'kyc', dsc_parsed: undefined }),
+      'secret',
+    );
+
+    expect(mockIsUserRegisteredWithAlternativeCSCA).toHaveBeenCalled();
+    expect(result).toEqual({ isRegistered: true, csca: 'matched-csca' });
+  });
+
+  it('wraps an aadhaar fetch rejection in ProtocolDataUnavailableError', async () => {
+    const cause = new Error('network down');
+    protocolState.aadhaar.fetch_all = jest.fn().mockRejectedValue(cause);
+
+    const error = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ documentCategory: 'aadhaar', dsc_parsed: undefined }),
+      'secret',
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ProtocolDataUnavailableError);
+    expect((error as ProtocolDataUnavailableError).documentCategory).toBe(
+      'aadhaar',
+    );
+    expect((error as ProtocolDataUnavailableError).cause).toBe(cause);
+  });
+});

--- a/app/tests/src/proving/checkRestoredDocumentRegistration.test.ts
+++ b/app/tests/src/proving/checkRestoredDocumentRegistration.test.ts
@@ -327,7 +327,47 @@ describe('checkRestoredDocumentRegistration', () => {
     expect(protocolState.aadhaar.fetch_all).toHaveBeenCalledTimes(1);
     expect(mockFetchAllTreesAndCircuits).not.toHaveBeenCalled();
     expect(mockIsUserRegisteredWithAlternativeCSCA).toHaveBeenCalled();
-    expect(result).toEqual({ isRegistered: true, csca: 'matched-csca' });
+    // csca must stay null for aadhaar: the validator returns the matched public
+    // key there, and callers feed this field to reStorePassportDataWithRightCSCA,
+    // which parses it as an X.509 certificate.
+    expect(result).toEqual({ isRegistered: true, csca: null });
+  });
+
+  it('proceeds when an unrelated aadhaar fetch fails but the tree arrived', async () => {
+    // fetch_all batches deployed circuits, DNS mapping and OFAC alongside the
+    // identity tree and rejects for the whole batch. Recovery must not be
+    // blocked by an endpoint this check does not use.
+    protocolState.aadhaar.fetch_all = jest.fn(async () => {
+      protocolState.aadhaar.commitment_tree = TREE;
+      throw new Error('ofac endpoint down');
+    });
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ documentCategory: 'aadhaar', dsc_parsed: undefined }),
+      'secret',
+    );
+
+    expect(result).toEqual({ isRegistered: true, csca: null });
+  });
+
+  it('falls back to the document commitment when aadhaar public keys are empty', async () => {
+    // validate.ts returns early for an empty public key map, before it can seed
+    // the document's own key, so the single-commitment path has to cover it.
+    protocolState.aadhaar.fetch_all = populates('aadhaar');
+    mockIsUserRegisteredWithAlternativeCSCA.mockResolvedValue({
+      isRegistered: false,
+      csca: null,
+    });
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ documentCategory: 'aadhaar', dsc_parsed: undefined }),
+      'secret',
+    );
+
+    expect(mockIsUserRegistered).toHaveBeenCalled();
+    expect(result).toEqual({ isRegistered: true, csca: null });
   });
 
   it('checks kyc documents even though public keys are always null', async () => {
@@ -340,7 +380,25 @@ describe('checkRestoredDocumentRegistration', () => {
     );
 
     expect(mockIsUserRegisteredWithAlternativeCSCA).toHaveBeenCalled();
-    expect(result).toEqual({ isRegistered: true, csca: 'matched-csca' });
+    expect(result).toEqual({ isRegistered: true, csca: null });
+  });
+
+  it('does not run a redundant fallback for kyc documents', async () => {
+    // The validator already routes kyc through isUserRegistered.
+    protocolState.kyc.fetch_all = populates('kyc');
+    mockIsUserRegisteredWithAlternativeCSCA.mockResolvedValue({
+      isRegistered: false,
+      csca: null,
+    });
+
+    const result = await checkRestoredDocumentRegistration(
+      selfClient,
+      documentFixture({ documentCategory: 'kyc', dsc_parsed: undefined }),
+      'secret',
+    );
+
+    expect(mockIsUserRegistered).not.toHaveBeenCalled();
+    expect(result).toEqual({ isRegistered: false, csca: null });
   });
 
   it('wraps an aadhaar fetch rejection in ProtocolDataUnavailableError', async () => {

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import AccountRecoveryChoiceScreen from '@/screens/account/recovery/AccountRecoveryChoiceScreen';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'mock-view': any;
+      'mock-text': any;
+      'mock-stack': any;
+      'mock-button': any;
+      'mock-icon': any;
+      'mock-separator': any;
+    }
+  }
+}
+
+jest.mock('tamagui', () => ({
+  __esModule: true,
+  Separator: (props: any) => <mock-separator {...props} />,
+  View: ({ children, ...props }: any) => (
+    <mock-view {...props}>{children}</mock-view>
+  ),
+  XStack: ({ children, ...props }: any) => (
+    <mock-stack {...props}>{children}</mock-stack>
+  ),
+  YStack: ({ children, ...props }: any) => (
+    <mock-stack {...props}>{children}</mock-stack>
+  ),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  markCurrentDocumentAsRegistered: jest.fn(),
+  useSelfClient: jest.fn(),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  Caption: ({ children, ...props }: any) => (
+    <mock-text {...props}>{children}</mock-text>
+  ),
+  Description: ({ children, ...props }: any) => (
+    <mock-text {...props}>{children}</mock-text>
+  ),
+  Title: ({ children, ...props }: any) => (
+    <mock-text {...props}>{children}</mock-text>
+  ),
+  PrimaryButton: ({ children, onPress, disabled, ...props }: any) => (
+    <mock-button onPress={onPress} disabled={disabled} {...props}>
+      {children}
+    </mock-button>
+  ),
+  SecondaryButton: ({ children, onPress, disabled, ...props }: any) => (
+    <mock-button onPress={onPress} disabled={disabled} {...props}>
+      {children}
+    </mock-button>
+  ),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
+  BackupEvents: {
+    ACCOUNT_RECOVERY_COMPLETED: 'ACCOUNT_RECOVERY_COMPLETED',
+    CLOUD_BACKUP_STARTED: 'CLOUD_BACKUP_STARTED',
+    CLOUD_RESTORE_FAILED_PASSPORT_NOT_REGISTERED:
+      'CLOUD_RESTORE_FAILED_PASSPORT_NOT_REGISTERED',
+    CLOUD_RESTORE_FAILED_UNKNOWN: 'CLOUD_RESTORE_FAILED_UNKNOWN',
+    CLOUD_RESTORE_SUCCESS: 'CLOUD_RESTORE_SUCCESS',
+    MANUAL_RECOVERY_SELECTED: 'MANUAL_RECOVERY_SELECTED',
+  },
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/colors', () => ({
+  black: '#000',
+  slate500: '#555',
+  slate600: '#666',
+  white: '#fff',
+}));
+
+jest.mock('@/assets/icons/keyboard.svg', () => ({
+  __esModule: true,
+  default: (props: any) => <mock-icon {...props} />,
+}));
+
+jest.mock('@/assets/icons/restore_account.svg', () => ({
+  __esModule: true,
+  default: (props: any) => <mock-icon {...props} />,
+}));
+
+jest.mock('@/layouts/ExpandableBottomLayout', () => ({
+  ExpandableBottomLayout: {
+    Layout: ({ children }: any) => <mock-view>{children}</mock-view>,
+    TopSection: ({ children }: any) => <mock-view>{children}</mock-view>,
+    BottomSection: ({ children }: any) => <mock-view>{children}</mock-view>,
+  },
+}));
+
+jest.mock('@/hooks/useHapticNavigation', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@/providers/authProvider', () => ({
+  getPrivateKeyFromMnemonic: jest.fn(),
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/providers/passportDataProvider', () => ({
+  loadPassportData: jest.fn(),
+  reStorePassportDataWithRightCSCA: jest.fn(),
+}));
+
+jest.mock('@/proving/checkRestoredDocumentRegistration', () => {
+  class ProtocolDataUnavailableError extends Error {}
+  return {
+    checkRestoredDocumentRegistration: jest.fn(),
+    ProtocolDataUnavailableError,
+  };
+});
+
+jest.mock('@/screens/account/recovery/recoveryCopy', () => ({
+  recoveryCopy: {
+    choice: {
+      title: 'Recover your Self account',
+      description: 'Choose how you want to recover your account.',
+      noBiometrics: 'Cloud recovery requires biometrics.',
+      actions: {
+        cloud: (restoring: boolean) => (restoring ? 'Recovering' : 'Recover'),
+        or: 'OR',
+        phrase: 'Enter your recovery phrase',
+      },
+    },
+  },
+}));
+
+jest.mock('@/services/cloud-backup', () => ({
+  STORAGE_NAME: 'iCloud',
+  useBackupMnemonic: jest.fn(),
+}));
+
+jest.mock('@/stores/settingStore', () => ({
+  useSettingStore: jest.fn(),
+}));
+
+const { useNavigation } = jest.requireMock('@react-navigation/native') as {
+  useNavigation: jest.Mock;
+};
+const { useSelfClient, markCurrentDocumentAsRegistered } = jest.requireMock(
+  '@selfxyz/mobile-sdk-alpha',
+) as { useSelfClient: jest.Mock; markCurrentDocumentAsRegistered: jest.Mock };
+const { useAuth, getPrivateKeyFromMnemonic } = jest.requireMock(
+  '@/providers/authProvider',
+) as { useAuth: jest.Mock; getPrivateKeyFromMnemonic: jest.Mock };
+const { loadPassportData, reStorePassportDataWithRightCSCA } = jest.requireMock(
+  '@/providers/passportDataProvider',
+) as {
+  loadPassportData: jest.Mock;
+  reStorePassportDataWithRightCSCA: jest.Mock;
+};
+const {
+  checkRestoredDocumentRegistration: mockCheckRegistration,
+  ProtocolDataUnavailableError: MockProtocolDataUnavailableError,
+} = jest.requireMock('@/proving/checkRestoredDocumentRegistration') as {
+  checkRestoredDocumentRegistration: jest.Mock;
+  ProtocolDataUnavailableError: new (message?: string) => Error;
+};
+const { useBackupMnemonic } = jest.requireMock('@/services/cloud-backup') as {
+  useBackupMnemonic: jest.Mock;
+};
+const { useSettingStore } = jest.requireMock('@/stores/settingStore') as {
+  useSettingStore: jest.Mock;
+};
+const useHapticNavigation = jest.requireMock('@/hooks/useHapticNavigation')
+  .default as jest.Mock;
+
+describe('AccountRecoveryChoiceScreen', () => {
+  const mockTrackEvent = jest.fn();
+  const mockRestoreAccountFromMnemonic = jest.fn();
+  const mockDownload = jest.fn();
+  const mockToggleCloudBackupEnabled = jest.fn();
+  const mockRestoreSuccessNavigation = jest.fn();
+
+  function pressRestoreFromCloud() {
+    const { getByTestId } = render(<AccountRecoveryChoiceScreen />);
+    fireEvent.press(getByTestId('button-from-teststorage'));
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useNavigation.mockReturnValue({ navigate: jest.fn() });
+    useHapticNavigation.mockImplementation((route: string) =>
+      route === 'AccountVerifiedSuccess'
+        ? mockRestoreSuccessNavigation
+        : jest.fn(),
+    );
+    useSelfClient.mockReturnValue({ trackEvent: mockTrackEvent });
+    useAuth.mockReturnValue({
+      restoreAccountFromMnemonic: mockRestoreAccountFromMnemonic,
+    });
+    useBackupMnemonic.mockReturnValue({ download: mockDownload });
+    useSettingStore.mockReturnValue({
+      cloudBackupEnabled: false,
+      toggleCloudBackupEnabled: mockToggleCloudBackupEnabled,
+      biometricsAvailable: true,
+    });
+
+    mockDownload.mockResolvedValue({ phrase: 'twenty four words' });
+    mockRestoreAccountFromMnemonic.mockResolvedValue(true);
+    loadPassportData.mockResolvedValue('{"documentCategory":"passport"}');
+    getPrivateKeyFromMnemonic.mockReturnValue('secret');
+  });
+
+  it('completes recovery without re-storing the document when no alternative CSCA matched', async () => {
+    // csca is null whenever the document's own keys were sufficient, and for
+    // registered KYC documents. Passing it through to
+    // reStorePassportDataWithRightCSCA used to dereference null.
+    mockCheckRegistration.mockResolvedValue({ isRegistered: true, csca: null });
+
+    pressRestoreFromCloud();
+
+    await waitFor(() => {
+      expect(markCurrentDocumentAsRegistered).toHaveBeenCalled();
+    });
+    expect(reStorePassportDataWithRightCSCA).not.toHaveBeenCalled();
+    expect(mockToggleCloudBackupEnabled).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalledWith('CLOUD_RESTORE_SUCCESS');
+    expect(mockTrackEvent).toHaveBeenCalledWith('ACCOUNT_RECOVERY_COMPLETED');
+    expect(mockRestoreSuccessNavigation).toHaveBeenCalled();
+  });
+
+  it('re-stores the document when an alternative CSCA matched', async () => {
+    mockCheckRegistration.mockResolvedValue({
+      isRegistered: true,
+      csca: 'matched-csca',
+    });
+
+    pressRestoreFromCloud();
+
+    await waitFor(() => {
+      expect(reStorePassportDataWithRightCSCA).toHaveBeenCalledWith(
+        { documentCategory: 'passport' },
+        'matched-csca',
+      );
+    });
+  });
+
+  it('reports a distinct reason when protocol data is unavailable', async () => {
+    mockCheckRegistration.mockRejectedValue(
+      new MockProtocolDataUnavailableError('unavailable'),
+    );
+
+    pressRestoreFromCloud();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_RESTORE_FAILED_UNKNOWN',
+        { reason: 'protocol_data_unavailable', error: 'Error' },
+      );
+    });
+    expect(mockToggleCloudBackupEnabled).not.toHaveBeenCalled();
+    expect(mockRestoreSuccessNavigation).not.toHaveBeenCalled();
+    expect(markCurrentDocumentAsRegistered).not.toHaveBeenCalled();
+  });
+
+  it('reports a backup download failure separately from a check failure', async () => {
+    const downloadError = new Error('no backup');
+    downloadError.name = 'BackupMissingError';
+    mockDownload.mockRejectedValue(downloadError);
+
+    pressRestoreFromCloud();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_RESTORE_FAILED_UNKNOWN',
+        { reason: 'backup_download_failed', error: 'BackupMissingError' },
+      );
+    });
+    expect(mockCheckRegistration).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/src/screens/account/recovery/RecoverWithPhraseScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/RecoverWithPhraseScreen.test.tsx
@@ -73,14 +73,18 @@ jest.mock('ethers', () => ({
   },
 }));
 
-jest.mock('@selfxyz/common/utils/passports/validate', () => ({
-  isUserRegisteredWithAlternativeCSCA: jest.fn(),
-}));
-
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
   markCurrentDocumentAsRegistered: jest.fn(),
   useSelfClient: jest.fn(),
 }));
+
+jest.mock('@/proving/checkRestoredDocumentRegistration', () => {
+  class ProtocolDataUnavailableError extends Error {}
+  return {
+    checkRestoredDocumentRegistration: jest.fn(),
+    ProtocolDataUnavailableError,
+  };
+});
 
 jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
   Description: ({ children, ...props }: any) => (
@@ -145,8 +149,21 @@ const { useNavigation } = jest.requireMock('@react-navigation/native') as {
 const { useSelfClient } = jest.requireMock('@selfxyz/mobile-sdk-alpha') as {
   useSelfClient: jest.Mock;
 };
-const { useAuth } = jest.requireMock('@/providers/authProvider') as {
-  useAuth: jest.Mock;
+const { useAuth, getPrivateKeyFromMnemonic } = jest.requireMock(
+  '@/providers/authProvider',
+) as { useAuth: jest.Mock; getPrivateKeyFromMnemonic: jest.Mock };
+const { loadPassportData, reStorePassportDataWithRightCSCA } = jest.requireMock(
+  '@/providers/passportDataProvider',
+) as {
+  loadPassportData: jest.Mock;
+  reStorePassportDataWithRightCSCA: jest.Mock;
+};
+const {
+  checkRestoredDocumentRegistration: mockCheckRegistration,
+  ProtocolDataUnavailableError: MockProtocolDataUnavailableError,
+} = jest.requireMock('@/proving/checkRestoredDocumentRegistration') as {
+  checkRestoredDocumentRegistration: jest.Mock;
+  ProtocolDataUnavailableError: new (message?: string) => Error;
 };
 
 describe('RecoverWithPhraseScreen', () => {
@@ -212,5 +229,64 @@ describe('RecoverWithPhraseScreen', () => {
         error: 'mnemonic payload leaked into raw error message',
       }),
     );
+  });
+
+  it('surfaces a retryable message when protocol data is unavailable', async () => {
+    mockRestoreAccountFromMnemonic.mockResolvedValue(true);
+    loadPassportData.mockResolvedValue('{"documentCategory":"passport"}');
+    getPrivateKeyFromMnemonic.mockReturnValue('secret');
+    mockCheckRegistration.mockRejectedValue(
+      new MockProtocolDataUnavailableError('unavailable'),
+    );
+
+    const { UNSAFE_getByType, UNSAFE_getAllByType } = render(
+      <RecoverWithPhraseScreen />,
+    );
+
+    fireEvent.changeText(
+      UNSAFE_getByType('mock-textarea'),
+      'valid seed phrase',
+    );
+    fireEvent.press(UNSAFE_getByType('mock-button'));
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_RESTORE_FAILED_UNKNOWN',
+        { reason: 'protocol_data_unavailable', error: 'Error' },
+      );
+    });
+
+    // Must not read as "your phrase is wrong" — the phrase was never checked.
+    const renderedText = UNSAFE_getAllByType('mock-text').map(
+      node => node.props.children,
+    );
+    expect(renderedText).toContain(
+      'We couldn’t reach the Self network to verify your ID. Check your connection and try again.',
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('completes recovery without re-storing the document when no alternative CSCA matched', async () => {
+    mockRestoreAccountFromMnemonic.mockResolvedValue(true);
+    loadPassportData.mockResolvedValue('{"documentCategory":"passport"}');
+    getPrivateKeyFromMnemonic.mockReturnValue('secret');
+    mockCheckRegistration.mockResolvedValue({
+      isRegistered: true,
+      csca: null,
+    });
+
+    const { UNSAFE_getByType } = render(<RecoverWithPhraseScreen />);
+
+    fireEvent.changeText(
+      UNSAFE_getByType('mock-textarea'),
+      'valid seed phrase',
+    );
+    fireEvent.press(UNSAFE_getByType('mock-button'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('AccountVerifiedSuccess');
+    });
+    expect(reStorePassportDataWithRightCSCA).not.toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalledWith('ACCOUNT_RECOVERY_COMPLETED');
   });
 });


### PR DESCRIPTION
Fixes SELF-3931.

## Problem

Account restore fails for almost everyone. Mixpanel, last 30 days: **15 unique
users restored successfully, 701 hit `Cloud Restore Failed: Unknown Error`**, and
84 more got a false "Passport Not Registered". Chronic for 4+ months, not a
regression.

Both recovery screens called `isUserRegisteredWithAlternativeCSCA` while reading
`commitment_tree` and `alternative_csca` straight out of the protocol store,
without ever fetching them. Both default to `null`, so `LeanIMT.import(hash, null)`
threw a TypeError, or an empty commitment list produced a false "not registered".
The phrase path's telemetry confirms it: `error: TypeError` on 151 events.

Nothing warmed the store on those paths — `SplashScreen` only calls
`checkAndUpdateRegistrationStates` when a document has `isRegistered === undefined`,
which is false on any modern install.

## Fix

New `app/src/proving/checkRestoredDocumentRegistration.ts`, used by both screens,
replacing ~20 lines of duplicated inline callbacks in each. It fetches first, then
checks:

- **passport / id_card** with an authority key identifier → `fetchAllTreesAndCircuits`.
  Without one → just `fetch_identity_tree`, since only `fetch_alternative_csca`
  consumes the AKI and a blank ski would fire a pointless `/ski-pems/` request.
- **aadhaar / kyc** → `fetch_all(environment)` directly, so they are no longer
  skipped for lacking a `dsc_parsed` (which they never have).
- **One hard failure**: a missing commitment tree, raised as a retryable
  `ProtocolDataUnavailableError`. It is the only universally required input.
- **No key-material guards.** An empty `alternative_csca` or absent AKI falls back
  to `isUserRegistered` on the document's own stored DSC/CSCA. Aadhaar seeds
  `document_public_key` itself; kyc's `public_keys` is always null by design
  (`fetch_public_keys` sets it unconditionally), so guarding either would reject
  restores that work today.
- If the alternative-CSCA sweep reports not-registered, it still tries the
  single-commitment path before giving up — this has strictly **more** recall than
  either screen had before, and covers a stale `/ski-pems/` response.

`commitment_tree` is typed `any` in the store; the endpoint returns it as a JSON
string today (verified against `tree.self.xyz/identity`) and `LeanIMT.import`
requires that, so a structured value is serialized rather than reported as missing.

## Also fixed

- **Null deref**: `AccountRecoveryChoiceScreen` called
  `reStorePassportDataWithRightCSCA(data, csca as string)` unconditionally, but
  `csca` is null for registered KYC documents and the callee dereferences it via
  `parseCertificateSimple`. Now guarded, matching the phrase screen.
- **Telemetry**: 1787 of the 1938 unknown-error events carried no properties, so
  the failing branch was unknowable. All four sites now report a `reason` —
  `restore_failed`, `protocol_data_unavailable`, `backup_download_failed`,
  `unexpected_error`. That last split matters for SELF-3934: it separates "no
  backup / OAuth failed" from "registration check failed".
- **Layering**: `getAlternativeCSCA` moved to `app/src/proving/alternativeCSCA.ts`.
  Importing it from `validateDocument` pulled `@/services/analytics` into the
  screens' module graph, which broke their tests at import time.
  `validateDocument` re-exports it, so existing importers are unchanged.
- Deletes the unreachable `throw new Error('KYC is not supported yet')` from both
  screens — `validate.ts` returns early for kyc before `getAltCSCA` is consulted.

## Deliberately out of scope

- `packages/mobile-sdk-alpha/src/proving/recoveryValidation.ts` has the same
  missing-fetch bug on the webview path. Separate issue — the app does not use it,
  and fixing it here would change webview behaviour in an app PR.
- `validateDocument.ts` skipping every aadhaar/kyc document for lacking an AKI.
- Error UI for the cloud screen, which has none at all — that's SELF-3932.
- No change to `protocolStore.ts`'s error-swallowing fetchers or to
  `fetchAllTreesAndCircuits`'s signature; both ripple into `provingMachine`.

## Validation

`pnpm nice` (0 errors), `pnpm types`, `pnpm test` — **111 suites / 1231 tests**
passing. Every file these tests depend on is identical between this base and `dev`.

19 new tests: 15 on the helper (fetch-before-check ordering, missing-tree error,
both fallback paths, aadhaar/kyc not skipped, empty-string AKI, staging env,
wrapped fetch rejection, tree serialization) and 4 on
`AccountRecoveryChoiceScreen`, which had no test file at all.

Post-merge, watch `Cloud Restore Success` vs `Cloud Restore Failed: *` uniques
against the 15-vs-785 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved account recovery by validating restored document registration before completion.
  - Added support for restoring signing credentials from document data when applicable.
  - Added clearer messaging when required protocol data is unavailable.

- **Bug Fixes**
  - Prevents unnecessary document re-storage when no matching signing credentials are available.
  - Improves recovery error reporting, analytics, and retry behavior across recovery methods.

- **Tests**
  - Added coverage for restored-document validation, credential fallback, protocol-data failures, and recovery flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->