### PR TITLE
fix(app): surface cloud restore failures to the user and telemetry (SELF-3932)

### DIFF
--- a/app/src/hooks/useBiometricsAvailability.ts
+++ b/app/src/hooks/useBiometricsAvailability.ts
@@ -33,16 +33,13 @@ export function useBiometricsAvailability(): boolean {
       let active = true;
 
       const refresh = () => {
-        checkBiometricsAvailable()
-          .then(available => {
-            if (active) {
-              setBiometricsAvailable(available);
-            }
-          })
-          .catch(() => {
-            // Keep the last known value; a failed capability query is not
-            // evidence that biometrics are unavailable.
-          });
+        checkBiometricsAvailable().then(available => {
+          // `null` means the query failed. Keep the last known value — treating
+          // it as `false` would disable cloud recovery on a transient error.
+          if (active && available !== null) {
+            setBiometricsAvailable(available);
+          }
+        });
       };
 
       refresh();

--- a/app/src/hooks/useBiometricsAvailability.ts
+++ b/app/src/hooks/useBiometricsAvailability.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useCallback } from 'react';
+import { AppState } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+
+import { useAuth } from '@/providers/authProvider';
+import { useSettingStore } from '@/stores/settingStore';
+
+/**
+ * Whether biometric unlock is currently available, re-read from the OS whenever
+ * the screen using this hook is focused and whenever the app returns to the
+ * foreground.
+ *
+ * Both triggers are needed: focus alone misses the user leaving to OS settings
+ * and coming back, because the screen stays focused across that round trip;
+ * foreground alone misses in-app navigation onto the screen. The check is a
+ * capability query, so it never shows a biometric prompt.
+ */
+export function useBiometricsAvailability(): boolean {
+  const { checkBiometricsAvailable } = useAuth();
+  const biometricsAvailable = useSettingStore(
+    state => state.biometricsAvailable,
+  );
+  const setBiometricsAvailable = useSettingStore(
+    state => state.setBiometricsAvailable,
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      let active = true;
+
+      const refresh = () => {
+        checkBiometricsAvailable()
+          .then(available => {
+            if (active) {
+              setBiometricsAvailable(available);
+            }
+          })
+          .catch(() => {
+            // Keep the last known value; a failed capability query is not
+            // evidence that biometrics are unavailable.
+          });
+      };
+
+      refresh();
+      const subscription = AppState.addEventListener('change', nextAppState => {
+        if (nextAppState === 'active') {
+          refresh();
+        }
+      });
+
+      return () => {
+        active = false;
+        subscription.remove();
+      };
+    }, [checkBiometricsAvailable, setBiometricsAvailable]),
+  );
+
+  return biometricsAvailable;
+}

--- a/app/src/providers/authProvider.tsx
+++ b/app/src/providers/authProvider.tsx
@@ -123,7 +123,13 @@ const _getWithBiometrics = async function <T>(
   }
 };
 
-async function checkBiometricsAvailable(): Promise<boolean> {
+/**
+ * @returns whether biometric unlock is available, or `null` when the capability
+ * could not be determined. A failed query is not evidence of unavailability, so
+ * callers must not treat `null` as `false` — overwriting a known-good value with
+ * `false` disables biometric-gated features until the next successful check.
+ */
+async function checkBiometricsAvailable(): Promise<boolean | null> {
   try {
     const { available } = await biometrics.isSensorAvailable();
     logAuthEvent('info', 'biometric_sensor_checked', {
@@ -140,7 +146,7 @@ async function checkBiometricsAvailable(): Promise<boolean> {
       { ...authBaseContext, stage: 'sensor_check' },
       { reason: 'unknown_error' },
     );
-    return false;
+    return null;
   }
 }
 
@@ -303,7 +309,7 @@ interface IAuthContext {
   restoreAccountFromMnemonic: (
     mnemonic: string,
   ) => Promise<SignedPayload<boolean> | null>;
-  checkBiometricsAvailable: () => Promise<boolean>;
+  checkBiometricsAvailable: () => Promise<boolean | null>;
 }
 export const AuthContext = createContext<IAuthContext>({
   isAuthenticated: false,
@@ -313,7 +319,8 @@ export const AuthContext = createContext<IAuthContext>({
   _getWithBiometrics,
   getOrCreateMnemonic: () => Promise.resolve(null),
   restoreAccountFromMnemonic: () => Promise.resolve(null),
-  checkBiometricsAvailable: () => Promise.resolve(false),
+  // No provider mounted, so the capability is unknown rather than absent.
+  checkBiometricsAvailable: () => Promise.resolve(null),
 });
 
 export const AuthProvider = ({

--- a/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
@@ -57,7 +57,7 @@ import type { Mnemonic } from '@/types/mnemonic';
  */
 type CloudRecoveryError =
   | CloudBackupErrorReason
-  | 'restore_failed'
+  | 'secret_storage_failed'
   | 'not_registered'
   | 'network_error'
   | 'unexpected_error';
@@ -101,11 +101,13 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
         const result = await restoreAccountFromMnemonic(mnemonic.phrase);
 
         if (!result) {
-          console.warn('Failed to restore account');
+          // `download` already validated the phrase, so this is the keychain
+          // write failing rather than a bad phrase.
+          console.warn('Failed to store the restored secret');
           trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN, {
-            reason: 'restore_failed',
+            reason: 'secret_storage_failed',
           });
-          setError('restore_failed');
+          setError('secret_storage_failed');
           setRestoring(false);
           return false;
         }

--- a/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
@@ -3,7 +3,8 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import React, { useCallback, useState } from 'react';
-import { Separator, View, XStack, YStack } from 'tamagui';
+import { StyleSheet } from 'react-native';
+import { Separator, Text, View, XStack, YStack } from 'tamagui';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
@@ -21,6 +22,7 @@ import {
 import { BackupEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import {
   black,
+  red500,
   slate500,
   slate600,
   white,
@@ -28,6 +30,7 @@ import {
 
 import Keyboard from '@/assets/icons/keyboard.svg';
 import RestoreAccountSvg from '@/assets/icons/restore_account.svg';
+import { useBiometricsAvailability } from '@/hooks/useBiometricsAvailability';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
 import type { RootStackParamList } from '@/navigation';
@@ -42,8 +45,22 @@ import {
 } from '@/proving/checkRestoredDocumentRegistration';
 import { recoveryCopy } from '@/screens/account/recovery/recoveryCopy';
 import { useBackupMnemonic } from '@/services/cloud-backup';
+import type { CloudBackupErrorReason } from '@/services/cloud-backup/errors';
+import { isCloudBackupError } from '@/services/cloud-backup/errors';
 import { useSettingStore } from '@/stores/settingStore';
 import type { Mnemonic } from '@/types/mnemonic';
+
+/**
+ * Every way a cloud restore can fail. Built on `CloudBackupErrorReason` so any
+ * new download failure is renderable by construction rather than collapsing into
+ * "something went wrong".
+ */
+type CloudRecoveryError =
+  | CloudBackupErrorReason
+  | 'restore_failed'
+  | 'not_registered'
+  | 'network_error'
+  | 'unexpected_error';
 
 const AccountRecoveryChoiceScreen: React.FC = () => {
   const selfClient = useSelfClient();
@@ -55,8 +72,9 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
   // const { authState } = useTurnkey();
   const [_restoringFromTurnkey, _setRestoringFromTurnkey] = useState(false);
   const [restoringFromCloud, setRestoringFromCloud] = useState(false);
-  const { cloudBackupEnabled, toggleCloudBackupEnabled, biometricsAvailable } =
-    useSettingStore();
+  const [error, setError] = useState<CloudRecoveryError | null>(null);
+  const { cloudBackupEnabled, toggleCloudBackupEnabled } = useSettingStore();
+  const biometricsAvailable = useBiometricsAvailability();
   const { download } = useBackupMnemonic();
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -87,6 +105,7 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
           trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN, {
             reason: 'restore_failed',
           });
+          setError('restore_failed');
           setRestoring(false);
           return false;
         }
@@ -127,6 +146,7 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
               hasCSCA: !!csca,
             },
           );
+          setError('not_registered');
           setRestoring(false);
           return false;
         }
@@ -147,13 +167,17 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
           'Restore account error:',
           e instanceof Error ? e.message : 'Unknown error',
         );
+        const isProtocolDataUnavailable =
+          e instanceof ProtocolDataUnavailableError;
         trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN, {
-          reason:
-            e instanceof ProtocolDataUnavailableError
-              ? 'protocol_data_unavailable'
-              : 'unexpected_error',
+          reason: isProtocolDataUnavailable
+            ? 'protocol_data_unavailable'
+            : 'unexpected_error',
           error: e instanceof Error ? e.name : 'unknown',
         });
+        setError(
+          isProtocolDataUnavailable ? 'network_error' : 'unexpected_error',
+        );
         setRestoring(false);
         return false;
       }
@@ -199,19 +223,30 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
   // }, [getMnemonic, restoreAccountFlow, setTurnkeyBackupEnabled, trackEvent]);
 
   const onRestoreFromCloudPress = useCallback(async () => {
+    trackEvent(BackupEvents.CLOUD_RESTORE_STARTED);
+    setError(null);
     setRestoringFromCloud(true);
     try {
       const mnemonic = await download();
       await restoreAccountFlow(mnemonic, true, setRestoringFromCloud);
-    } catch (error) {
+    } catch (downloadError) {
       console.error(
         'Cloud restore error:',
-        error instanceof Error ? error.message : 'Unknown error',
+        downloadError instanceof Error
+          ? downloadError.message
+          : 'Unknown error',
       );
+      // A classified reason is both the message the user sees and the analytics
+      // reason. Anything unclassified keeps the legacy bucket so it stays
+      // distinguishable from a restore that failed after the download.
+      const reason = isCloudBackupError(downloadError)
+        ? downloadError.reason
+        : null;
       trackEvent(BackupEvents.CLOUD_RESTORE_FAILED_UNKNOWN, {
-        reason: 'backup_download_failed',
-        error: error instanceof Error ? error.name : 'unknown',
+        reason: reason ?? 'backup_download_failed',
+        error: downloadError instanceof Error ? downloadError.name : 'unknown',
       });
+      setError(reason ?? 'unexpected_error');
       setRestoringFromCloud(false);
     }
   }, [download, restoreAccountFlow, trackEvent]);
@@ -235,10 +270,11 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
       <ExpandableBottomLayout.BottomSection backgroundColor={white}>
         <YStack alignItems="center" gap="$2.5" paddingBottom="$2.5">
           <Title>{recoveryCopy.choice.title}</Title>
-          <Description>
-            {recoveryCopy.choice.description}{' '}
-            {!biometricsAvailable && recoveryCopy.choice.noBiometrics}
-          </Description>
+          <Description>{recoveryCopy.choice.description}</Description>
+
+          {error && (
+            <Text style={styles.errorText}>{recoveryCopy.errors[error]}</Text>
+          )}
 
           <YStack gap="$2.5" width="100%" paddingTop="$6">
             {/* DISABLED FOR NOW: Turnkey functionality */}
@@ -257,13 +293,17 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
               {restoringFromTurnkey ? '…' : ''}
             </PrimaryButton> */}
             <PrimaryButton
-              trackEvent={BackupEvents.CLOUD_BACKUP_STARTED}
               onPress={onRestoreFromCloudPress}
               testID="button-from-teststorage"
               disabled={restoringFromCloud || !biometricsAvailable}
             >
               {recoveryCopy.choice.actions.cloud(restoringFromCloud)}
             </PrimaryButton>
+            {!biometricsAvailable && (
+              <Text style={styles.noticeText}>
+                {recoveryCopy.choice.noBiometrics}
+              </Text>
+            )}
             <XStack gap={64} alignItems="center" justifyContent="space-between">
               <Separator flexGrow={1} />
               <Caption>{recoveryCopy.choice.actions.or}</Caption>
@@ -290,3 +330,18 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
 };
 
 export default AccountRecoveryChoiceScreen;
+
+const styles = StyleSheet.create({
+  errorText: {
+    color: red500,
+    fontSize: 14,
+    textAlign: 'center',
+    paddingHorizontal: 20,
+  },
+  noticeText: {
+    color: slate500,
+    fontSize: 14,
+    textAlign: 'center',
+    paddingHorizontal: 20,
+  },
+});

--- a/app/src/screens/account/recovery/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/account/recovery/RecoverWithPhraseScreen.tsx
@@ -49,18 +49,6 @@ type RecoveryError =
   | 'network_error'
   | 'unexpected_error';
 
-const ERROR_MESSAGES: Record<RecoveryError, string> = {
-  invalid_mnemonic:
-    'That doesn’t look like a valid recovery phrase. Make sure all 24 words are correct and in the right order.',
-  restore_failed:
-    'We couldn’t restore your account with this phrase. Please double-check and try again.',
-  not_registered:
-    'This recovery phrase doesn’t match a registered ID. If you registered with a different phrase, try that one instead.',
-  network_error:
-    'We couldn’t reach the Self network to verify your ID. Check your connection and try again.',
-  unexpected_error: 'Something went wrong. Please try again.',
-};
-
 const RecoverWithPhraseScreen: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -209,7 +197,9 @@ const RecoverWithPhraseScreen: React.FC = () => {
         </Pressable>
       </View>
 
-      {error && <Text style={styles.errorText}>{ERROR_MESSAGES[error]}</Text>}
+      {error && (
+        <Text style={styles.errorText}>{recoveryCopy.errors[error]}</Text>
+      )}
 
       <SecondaryButton
         disabled={!mnemonic || restoring}

--- a/app/src/screens/account/recovery/recoveryCopy.ts
+++ b/app/src/screens/account/recovery/recoveryCopy.ts
@@ -20,8 +20,7 @@ export const recoveryCopy = {
   choice: {
     title: 'Recover your Self account',
     description: 'Choose how you want to recover your account.',
-    noBiometrics:
-      'Cloud recovery requires biometrics, which are unavailable on this device. You can still recover using your recovery phrase.',
+    noBiometrics: `Recovering from ${STORAGE_NAME} needs biometric unlock. Turn on Face ID, fingerprint or device unlock in your device settings and come back, or recover with your recovery phrase below.`,
     actions: {
       cloud: (restoring: boolean) =>
         `${restoring ? 'Recovering' : 'Recover'} from ${STORAGE_NAME}${restoring ? '\u2026' : ''}`,
@@ -37,5 +36,27 @@ export const recoveryCopy = {
     placeholder: 'Enter or paste your recovery phrase',
     paste: 'PASTE',
     submit: 'Continue',
+  },
+
+  /**
+   * Failure messages for both recovery screens, keyed by the reason each screen
+   * tracks. A superset of either screen's cases, so indexing it only compiles
+   * while a screen's error union stays a subset of these keys.
+   */
+  errors: {
+    no_backup_found: `We couldn’t find a backup in ${STORAGE_NAME}. Backups don’t move between platforms — one made on Android can’t be restored on iPhone, and one made on iPhone can’t be restored on Android. Use your recovery phrase instead.`,
+    cloud_unavailable: `Sign in to ${STORAGE_NAME} in your device settings, then try again. You can also recover with your recovery phrase.`,
+    sign_in_cancelled: `The ${STORAGE_NAME} sign-in was dismissed before it finished. Try again, or use your recovery phrase.`,
+    backup_corrupt: `We found a backup in ${STORAGE_NAME} but couldn’t read it. Recover with your recovery phrase instead.`,
+    backup_read_failed: `We couldn’t reach ${STORAGE_NAME}. Check your connection and try again.`,
+    invalid_mnemonic:
+      'That doesn’t look like a valid recovery phrase. Make sure all 24 words are correct and in the right order.',
+    restore_failed:
+      'We couldn’t restore your account with this phrase. Please double-check and try again.',
+    not_registered:
+      'This recovery phrase doesn’t match a registered ID. If you registered with a different phrase, try that one instead.',
+    network_error:
+      'We couldn’t reach the Self network to verify your ID. Check your connection and try again.',
+    unexpected_error: 'Something went wrong. Please try again.',
   },
 } as const;

--- a/app/src/screens/account/recovery/recoveryCopy.ts
+++ b/app/src/screens/account/recovery/recoveryCopy.ts
@@ -53,6 +53,11 @@ export const recoveryCopy = {
       'That doesn’t look like a valid recovery phrase. Make sure all 24 words are correct and in the right order.',
     restore_failed:
       'We couldn’t restore your account with this phrase. Please double-check and try again.',
+    // The cloud path validates the phrase before restoring it, so a failure
+    // here is this device refusing to store the secret — telling the user to
+    // check a phrase they never typed would send them nowhere.
+    secret_storage_failed:
+      'We found your backup but couldn’t save it securely on this device. Make sure your device lock is set up, then try again.',
     not_registered:
       'This recovery phrase doesn’t match a registered ID. If you registered with a different phrase, try that one instead.',
     network_error:

--- a/app/src/screens/app/SplashScreen.tsx
+++ b/app/src/screens/app/SplashScreen.tsx
@@ -66,7 +66,13 @@ const SplashScreen: React.FC = ({}) => {
       dataLoadInitiatedRef.current = true;
 
       checkBiometricsAvailable()
-        .then(setBiometricsAvailable)
+        .then(available => {
+          // `null` means the capability could not be determined; leave the
+          // store at its default rather than asserting biometrics are absent.
+          if (available !== null) {
+            setBiometricsAvailable(available);
+          }
+        })
         .catch(err => {
           console.warn('Error checking biometrics availability', err);
         });

--- a/app/src/services/cloud-backup/errors.ts
+++ b/app/src/services/cloud-backup/errors.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+/**
+ * Why a cloud backup could not be read. Recovery screens map these to per-branch
+ * copy and to the `reason` property on restore-failure analytics, so a failure is
+ * never reported to the user or to telemetry as an undifferentiated "unknown".
+ */
+export type CloudBackupErrorReason =
+  /** Android only: the Google sign-in sheet returned no account. */
+  | 'sign_in_cancelled'
+  /** iOS only: iCloud Drive is off or the device is signed out of iCloud. */
+  | 'cloud_unavailable'
+  /** Reached the provider, but this account holds no backup file. */
+  | 'no_backup_found'
+  /** Found a backup file whose contents are not a usable mnemonic. */
+  | 'backup_corrupt'
+  /**
+   * Anything else from the storage layer. `withRetries` replaces the original
+   * error with a fresh one, so every classifiable branch must throw outside it —
+   * whatever escapes the retry wrapper is unclassifiable by construction.
+   */
+  | 'backup_read_failed';
+
+export class CloudBackupError extends Error {
+  readonly reason: CloudBackupErrorReason;
+
+  constructor(
+    reason: CloudBackupErrorReason,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message);
+    this.name = 'CloudBackupError';
+    this.reason = reason;
+    if (options?.cause) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+export function isCloudBackupError(error: unknown): error is CloudBackupError {
+  return error instanceof CloudBackupError;
+}

--- a/app/src/services/cloud-backup/index.ts
+++ b/app/src/services/cloud-backup/index.ts
@@ -9,6 +9,7 @@ import {
   MIME_TYPES,
 } from '@robinbobin/react-native-google-drive-api-wrapper';
 
+import { CloudBackupError } from '@/services/cloud-backup/errors';
 import { createGDrive } from '@/services/cloud-backup/google';
 import { FILE_NAME } from '@/services/cloud-backup/helpers';
 import {
@@ -63,7 +64,12 @@ export async function download() {
 
   const gdrive = await createGDrive();
   if (!gdrive) {
-    throw new Error('User canceled Google sign-in');
+    // `googleSignIn` swallows every `authorize` failure, so a genuine auth or
+    // network error is indistinguishable from a cancel here.
+    throw new CloudBackupError(
+      'sign_in_cancelled',
+      'User canceled Google sign-in',
+    );
   }
   const { files } = await gdrive.files.list({
     spaces: APP_DATA_FOLDER_ID,
@@ -74,7 +80,8 @@ export async function download() {
   const firstFile = driveFiles[0];
 
   if (!isDriveFile(firstFile)) {
-    throw new Error(
+    throw new CloudBackupError(
+      'no_backup_found',
       'Couldnt find the encrypted backup, did you back it up previously?',
     );
   }
@@ -85,7 +92,11 @@ export async function download() {
     const mnemonic = parseMnemonic(mnemonicString);
     return mnemonic;
   } catch (e) {
-    throw new Error(`Failed to parse mnemonic backup: ${(e as Error).message}`);
+    throw new CloudBackupError(
+      'backup_corrupt',
+      `Failed to parse mnemonic backup: ${(e as Error).message}`,
+      { cause: e },
+    );
   }
 }
 
@@ -100,7 +111,10 @@ export async function upload(mnemonic: Mnemonic) {
   } else {
     const gdrive = await createGDrive();
     if (!gdrive) {
-      throw new Error('User canceled Google sign-in');
+      throw new CloudBackupError(
+        'sign_in_cancelled',
+        'User canceled Google sign-in',
+      );
     }
     await withRetries(() =>
       gdrive.files

--- a/app/src/services/cloud-backup/index.ts
+++ b/app/src/services/cloud-backup/index.ts
@@ -9,7 +9,10 @@ import {
   MIME_TYPES,
 } from '@robinbobin/react-native-google-drive-api-wrapper';
 
-import { CloudBackupError } from '@/services/cloud-backup/errors';
+import {
+  CloudBackupError,
+  isCloudBackupError,
+} from '@/services/cloud-backup/errors';
 import { createGDrive } from '@/services/cloud-backup/google';
 import { FILE_NAME } from '@/services/cloud-backup/helpers';
 import {
@@ -62,39 +65,52 @@ export async function download() {
     return iosDownload();
   }
 
-  const gdrive = await createGDrive();
-  if (!gdrive) {
-    // `googleSignIn` swallows every `authorize` failure, so a genuine auth or
-    // network error is indistinguishable from a cancel here.
-    throw new CloudBackupError(
-      'sign_in_cancelled',
-      'User canceled Google sign-in',
-    );
-  }
-  const { files } = await gdrive.files.list({
-    spaces: APP_DATA_FOLDER_ID,
-    q: `name = '${FILE_NAME}'`,
-  });
-
-  const driveFiles: unknown[] = files;
-  const firstFile = driveFiles[0];
-
-  if (!isDriveFile(firstFile)) {
-    throw new CloudBackupError(
-      'no_backup_found',
-      'Couldnt find the encrypted backup, did you back it up previously?',
-    );
-  }
-  const mnemonicString = await withRetries(() =>
-    gdrive.files.getText(firstFile.id),
-  );
   try {
-    const mnemonic = parseMnemonic(mnemonicString);
-    return mnemonic;
+    const gdrive = await createGDrive();
+    if (!gdrive) {
+      // `googleSignIn` swallows every `authorize` failure, so a genuine auth or
+      // network error is indistinguishable from a cancel here.
+      throw new CloudBackupError(
+        'sign_in_cancelled',
+        'User canceled Google sign-in',
+      );
+    }
+    const { files } = await gdrive.files.list({
+      spaces: APP_DATA_FOLDER_ID,
+      q: `name = '${FILE_NAME}'`,
+    });
+
+    const driveFiles: unknown[] = files;
+    const firstFile = driveFiles[0];
+
+    if (!isDriveFile(firstFile)) {
+      throw new CloudBackupError(
+        'no_backup_found',
+        'Couldnt find the encrypted backup, did you back it up previously?',
+      );
+    }
+    const mnemonicString = await withRetries(() =>
+      gdrive.files.getText(firstFile.id),
+    );
+    try {
+      const mnemonic = parseMnemonic(mnemonicString);
+      return mnemonic;
+    } catch (e) {
+      throw new CloudBackupError(
+        'backup_corrupt',
+        `Failed to parse mnemonic backup: ${(e as Error).message}`,
+        { cause: e },
+      );
+    }
   } catch (e) {
+    if (isCloudBackupError(e)) {
+      throw e;
+    }
+    // Drive rejected the list or read. `withRetries` replaces the original
+    // error, so report a retryable read failure rather than a missing backup.
     throw new CloudBackupError(
-      'backup_corrupt',
-      `Failed to parse mnemonic backup: ${(e as Error).message}`,
+      'backup_read_failed',
+      `Failed to read the backup from Google Drive: ${(e as Error).message}`,
       { cause: e },
     );
   }

--- a/app/src/services/cloud-backup/ios.ts
+++ b/app/src/services/cloud-backup/ios.ts
@@ -4,7 +4,10 @@
 
 import { CloudStorage } from 'react-native-cloud-storage';
 
-import { CloudBackupError } from '@/services/cloud-backup/errors';
+import {
+  CloudBackupError,
+  isCloudBackupError,
+} from '@/services/cloud-backup/errors';
 import { ENCRYPTED_FILE_PATH, FOLDER } from '@/services/cloud-backup/helpers';
 import type { Mnemonic } from '@/types/mnemonic';
 import { parseMnemonic } from '@/utils/crypto/mnemonic';
@@ -15,35 +18,50 @@ export async function disableBackup() {
 }
 
 export async function download() {
-  // When the device is signed out of iCloud, `exists` resolves false rather than
-  // throwing, so without this guard a signed-out user is told they have no
-  // backup. Check availability first so the two stay distinguishable.
-  if (!(await CloudStorage.isCloudAvailable())) {
-    throw new CloudBackupError(
-      'cloud_unavailable',
-      'iCloud is unavailable, is the device signed in to iCloud?',
-    );
-  }
-
-  if (await CloudStorage.exists(ENCRYPTED_FILE_PATH)) {
-    const mnemonicString = await withRetries(() =>
-      CloudStorage.readFile(ENCRYPTED_FILE_PATH),
-    );
-    try {
-      return parseMnemonic(mnemonicString);
-    } catch (e) {
+  try {
+    // When the device is signed out of iCloud, `exists` resolves false rather
+    // than throwing, so without this guard a signed-out user is told they have
+    // no backup. Check availability first so the two stay distinguishable.
+    if (!(await CloudStorage.isCloudAvailable())) {
       throw new CloudBackupError(
-        'backup_corrupt',
-        `Failed to parse mnemonic backup: ${(e as Error).message}`,
-        { cause: e },
+        'cloud_unavailable',
+        'iCloud is unavailable, is the device signed in to iCloud?',
       );
     }
-  }
 
-  throw new CloudBackupError(
-    'no_backup_found',
-    'Couldnt find the encrypted backup, did you back it up previously?',
-  );
+    if (await CloudStorage.exists(ENCRYPTED_FILE_PATH)) {
+      const mnemonicString = await withRetries(() =>
+        CloudStorage.readFile(ENCRYPTED_FILE_PATH),
+      );
+      try {
+        return parseMnemonic(mnemonicString);
+      } catch (e) {
+        throw new CloudBackupError(
+          'backup_corrupt',
+          `Failed to parse mnemonic backup: ${(e as Error).message}`,
+          { cause: e },
+        );
+      }
+    }
+
+    throw new CloudBackupError(
+      'no_backup_found',
+      'Couldnt find the encrypted backup, did you back it up previously?',
+    );
+  } catch (e) {
+    if (isCloudBackupError(e)) {
+      throw e;
+    }
+    // Whatever the provider rejected with is unclassifiable — `withRetries`
+    // replaces the original error, so there is nothing left to inspect. Report
+    // it as a read failure so the user is told to retry rather than that their
+    // backup is missing.
+    throw new CloudBackupError(
+      'backup_read_failed',
+      `Failed to read the backup from iCloud: ${(e as Error).message}`,
+      { cause: e },
+    );
+  }
 }
 
 export async function upload(mnemonic: Mnemonic) {

--- a/app/src/services/cloud-backup/ios.ts
+++ b/app/src/services/cloud-backup/ios.ts
@@ -4,6 +4,7 @@
 
 import { CloudStorage } from 'react-native-cloud-storage';
 
+import { CloudBackupError } from '@/services/cloud-backup/errors';
 import { ENCRYPTED_FILE_PATH, FOLDER } from '@/services/cloud-backup/helpers';
 import type { Mnemonic } from '@/types/mnemonic';
 import { parseMnemonic } from '@/utils/crypto/mnemonic';
@@ -14,6 +15,16 @@ export async function disableBackup() {
 }
 
 export async function download() {
+  // When the device is signed out of iCloud, `exists` resolves false rather than
+  // throwing, so without this guard a signed-out user is told they have no
+  // backup. Check availability first so the two stay distinguishable.
+  if (!(await CloudStorage.isCloudAvailable())) {
+    throw new CloudBackupError(
+      'cloud_unavailable',
+      'iCloud is unavailable, is the device signed in to iCloud?',
+    );
+  }
+
   if (await CloudStorage.exists(ENCRYPTED_FILE_PATH)) {
     const mnemonicString = await withRetries(() =>
       CloudStorage.readFile(ENCRYPTED_FILE_PATH),
@@ -21,13 +32,16 @@ export async function download() {
     try {
       return parseMnemonic(mnemonicString);
     } catch (e) {
-      throw new Error(
+      throw new CloudBackupError(
+        'backup_corrupt',
         `Failed to parse mnemonic backup: ${(e as Error).message}`,
+        { cause: e },
       );
     }
   }
 
-  throw new Error(
+  throw new CloudBackupError(
+    'no_backup_found',
     'Couldnt find the encrypted backup, did you back it up previously?',
   );
 }

--- a/app/src/stores/settingStore.ts
+++ b/app/src/stores/settingStore.ts
@@ -12,7 +12,6 @@ type LoggingSeverity = 'debug' | 'info' | 'warn' | 'error';
 
 interface PersistedSettingsState {
   addSubscribedTopic: (topic: string) => void;
-  biometricsAvailable: boolean;
   cloudBackupEnabled: boolean;
   dismissPrivacyNote: () => void;
   fcmToken: string | null;
@@ -32,7 +31,6 @@ interface PersistedSettingsState {
   removeSubscribedTopic: (topic: string) => void;
   resetBackupForPoints: () => void;
   setBackupForPointsCompleted: () => void;
-  setBiometricsAvailable: (biometricsAvailable: boolean) => void;
   setDevModeOff: () => void;
   setDevModeOn: () => void;
   setFcmToken: (token: string | null) => void;
@@ -56,6 +54,12 @@ interface PersistedSettingsState {
 }
 
 interface NonPersistedSettingsState {
+  // A device capability, not a preference: biometric enrolment can be turned off
+  // in OS settings between launches, so a persisted value goes stale and would
+  // keep cloud recovery disabled until it happened to be rewritten. Always
+  // re-read from the OS instead.
+  biometricsAvailable: boolean;
+  setBiometricsAvailable: (biometricsAvailable: boolean) => void;
   // Dev-only one-shot flag armed by the "Test registration circuit" debug
   // shortcut. Bypasses only the document "already registered / nullifier"
   // checks so the register circuit runs even when the document is on-chain.
@@ -73,11 +77,14 @@ interface NonPersistedSettingsState {
 
 type SettingsState = PersistedSettingsState & NonPersistedSettingsState;
 
-export const SETTING_STORE_VERSION = 1;
+export const SETTING_STORE_VERSION = 2;
 
 // v1: force support ID sharing off for all existing users. It is opt-in
 // from here on — users can re-enable it in settings when a support agent
 // asks for it.
+// v2: drop the persisted biometricsAvailable. Excluding it from `partialize`
+// only stops future writes; without deleting it here the stale value would
+// still rehydrate once and clobber the fresh capability check.
 export const migrateSettingStore = (
   persistedState: unknown,
   version: number,
@@ -86,6 +93,9 @@ export const migrateSettingStore = (
   if (version < 1) {
     state.supportUuidEnabled = false;
     state.supportUuid = null;
+  }
+  if (version < 2) {
+    delete state.biometricsAvailable;
   }
   return state as SettingsState;
 };
@@ -252,6 +262,9 @@ export const useSettingStore = create<SettingsState>()(
         delete (persistedState as Partial<SettingsState>).testDscCircuitArmed;
         delete (persistedState as Partial<SettingsState>).armTestDscCircuit;
         delete (persistedState as Partial<SettingsState>).consumeTestDscCircuit;
+        delete (persistedState as Partial<SettingsState>).biometricsAvailable;
+        delete (persistedState as Partial<SettingsState>)
+          .setBiometricsAvailable;
         return persistedState;
       },
       version: SETTING_STORE_VERSION,

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -165,6 +165,7 @@ jest.mock('@/screens/account/recovery/recoveryCopy', () => ({
       backup_corrupt: 'Error: backup could not be read',
       backup_read_failed: 'Error: could not reach the cloud provider',
       restore_failed: 'Error: could not restore with this phrase',
+      secret_storage_failed: 'Error: could not save securely on this device',
       not_registered: 'Error: phrase does not match a registered ID',
       network_error: 'Error: could not reach the Self network',
       unexpected_error: 'Error: something went wrong',
@@ -430,6 +431,23 @@ describe('AccountRecoveryChoiceScreen', () => {
     });
   });
 
+  it('blames secure storage, not the phrase, when the restore itself fails', async () => {
+    mockRestoreAccountFromMnemonic.mockResolvedValue(false);
+
+    const { renderedText } = pressRestoreFromCloud();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_RESTORE_FAILED_UNKNOWN',
+        { reason: 'secret_storage_failed' },
+      );
+    });
+    // The user never typed a phrase on this path, and download() already
+    // validated the one it fetched.
+    expect(renderedText()).toContain(recoveryCopy.errors.secret_storage_failed);
+    expect(renderedText()).not.toContain(recoveryCopy.errors.restore_failed);
+  });
+
   it('explains an unregistered document without blaming the network', async () => {
     mockCheckRegistration.mockResolvedValue({
       isRegistered: false,
@@ -518,8 +536,9 @@ describe('AccountRecoveryChoiceScreen', () => {
     });
   });
 
-  it('keeps the last known availability when the capability query fails', async () => {
-    mockCheckBiometricsAvailable.mockRejectedValue(new Error('sensor error'));
+  it('keeps the last known availability when the capability is indeterminate', async () => {
+    // The provider resolves null (never rejects) when isSensorAvailable throws.
+    mockCheckBiometricsAvailable.mockResolvedValue(null);
     useSettingStore.setState({ biometricsAvailable: true });
 
     const { cloudButton } = renderScreen();
@@ -527,7 +546,8 @@ describe('AccountRecoveryChoiceScreen', () => {
     await waitFor(() => {
       expect(mockCheckBiometricsAvailable).toHaveBeenCalled();
     });
-    // A failed query is not evidence that biometrics are unavailable.
+    // A failed query is not evidence that biometrics are unavailable, so a
+    // transient native error must not disable cloud recovery.
     expect(cloudButton().props.disabled).toBe(false);
   });
 

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -3,9 +3,12 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import React from 'react';
+import { AppState } from 'react-native';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
 import AccountRecoveryChoiceScreen from '@/screens/account/recovery/AccountRecoveryChoiceScreen';
+// The real error class, so `isCloudBackupError` is exercised rather than stubbed.
+import { CloudBackupError } from '@/services/cloud-backup/errors';
 
 declare global {
   namespace JSX {
@@ -23,6 +26,9 @@ declare global {
 jest.mock('tamagui', () => ({
   __esModule: true,
   Separator: (props: any) => <mock-separator {...props} />,
+  Text: ({ children, ...props }: any) => (
+    <mock-text {...props}>{children}</mock-text>
+  ),
   View: ({ children, ...props }: any) => (
     <mock-view {...props}>{children}</mock-view>
   ),
@@ -34,9 +40,22 @@ jest.mock('tamagui', () => ({
   ),
 }));
 
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: jest.fn(),
-}));
+// Focus maps onto mount/unmount here: the screen under test is focused for as
+// long as it is rendered, and the cleanup still runs on unmount.
+jest.mock('@react-navigation/native', () => {
+  const react = jest.requireActual('react');
+  return {
+    useNavigation: jest.fn(),
+    useFocusEffect: (callback: () => void | (() => void)) =>
+      react.useEffect(callback, [callback]),
+  };
+});
+
+const appStateListeners: Array<(state: string) => void> = [];
+
+function foregroundApp() {
+  appStateListeners.forEach(listener => listener('active'));
+}
 
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
   markCurrentDocumentAsRegistered: jest.fn(),
@@ -72,6 +91,7 @@ jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
     CLOUD_RESTORE_FAILED_PASSPORT_NOT_REGISTERED:
       'CLOUD_RESTORE_FAILED_PASSPORT_NOT_REGISTERED',
     CLOUD_RESTORE_FAILED_UNKNOWN: 'CLOUD_RESTORE_FAILED_UNKNOWN',
+    CLOUD_RESTORE_STARTED: 'CLOUD_RESTORE_STARTED',
     CLOUD_RESTORE_SUCCESS: 'CLOUD_RESTORE_SUCCESS',
     MANUAL_RECOVERY_SELECTED: 'MANUAL_RECOVERY_SELECTED',
   },
@@ -79,6 +99,7 @@ jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
 
 jest.mock('@selfxyz/mobile-sdk-alpha/constants/colors', () => ({
   black: '#000',
+  red500: '#f00',
   slate500: '#555',
   slate600: '#666',
   white: '#fff',
@@ -137,6 +158,17 @@ jest.mock('@/screens/account/recovery/recoveryCopy', () => ({
         phrase: 'Enter your recovery phrase',
       },
     },
+    errors: {
+      no_backup_found: 'Error: no backup found',
+      cloud_unavailable: 'Error: sign in to the cloud provider',
+      sign_in_cancelled: 'Error: sign-in was dismissed',
+      backup_corrupt: 'Error: backup could not be read',
+      backup_read_failed: 'Error: could not reach the cloud provider',
+      restore_failed: 'Error: could not restore with this phrase',
+      not_registered: 'Error: phrase does not match a registered ID',
+      network_error: 'Error: could not reach the Self network',
+      unexpected_error: 'Error: something went wrong',
+    },
   },
 }));
 
@@ -145,9 +177,22 @@ jest.mock('@/services/cloud-backup', () => ({
   useBackupMnemonic: jest.fn(),
 }));
 
-jest.mock('@/stores/settingStore', () => ({
-  useSettingStore: jest.fn(),
-}));
+// A real zustand store, so the availability re-check actually re-renders the
+// screen the way it does on device.
+jest.mock('@/stores/settingStore', () => {
+  const { create } = jest.requireActual('zustand');
+  return {
+    useSettingStore: create(
+      (set: (partial: Record<string, unknown>) => void) => ({
+        cloudBackupEnabled: false,
+        toggleCloudBackupEnabled: jest.fn(),
+        biometricsAvailable: false,
+        setBiometricsAvailable: (biometricsAvailable: boolean) =>
+          set({ biometricsAvailable }),
+      }),
+    ),
+  };
+});
 
 const { useNavigation } = jest.requireMock('@react-navigation/native') as {
   useNavigation: jest.Mock;
@@ -175,21 +220,49 @@ const { useBackupMnemonic } = jest.requireMock('@/services/cloud-backup') as {
   useBackupMnemonic: jest.Mock;
 };
 const { useSettingStore } = jest.requireMock('@/stores/settingStore') as {
-  useSettingStore: jest.Mock;
+  useSettingStore: {
+    getState: () => {
+      toggleCloudBackupEnabled: jest.Mock;
+      biometricsAvailable: boolean;
+      setBiometricsAvailable: (value: boolean) => void;
+    };
+    setState: (partial: Record<string, unknown>) => void;
+  };
 };
 const useHapticNavigation = jest.requireMock('@/hooks/useHapticNavigation')
   .default as jest.Mock;
+const { recoveryCopy } = jest.requireMock(
+  '@/screens/account/recovery/recoveryCopy',
+) as {
+  recoveryCopy: {
+    choice: { noBiometrics: string };
+    errors: Record<string, string>;
+  };
+};
 
 describe('AccountRecoveryChoiceScreen', () => {
   const mockTrackEvent = jest.fn();
   const mockRestoreAccountFromMnemonic = jest.fn();
   const mockDownload = jest.fn();
-  const mockToggleCloudBackupEnabled = jest.fn();
+  const mockCheckBiometricsAvailable = jest.fn();
   const mockRestoreSuccessNavigation = jest.fn();
+  const mockToggleCloudBackupEnabled = () =>
+    useSettingStore.getState().toggleCloudBackupEnabled;
+
+  function renderScreen() {
+    const utils = render(<AccountRecoveryChoiceScreen />);
+    return {
+      ...utils,
+      cloudButton: () => utils.getByTestId('button-from-teststorage'),
+      renderedText: () =>
+        utils.UNSAFE_getAllByType('mock-text').map(node => node.props.children),
+    };
+  }
 
   function pressRestoreFromCloud() {
-    const { getByTestId } = render(<AccountRecoveryChoiceScreen />);
-    fireEvent.press(getByTestId('button-from-teststorage'));
+    const utils = renderScreen();
+    fireEvent.press(utils.cloudButton());
+    return utils;
   }
 
   beforeEach(() => {
@@ -204,14 +277,34 @@ describe('AccountRecoveryChoiceScreen', () => {
     useSelfClient.mockReturnValue({ trackEvent: mockTrackEvent });
     useAuth.mockReturnValue({
       restoreAccountFromMnemonic: mockRestoreAccountFromMnemonic,
+      checkBiometricsAvailable: mockCheckBiometricsAvailable,
     });
     useBackupMnemonic.mockReturnValue({ download: mockDownload });
-    useSettingStore.mockReturnValue({
+
+    appStateListeners.length = 0;
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_event, listener) => {
+        appStateListeners.push(listener as (state: string) => void);
+        return {
+          remove: () => {
+            const index = appStateListeners.indexOf(
+              listener as (state: string) => void,
+            );
+            if (index >= 0) {
+              appStateListeners.splice(index, 1);
+            }
+          },
+        } as ReturnType<typeof AppState.addEventListener>;
+      });
+
+    useSettingStore.setState({
       cloudBackupEnabled: false,
-      toggleCloudBackupEnabled: mockToggleCloudBackupEnabled,
+      toggleCloudBackupEnabled: jest.fn(),
       biometricsAvailable: true,
     });
 
+    mockCheckBiometricsAvailable.mockResolvedValue(true);
     mockDownload.mockResolvedValue({ phrase: 'twenty four words' });
     mockRestoreAccountFromMnemonic.mockResolvedValue(true);
     loadPassportData.mockResolvedValue('{"documentCategory":"passport"}');
@@ -230,7 +323,7 @@ describe('AccountRecoveryChoiceScreen', () => {
       expect(markCurrentDocumentAsRegistered).toHaveBeenCalled();
     });
     expect(reStorePassportDataWithRightCSCA).not.toHaveBeenCalled();
-    expect(mockToggleCloudBackupEnabled).toHaveBeenCalled();
+    expect(mockToggleCloudBackupEnabled()).toHaveBeenCalled();
     expect(mockTrackEvent).toHaveBeenCalledWith('CLOUD_RESTORE_SUCCESS');
     expect(mockTrackEvent).toHaveBeenCalledWith('ACCOUNT_RECOVERY_COMPLETED');
     expect(mockRestoreSuccessNavigation).toHaveBeenCalled();
@@ -257,7 +350,7 @@ describe('AccountRecoveryChoiceScreen', () => {
       new MockProtocolDataUnavailableError('unavailable'),
     );
 
-    pressRestoreFromCloud();
+    const { renderedText } = pressRestoreFromCloud();
 
     await waitFor(() => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
@@ -265,7 +358,11 @@ describe('AccountRecoveryChoiceScreen', () => {
         { reason: 'protocol_data_unavailable', error: 'Error' },
       );
     });
-    expect(mockToggleCloudBackupEnabled).not.toHaveBeenCalled();
+    // Must read as retryable, never as "your document isn't registered" — the
+    // registry was never reached, so registration was never actually checked.
+    expect(renderedText()).toContain(recoveryCopy.errors.network_error);
+    expect(renderedText()).not.toContain(recoveryCopy.errors.not_registered);
+    expect(mockToggleCloudBackupEnabled()).not.toHaveBeenCalled();
     expect(mockRestoreSuccessNavigation).not.toHaveBeenCalled();
     expect(markCurrentDocumentAsRegistered).not.toHaveBeenCalled();
   });
@@ -275,7 +372,7 @@ describe('AccountRecoveryChoiceScreen', () => {
     downloadError.name = 'BackupMissingError';
     mockDownload.mockRejectedValue(downloadError);
 
-    pressRestoreFromCloud();
+    const { renderedText } = pressRestoreFromCloud();
 
     await waitFor(() => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
@@ -283,6 +380,166 @@ describe('AccountRecoveryChoiceScreen', () => {
         { reason: 'backup_download_failed', error: 'BackupMissingError' },
       );
     });
+    // An unclassified download failure still has to say something.
+    expect(renderedText()).toContain(recoveryCopy.errors.unexpected_error);
     expect(mockCheckRegistration).not.toHaveBeenCalled();
+  });
+
+  it('tracks one restore-started event per attempt and no backup event', async () => {
+    mockCheckRegistration.mockResolvedValue({ isRegistered: true, csca: null });
+
+    pressRestoreFromCloud();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith('CLOUD_RESTORE_STARTED');
+    });
+    expect(
+      mockTrackEvent.mock.calls.filter(
+        ([event]) => event === 'CLOUD_RESTORE_STARTED',
+      ),
+    ).toHaveLength(1);
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      'CLOUD_BACKUP_STARTED',
+      expect.anything(),
+    );
+    expect(mockTrackEvent).not.toHaveBeenCalledWith('CLOUD_BACKUP_STARTED');
+  });
+
+  describe.each([
+    ['sign_in_cancelled'],
+    ['cloud_unavailable'],
+    ['no_backup_found'],
+    ['backup_corrupt'],
+    ['backup_read_failed'],
+  ] as const)('when the download fails with %s', reason => {
+    it('renders that reason and reports it to analytics', async () => {
+      mockDownload.mockRejectedValue(
+        new CloudBackupError(reason, `download failed: ${reason}`),
+      );
+
+      const { renderedText } = pressRestoreFromCloud();
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          'CLOUD_RESTORE_FAILED_UNKNOWN',
+          { reason, error: 'CloudBackupError' },
+        );
+      });
+      expect(renderedText()).toContain(recoveryCopy.errors[reason]);
+      expect(mockCheckRegistration).not.toHaveBeenCalled();
+    });
+  });
+
+  it('explains an unregistered document without blaming the network', async () => {
+    mockCheckRegistration.mockResolvedValue({
+      isRegistered: false,
+      csca: null,
+    });
+
+    const { renderedText } = pressRestoreFromCloud();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_RESTORE_FAILED_PASSPORT_NOT_REGISTERED',
+        { reason: 'document_not_registered', hasCSCA: false },
+      );
+    });
+    expect(renderedText()).toContain(recoveryCopy.errors.not_registered);
+    expect(renderedText()).not.toContain(recoveryCopy.errors.network_error);
+  });
+
+  it('clears a previous failure when the user retries', async () => {
+    mockDownload.mockRejectedValueOnce(
+      new CloudBackupError('no_backup_found', 'nothing there'),
+    );
+
+    const { cloudButton, renderedText } = renderScreen();
+    fireEvent.press(cloudButton());
+
+    await waitFor(() => {
+      expect(renderedText()).toContain(recoveryCopy.errors.no_backup_found);
+    });
+
+    mockCheckRegistration.mockResolvedValue({ isRegistered: true, csca: null });
+    fireEvent.press(cloudButton());
+
+    await waitFor(() => {
+      expect(markCurrentDocumentAsRegistered).toHaveBeenCalled();
+    });
+    expect(renderedText()).not.toContain(recoveryCopy.errors.no_backup_found);
+  });
+
+  it('explains why cloud restore is unavailable and keeps the phrase path usable', async () => {
+    mockCheckBiometricsAvailable.mockResolvedValue(false);
+
+    const { cloudButton, renderedText, UNSAFE_getAllByType } = renderScreen();
+
+    await waitFor(() => {
+      expect(cloudButton().props.disabled).toBe(true);
+    });
+    expect(renderedText()).toContain(recoveryCopy.choice.noBiometrics);
+
+    // The phrase path is the fallback the notice points at, so it must stay live.
+    const phraseButton = UNSAFE_getAllByType('mock-button').find(
+      node => node.props.children !== undefined && node.props.disabled !== true,
+    );
+    expect(phraseButton).toBeDefined();
+  });
+
+  it('re-checks availability on focus rather than trusting a stale value', async () => {
+    useSettingStore.setState({ biometricsAvailable: false });
+    mockCheckBiometricsAvailable.mockResolvedValue(true);
+
+    const { cloudButton } = renderScreen();
+
+    // The stale `false` must not survive: focusing the screen re-reads the OS.
+    await waitFor(() => {
+      expect(cloudButton().props.disabled).toBe(false);
+    });
+    expect(mockCheckBiometricsAvailable).toHaveBeenCalled();
+  });
+
+  it('re-checks availability when the app returns to the foreground', async () => {
+    mockCheckBiometricsAvailable.mockResolvedValue(false);
+
+    const { cloudButton } = renderScreen();
+
+    await waitFor(() => {
+      expect(cloudButton().props.disabled).toBe(true);
+    });
+
+    // The user enrols biometrics in OS settings and comes back. The screen never
+    // lost focus, so only the foreground transition can pick this up.
+    mockCheckBiometricsAvailable.mockResolvedValue(true);
+    foregroundApp();
+
+    await waitFor(() => {
+      expect(cloudButton().props.disabled).toBe(false);
+    });
+  });
+
+  it('keeps the last known availability when the capability query fails', async () => {
+    mockCheckBiometricsAvailable.mockRejectedValue(new Error('sensor error'));
+    useSettingStore.setState({ biometricsAvailable: true });
+
+    const { cloudButton } = renderScreen();
+
+    await waitFor(() => {
+      expect(mockCheckBiometricsAvailable).toHaveBeenCalled();
+    });
+    // A failed query is not evidence that biometrics are unavailable.
+    expect(cloudButton().props.disabled).toBe(false);
+  });
+
+  it('stops listening for foreground transitions once the screen unmounts', async () => {
+    const { unmount } = renderScreen();
+
+    await waitFor(() => {
+      expect(appStateListeners).toHaveLength(1);
+    });
+
+    unmount();
+
+    expect(appStateListeners).toHaveLength(0);
   });
 });

--- a/app/tests/src/screens/account/recovery/RecoverWithPhraseScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/RecoverWithPhraseScreen.test.tsx
@@ -140,6 +140,13 @@ jest.mock('@/screens/account/recovery/recoveryCopy', () => ({
       paste: 'PASTE',
       submit: 'Continue',
     },
+    errors: {
+      invalid_mnemonic: 'Error: invalid recovery phrase',
+      restore_failed: 'Error: could not restore with this phrase',
+      not_registered: 'Error: phrase does not match a registered ID',
+      network_error: 'Error: could not reach the Self network',
+      unexpected_error: 'Error: something went wrong',
+    },
   },
 }));
 
@@ -165,6 +172,9 @@ const {
   checkRestoredDocumentRegistration: jest.Mock;
   ProtocolDataUnavailableError: new (message?: string) => Error;
 };
+const { recoveryCopy } = jest.requireMock(
+  '@/screens/account/recovery/recoveryCopy',
+) as { recoveryCopy: { errors: Record<string, string> } };
 
 describe('RecoverWithPhraseScreen', () => {
   const mockNavigate = jest.fn();
@@ -260,9 +270,7 @@ describe('RecoverWithPhraseScreen', () => {
     const renderedText = UNSAFE_getAllByType('mock-text').map(
       node => node.props.children,
     );
-    expect(renderedText).toContain(
-      'We couldn’t reach the Self network to verify your ID. Check your connection and try again.',
-    );
+    expect(renderedText).toContain(recoveryCopy.errors.network_error);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 

--- a/app/tests/src/services/cloud-backup.test.ts
+++ b/app/tests/src/services/cloud-backup.test.ts
@@ -497,6 +497,33 @@ describe('cloudBackup', () => {
           reason: 'backup_corrupt',
         });
       });
+
+      it('reports a rejected read as retryable, not as a missing backup', async () => {
+        (CloudStorage.exists as jest.Mock).mockResolvedValue(true);
+        (CloudStorage.readFile as jest.Mock).mockRejectedValue(
+          new Error('network offline'),
+        );
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_read_failed',
+        });
+      }, 30000);
+
+      it('reports a rejected availability check as a read failure', async () => {
+        (CloudStorage.isCloudAvailable as jest.Mock).mockRejectedValue(
+          new Error('provider unreachable'),
+        );
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_read_failed',
+        });
+      });
     });
 
     describe('Android', () => {
@@ -539,6 +566,20 @@ describe('cloudBackup', () => {
         expect(await rejectionReason(result.current.download)).toEqual({
           name: 'CloudBackupError',
           reason: 'backup_corrupt',
+        });
+      });
+
+      it('reports a rejected file listing as retryable, not as a missing backup', async () => {
+        (createGDrive as jest.Mock).mockResolvedValue(mockGDriveInstance);
+        mockGDriveInstance.files.list.mockRejectedValue(
+          new Error('network offline'),
+        );
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_read_failed',
         });
       });
     });

--- a/app/tests/src/services/cloud-backup.test.ts
+++ b/app/tests/src/services/cloud-backup.test.ts
@@ -9,6 +9,7 @@ import { GDrive } from '@robinbobin/react-native-google-drive-api-wrapper';
 import { renderHook } from '@testing-library/react-native';
 
 import { useBackupMnemonic } from '@/services/cloud-backup';
+import type { CloudBackupError } from '@/services/cloud-backup/errors';
 import { createGDrive } from '@/services/cloud-backup/google';
 
 type SupportedPlatforms = 'ios' | 'android';
@@ -66,6 +67,7 @@ jest.mock('react-native-cloud-storage', () => ({
     exists: jest.fn(),
     readFile: jest.fn(),
     rmdir: jest.fn(),
+    isCloudAvailable: jest.fn(),
   },
   CloudStorageScope: {
     AppData: 'AppData',
@@ -129,6 +131,7 @@ describe('cloudBackup', () => {
     consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     (GDrive as jest.Mock).mockImplementation(() => mockGDriveInstance);
     (ethers.Mnemonic.isValidMnemonic as jest.Mock).mockReturnValue(true);
+    (CloudStorage.isCloudAvailable as jest.Mock).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -437,6 +440,107 @@ describe('cloudBackup', () => {
       await expect(result.current.download()).rejects.toThrow(
         'Failed to parse mnemonic backup: Invalid mnemonic structure: missing required properties (phrase, password, wordlist, entropy)',
       );
+    });
+  });
+
+  describe('download failure classification', () => {
+    async function rejectionReason(run: () => Promise<unknown>) {
+      try {
+        await run();
+      } catch (error) {
+        return {
+          name: (error as Error).name,
+          reason: (error as CloudBackupError).reason,
+        };
+      }
+      throw new Error('expected the download to reject');
+    }
+
+    describe('iOS', () => {
+      beforeEach(() => {
+        mockPlatform.OS = 'ios';
+      });
+
+      it('reports iCloud being unavailable without looking for the file', async () => {
+        (CloudStorage.isCloudAvailable as jest.Mock).mockResolvedValue(false);
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'cloud_unavailable',
+        });
+        // A signed-out device resolves `exists` as false, so classifying it as
+        // "no backup" is exactly the misclassification this guard prevents.
+        expect(CloudStorage.exists).not.toHaveBeenCalled();
+      });
+
+      it('distinguishes a missing backup from an unavailable cloud', async () => {
+        (CloudStorage.exists as jest.Mock).mockResolvedValue(false);
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'no_backup_found',
+        });
+      });
+
+      it('reports an unreadable backup as corrupt', async () => {
+        (CloudStorage.exists as jest.Mock).mockResolvedValue(true);
+        (CloudStorage.readFile as jest.Mock).mockResolvedValue('invalid json');
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_corrupt',
+        });
+      });
+    });
+
+    describe('Android', () => {
+      beforeEach(() => {
+        mockPlatform.OS = 'android';
+      });
+
+      it('reports a cancelled sign-in', async () => {
+        (createGDrive as jest.Mock).mockResolvedValue(null);
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'sign_in_cancelled',
+        });
+      });
+
+      it('reports a missing backup', async () => {
+        (createGDrive as jest.Mock).mockResolvedValue(mockGDriveInstance);
+        mockGDriveInstance.files.list.mockResolvedValue({ files: [] });
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'no_backup_found',
+        });
+      });
+
+      it('reports an unreadable backup as corrupt', async () => {
+        (createGDrive as jest.Mock).mockResolvedValue(mockGDriveInstance);
+        mockGDriveInstance.files.list.mockResolvedValue({
+          files: [{ id: 'file-id', name: 'encrypted-private-key' }],
+        });
+        mockGDriveInstance.files.getText.mockResolvedValue('invalid json');
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_corrupt',
+        });
+      });
     });
   });
 

--- a/app/tests/src/stores/settingStore.test.ts
+++ b/app/tests/src/stores/settingStore.test.ts
@@ -54,6 +54,60 @@ describe('migrateSettingStore', () => {
     expect(migrated.supportUuidEnabled).toBe(false);
     expect(migrated.supportUuid).toBeNull();
   });
+
+  it('drops a stale persisted biometricsAvailable when upgrading from v1', () => {
+    const migrated = migrateSettingStore(
+      { biometricsAvailable: false, cloudBackupEnabled: true },
+      1,
+    );
+
+    // Left in place it would rehydrate over the fresh capability check and keep
+    // cloud recovery disabled on a device that does support biometrics.
+    expect(migrated).not.toHaveProperty('biometricsAvailable');
+    expect(migrated.cloudBackupEnabled).toBe(true);
+  });
+
+  it('applies both migrations when upgrading from v0', () => {
+    const migrated = migrateSettingStore(
+      {
+        supportUuidEnabled: true,
+        supportUuid: '33333333-3333-3333-3333-333333333333',
+        biometricsAvailable: false,
+      },
+      0,
+    );
+
+    expect(migrated.supportUuidEnabled).toBe(false);
+    expect(migrated.supportUuid).toBeNull();
+    expect(migrated).not.toHaveProperty('biometricsAvailable');
+  });
+
+  it('keeps biometricsAvailable when already at the current version', () => {
+    const migrated = migrateSettingStore(
+      { biometricsAvailable: true },
+      SETTING_STORE_VERSION,
+    );
+
+    expect(migrated.biometricsAvailable).toBe(true);
+  });
+});
+
+describe('useSettingStore biometrics availability', () => {
+  afterEach(() => {
+    useSettingStore.setState(useSettingStore.getInitialState(), true);
+  });
+
+  it('excludes the device capability from persisted state', () => {
+    useSettingStore.getState().setBiometricsAvailable(true);
+
+    const partialize = useSettingStore.persist.getOptions().partialize;
+    const persistedState = partialize?.(useSettingStore.getState());
+
+    expect(useSettingStore.getState().biometricsAvailable).toBe(true);
+    expect(persistedState).toBeDefined();
+    expect(persistedState).not.toHaveProperty('biometricsAvailable');
+    expect(persistedState).not.toHaveProperty('setBiometricsAvailable');
+  });
 });
 
 describe('useSettingStore test registration circuit flag', () => {

--- a/packages/mobile-sdk-alpha/src/constants/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/constants/analytics.ts
@@ -47,6 +47,7 @@ export const BackupEvents = {
   CLOUD_RESTORE_FAILED_AUTH: 'Backup: Cloud Restore Failed: Authentication Failed',
   CLOUD_RESTORE_FAILED_PASSPORT_NOT_REGISTERED: 'Backup: Cloud Restore Failed: Passport Not Registered',
   CLOUD_RESTORE_FAILED_UNKNOWN: 'Backup: Cloud Restore Failed: Unknown Error',
+  CLOUD_RESTORE_STARTED: 'Backup: Cloud Restore Started',
   CLOUD_RESTORE_SUCCESS: 'Backup: Cloud Restore Success',
   TURNKEY_RESTORE_FAILED: 'Backup: Turnkey Restore Failed',
   CREATE_NEW_ACCOUNT: 'Backup: Create New Account',


### PR DESCRIPTION
Closes [SELF-3932](https://linear.app/selfprotocol/issue/SELF-3932/cloud-restore-failures-are-invisible-to-the-user-and-to-telemetry).

**Stacked on #2272 (SELF-3931).** Base is `fix/self-3931-recovery-protocol-data`; retarget to `dev` once that merges.

## Problem

`AccountRecoveryChoiceScreen` caught every cloud restore failure, logged to console, fired an event and cleared the spinner — and rendered nothing. The user saw a spinner, then an idle button, with nothing to report to support. 1787 of 1938 `Cloud Restore Failed: Unknown Error` events in the last 30 days carried no properties, so the failing branch was unknowable, and there was no restore-attempted event to serve as a denominator.

Two adjacent gating bugs on the same screen: `biometricsAvailable` was a device capability stored in persisted settings, so a stale `false` survived across launches and kept the cloud button permanently disabled; and it was only ever written by a fire-and-forget check at splash.

## Changes

- **Typed cloud-backup errors** — new `app/src/services/cloud-backup/errors.ts` with `CloudBackupError` carrying a `reason` (`sign_in_cancelled`, `cloud_unavailable`, `no_backup_found`, `backup_corrupt`, `backup_read_failed`). Every throw site in `index.ts`/`ios.ts` is classified. Messages are byte-identical to before, so the existing prose assertions act as the regression guard.
- **iOS signed-out is now distinguishable** — `ios.ts download()` calls `CloudStorage.isCloudAvailable()` *before* `exists()`. A signed-out device resolves `exists` as `false`, so without this guard it reported "no backup found" instead of "sign in to iCloud".
- **Choice-screen error state** — local error union mirroring `RecoverWithPhraseScreen`, rendered beneath the description. Built on `CloudBackupErrorReason`, so any new download failure is renderable by construction.
- **Events** — new `CLOUD_RESTORE_STARTED`, fired imperatively once per attempt; the `CLOUD_BACKUP_STARTED` prop is removed from the recover button. Untyped download failures keep `reason: 'backup_download_failed'` so they stay separable from `unexpected_error`.
- **Copy** — shared `recoveryCopy.errors` superset; the phrase screen's inline `ERROR_MESSAGES` moved there verbatim. The Android↔iOS backup incompatibility is stated in `no_backup_found`, the one branch a platform-switcher actually hits.
- **De-persisted `biometricsAvailable`** — moved to `NonPersistedSettingsState`, excluded from `partialize`, `SETTING_STORE_VERSION` bumped to 2 with a migration that **deletes** the stale key. `partialize` alone only stops future writes; the already-persisted value would still rehydrate once and clobber the fresh check.
- **`useBiometricsAvailability`** — re-reads capability on focus *and* on `AppState` `active`. Both are needed: the OS-settings round trip never unfocuses the screen, and foreground alone misses in-app navigation onto it. `isSensorAvailable()` is a capability query, so no biometric prompt is shown.
- **No inert button** — the cloud button stays visible but disabled, with the explanation moved out of the shared description to directly beneath it, naming the OS-settings remedy. Phrase path untouched.

## Notes for reviewers

- `CloudBackupScreen` also reads `biometricsAvailable`. It now reads `false` until the splash check resolves, where it previously read a sticky persisted value. This widens an existing SplashScreen ordering race rather than creating one; the recovery screen is immunised by the new hook. Extending the hook to `CloudBackupScreen` is a follow-up.
- `google.ts` `googleSignIn()` swallows every `authorize()` failure, so a genuine Android auth or network failure reports as `sign_in_cancelled`. `react-native-app-auth` exposes no cancel sentinel in its JS surface, so splitting them means string-matching native errors. Follow-up, not scope.
- `cloud_unavailable` is iOS-only in practice — Google Drive always reports available — so there is no Android repro for testing instruction 2.
- The focus/foreground re-checks increase `biometric_sensor_checked` log volume.
- `CloudStorageError.code` is deliberately not mapped: `withRetries` replaces the original error, so every classifiable branch throws outside it and anything escaping the retry wrapper is unclassifiable by construction.

## Validation

```
pnpm --filter @selfxyz/mobile-sdk-alpha test      # 528 passed
pnpm --filter @selfxyz/mobile-sdk-alpha types     # clean
madge src/browser.ts | grep react-native          # prints nothing
pnpm --filter @selfxyz/mobile-sdk-alpha build     # required before app types
pnpm --filter @selfxyz/mobile-app run test        # 1257 passed, 111 suites
pnpm --filter @selfxyz/mobile-app run types       # clean
pnpm --filter @selfxyz/mobile-app run lint        # 0 errors
```

New coverage: per-reason download classification (incl. `exists` never called when iCloud is unavailable), one test per rendered failure branch with its analytics `reason`, `CLOUD_RESTORE_STARTED` exactly once and `CLOUD_BACKUP_STARTED` never, error clearing on retry, the v2 migration, and the focus/foreground re-check with listener cleanup.

**Device QA still owed** — these cannot be unit-tested: iOS signed out of iCloud (instruction 2), cancelling the real Google sign-in sheet (instruction 3), and toggling biometrics in OS settings and returning (instruction 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)