### PR TITLE
fix(app): trigger iCloud sync before concluding a backup is missing (SELF-3933)

### DIFF
--- a/app/src/screens/account/recovery/recoveryCopy.ts
+++ b/app/src/screens/account/recovery/recoveryCopy.ts
@@ -49,6 +49,7 @@ export const recoveryCopy = {
     sign_in_cancelled: `The ${STORAGE_NAME} sign-in was dismissed before it finished. Try again, or use your recovery phrase.`,
     backup_corrupt: `We found a backup in ${STORAGE_NAME} but couldn’t read it. Recover with your recovery phrase instead.`,
     backup_read_failed: `We couldn’t reach ${STORAGE_NAME}. Check your connection and try again.`,
+    backup_not_synced: `Your backup is still syncing from ${STORAGE_NAME}. Keep the app open and try again in a moment.`,
     invalid_mnemonic:
       'That doesn’t look like a valid recovery phrase. Make sure all 24 words are correct and in the right order.',
     restore_failed:

--- a/app/src/services/cloud-backup/errors.ts
+++ b/app/src/services/cloud-backup/errors.ts
@@ -14,6 +14,11 @@ export type CloudBackupErrorReason =
   | 'cloud_unavailable'
   /** Reached the provider, but this account holds no backup file. */
   | 'no_backup_found'
+  /**
+   * iOS only: the backup exists in iCloud but hasn't finished downloading to
+   * this device. Retryable — the download continues in the background.
+   */
+  | 'backup_not_synced'
   /** Found a backup file whose contents are not a usable mnemonic. */
   | 'backup_corrupt'
   /**

--- a/app/src/services/cloud-backup/helpers.ts
+++ b/app/src/services/cloud-backup/helpers.ts
@@ -9,8 +9,10 @@ import { name } from '../../../package.json';
 
 const packageName = name?.startsWith('@') ? name : '@selfxyz/mobile-app';
 const folder = `/${packageName}`;
-export const ENCRYPTED_FILE_PATH = `/${folder}/encrypted-private-key`;
 export const FILE_NAME = 'encrypted-private-key';
+export const ENCRYPTED_FILE_PATH = `/${folder}/${FILE_NAME}`;
+// The name iOS gives a not-yet-downloaded iCloud item in directory listings.
+export const PLACEHOLDER_FILE_PATH = `/${folder}/.${FILE_NAME}.icloud`;
 export const FOLDER = folder;
 
 if (Platform.OS === 'ios') {

--- a/app/src/services/cloud-backup/index.ts
+++ b/app/src/services/cloud-backup/index.ts
@@ -15,6 +15,7 @@ import {
 } from '@/services/cloud-backup/errors';
 import { createGDrive } from '@/services/cloud-backup/google';
 import { FILE_NAME } from '@/services/cloud-backup/helpers';
+import type { IosDownloadOptions } from '@/services/cloud-backup/ios';
 import {
   disableBackup as disableIosBackup,
   download as iosDownload,
@@ -60,10 +61,12 @@ export async function disableBackup() {
   );
 }
 
-export async function download() {
+export async function download(options?: IosDownloadOptions) {
   if (Platform.OS === 'ios') {
-    return iosDownload();
+    return iosDownload(options);
   }
+  // Android has no placeholder concept — Drive's file listing is authoritative,
+  // so the sync options only apply to iOS.
 
   try {
     const gdrive = await createGDrive();

--- a/app/src/services/cloud-backup/ios.ts
+++ b/app/src/services/cloud-backup/ios.ts
@@ -8,16 +8,103 @@ import {
   CloudBackupError,
   isCloudBackupError,
 } from '@/services/cloud-backup/errors';
-import { ENCRYPTED_FILE_PATH, FOLDER } from '@/services/cloud-backup/helpers';
+import {
+  ENCRYPTED_FILE_PATH,
+  FILE_NAME,
+  FOLDER,
+  PLACEHOLDER_FILE_PATH,
+} from '@/services/cloud-backup/helpers';
 import type { Mnemonic } from '@/types/mnemonic';
 import { parseMnemonic } from '@/utils/crypto/mnemonic';
 import { withRetries } from '@/utils/retry';
+
+export interface IosDownloadOptions {
+  /** Total budget for waiting on iCloud to materialise the backup file. */
+  syncTimeoutMs?: number;
+  /** Delay between `exists` checks while waiting, and between remote probes. */
+  pollIntervalMs?: number;
+  /** How often to re-probe when the folder listing itself fails. */
+  remoteProbeAttempts?: number;
+}
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export async function disableBackup() {
   await withRetries(() => CloudStorage.rmdir(FOLDER, { recursive: true }));
 }
 
-export async function download() {
+/**
+ * Whether iCloud holds a backup for this account, downloaded or not.
+ *
+ * iCloud syncs metadata before content: a backup made on another device shows
+ * up here first as a `.name.icloud` placeholder that `exists` reports false
+ * for. A failed folder listing is ambiguous — `contentsOfDirectory` throws the
+ * same ERR_READ_ERROR for "folder never created" (no backup) and for a genuine
+ * read failure — so a rejection gets a few re-probes before it counts as
+ * absent, giving a fresh device's metadata a window to arrive. The residual
+ * gap (metadata lag beyond the probe budget) is not closable with this
+ * library's API surface; it exposes no NSMetadataQuery.
+ */
+async function hasRemoteBackup(
+  probeAttempts: number,
+  probeIntervalMs: number,
+): Promise<boolean> {
+  for (let attempt = 0; attempt < probeAttempts; attempt++) {
+    if (attempt > 0) {
+      await sleep(probeIntervalMs);
+    }
+    if (await CloudStorage.exists(PLACEHOLDER_FILE_PATH)) {
+      return true;
+    }
+    try {
+      const entries = await CloudStorage.readdir(FOLDER);
+      // A successful listing is authoritative: the folder is materialised, so
+      // the file is either visible (possibly under a placeholder name this
+      // check tolerates) or genuinely absent.
+      return entries.some(entry => entry.includes(FILE_NAME));
+    } catch {
+      // Ambiguous — retry the whole probe.
+    }
+  }
+  return false;
+}
+
+/**
+ * Asks iOS to download the backup and waits for it to appear locally.
+ *
+ * `triggerSync` is fired at both the plain path and the placeholder path:
+ * Apple does not document which of the two `isUbiquitousItem` accepts for a
+ * not-yet-downloaded item, and the wrong one throws instead of enqueueing. It
+ * is re-fired on every poll tick — the enqueue is idempotent, and a single
+ * dropped request must not strand the user in a retry loop that can never
+ * succeed. The poll is the arbiter either way.
+ */
+async function waitForBackupFile(
+  syncTimeoutMs: number,
+  pollIntervalMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + syncTimeoutMs;
+  for (;;) {
+    await Promise.allSettled([
+      CloudStorage.triggerSync(ENCRYPTED_FILE_PATH),
+      CloudStorage.triggerSync(PLACEHOLDER_FILE_PATH),
+    ]);
+    if (await CloudStorage.exists(ENCRYPTED_FILE_PATH)) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await sleep(Math.min(pollIntervalMs, Math.max(deadline - Date.now(), 1)));
+  }
+}
+
+export async function download(options?: IosDownloadOptions) {
+  const {
+    syncTimeoutMs = 30_000,
+    pollIntervalMs = 1_000,
+    remoteProbeAttempts = 3,
+  } = options ?? {};
   try {
     // When the device is signed out of iCloud, `exists` resolves false rather
     // than throwing, so without this guard a signed-out user is told they have
@@ -29,25 +116,33 @@ export async function download() {
       );
     }
 
-    if (await CloudStorage.exists(ENCRYPTED_FILE_PATH)) {
-      const mnemonicString = await withRetries(() =>
-        CloudStorage.readFile(ENCRYPTED_FILE_PATH),
-      );
-      try {
-        return parseMnemonic(mnemonicString);
-      } catch (e) {
+    if (!(await CloudStorage.exists(ENCRYPTED_FILE_PATH))) {
+      if (!(await hasRemoteBackup(remoteProbeAttempts, pollIntervalMs))) {
         throw new CloudBackupError(
-          'backup_corrupt',
-          `Failed to parse mnemonic backup: ${(e as Error).message}`,
-          { cause: e },
+          'no_backup_found',
+          'Couldnt find the encrypted backup, did you back it up previously?',
+        );
+      }
+      if (!(await waitForBackupFile(syncTimeoutMs, pollIntervalMs))) {
+        throw new CloudBackupError(
+          'backup_not_synced',
+          'The iCloud backup has not finished downloading to this device yet',
         );
       }
     }
 
-    throw new CloudBackupError(
-      'no_backup_found',
-      'Couldnt find the encrypted backup, did you back it up previously?',
+    const mnemonicString = await withRetries(() =>
+      CloudStorage.readFile(ENCRYPTED_FILE_PATH),
     );
+    try {
+      return parseMnemonic(mnemonicString);
+    } catch (e) {
+      throw new CloudBackupError(
+        'backup_corrupt',
+        `Failed to parse mnemonic backup: ${(e as Error).message}`,
+        { cause: e },
+      );
+    }
   } catch (e) {
     if (isCloudBackupError(e)) {
       throw e;

--- a/app/src/services/cloud-backup/ios.ts
+++ b/app/src/services/cloud-backup/ios.ts
@@ -40,10 +40,13 @@ export async function disableBackup() {
  * up here first as a `.name.icloud` placeholder that `exists` reports false
  * for. A failed folder listing is ambiguous — `contentsOfDirectory` throws the
  * same ERR_READ_ERROR for "folder never created" (no backup) and for a genuine
- * read failure — so a rejection gets a few re-probes before it counts as
- * absent, giving a fresh device's metadata a window to arrive. The residual
- * gap (metadata lag beyond the probe budget) is not closable with this
- * library's API surface; it exposes no NSMetadataQuery.
+ * read failure. Nor is a successful listing that lacks the file conclusive:
+ * the folder can materialise before its file placeholders do during the first
+ * metadata sync. Only a sighting of the file ends the probe early — every
+ * negative outcome is retried until the budget runs out, so "no backup" is
+ * only ever concluded after the metadata has had a window to arrive. The
+ * residual gap (metadata lag beyond the probe budget) is not closable with
+ * this library's API surface; it exposes no NSMetadataQuery.
  */
 async function hasRemoteBackup(
   probeAttempts: number,
@@ -58,12 +61,12 @@ async function hasRemoteBackup(
     }
     try {
       const entries = await CloudStorage.readdir(FOLDER);
-      // A successful listing is authoritative: the folder is materialised, so
-      // the file is either visible (possibly under a placeholder name this
-      // check tolerates) or genuinely absent.
-      return entries.some(entry => entry.includes(FILE_NAME));
+      if (entries.some(entry => entry.includes(FILE_NAME))) {
+        return true;
+      }
     } catch {
-      // Ambiguous — retry the whole probe.
+      // Missing folder or read failure — inconclusive, same as a listing
+      // without the file. Retry the whole probe.
     }
   }
   return false;

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -164,6 +164,7 @@ jest.mock('@/screens/account/recovery/recoveryCopy', () => ({
       sign_in_cancelled: 'Error: sign-in was dismissed',
       backup_corrupt: 'Error: backup could not be read',
       backup_read_failed: 'Error: could not reach the cloud provider',
+      backup_not_synced: 'Error: still downloading from the cloud provider',
       restore_failed: 'Error: could not restore with this phrase',
       secret_storage_failed: 'Error: could not save securely on this device',
       not_registered: 'Error: phrase does not match a registered ID',
@@ -410,6 +411,7 @@ describe('AccountRecoveryChoiceScreen', () => {
     ['sign_in_cancelled'],
     ['cloud_unavailable'],
     ['no_backup_found'],
+    ['backup_not_synced'],
     ['backup_corrupt'],
     ['backup_read_failed'],
   ] as const)('when the download fails with %s', reason => {

--- a/app/tests/src/services/cloud-backup.test.ts
+++ b/app/tests/src/services/cloud-backup.test.ts
@@ -305,7 +305,9 @@ describe('cloudBackup', () => {
 
       const { result } = renderHook(() => useBackupMnemonic());
 
-      await expect(result.current.download()).rejects.toThrow(
+      await expect(
+        result.current.download({ remoteProbeAttempts: 1, pollIntervalMs: 10 }),
+      ).rejects.toThrow(
         'Couldnt find the encrypted backup, did you back it up previously?',
       );
     });
@@ -490,7 +492,14 @@ describe('cloudBackup', () => {
 
         const { result } = renderHook(() => useBackupMnemonic());
 
-        expect(await rejectionReason(result.current.download)).toEqual({
+        expect(
+          await rejectionReason(() =>
+            result.current.download({
+              remoteProbeAttempts: 1,
+              pollIntervalMs: 10,
+            }),
+          ),
+        ).toEqual({
           name: 'CloudBackupError',
           reason: 'no_backup_found',
         });
@@ -579,11 +588,21 @@ describe('cloudBackup', () => {
 
         const { result } = renderHook(() => useBackupMnemonic());
 
-        expect(await rejectionReason(result.current.download)).toEqual({
+        expect(
+          await rejectionReason(() =>
+            result.current.download({
+              remoteProbeAttempts: 2,
+              pollIntervalMs: 10,
+            }),
+          ),
+        ).toEqual({
           name: 'CloudBackupError',
           reason: 'no_backup_found',
         });
         expect(CloudStorage.triggerSync).not.toHaveBeenCalled();
+        // A listing without the file is inconclusive during first metadata
+        // sync, so the whole probe budget must be spent before concluding.
+        expect(CloudStorage.readdir).toHaveBeenCalledTimes(2);
       });
 
       it('reports no backup when the folder listing keeps failing', async () => {
@@ -769,6 +788,41 @@ describe('cloudBackup', () => {
       await expect(
         result.current.download({ syncTimeoutMs: 500, pollIntervalMs: 10 }),
       ).resolves.toEqual(mockMnemonic);
+    });
+
+    it('keeps probing after an empty folder listing until the placeholder appears', async () => {
+      // Fresh-device window: the iCloud folder can materialise before its
+      // file placeholders do, so an empty listing must not conclude
+      // "no backup" while probe budget remains.
+      let materialized = false;
+      let placeholderProbes = 0;
+      (CloudStorage.exists as jest.Mock).mockImplementation(
+        async (path: string) => {
+          if (path === PLACEHOLDER_FILE_PATH) {
+            placeholderProbes += 1;
+            return placeholderProbes >= 2;
+          }
+          return materialized;
+        },
+      );
+      (CloudStorage.readdir as jest.Mock).mockResolvedValue([]);
+      (CloudStorage.triggerSync as jest.Mock).mockImplementation(async () => {
+        materialized = true;
+      });
+      (CloudStorage.readFile as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(
+        result.current.download({
+          syncTimeoutMs: 200,
+          pollIntervalMs: 10,
+          remoteProbeAttempts: 3,
+        }),
+      ).resolves.toEqual(mockMnemonic);
+      expect(CloudStorage.readdir).toHaveBeenCalled();
     });
 
     it('skips the sync machinery entirely when the file is already local', async () => {

--- a/app/tests/src/services/cloud-backup.test.ts
+++ b/app/tests/src/services/cloud-backup.test.ts
@@ -11,6 +11,12 @@ import { renderHook } from '@testing-library/react-native';
 import { useBackupMnemonic } from '@/services/cloud-backup';
 import type { CloudBackupError } from '@/services/cloud-backup/errors';
 import { createGDrive } from '@/services/cloud-backup/google';
+import {
+  ENCRYPTED_FILE_PATH,
+  FILE_NAME,
+  FOLDER,
+  PLACEHOLDER_FILE_PATH,
+} from '@/services/cloud-backup/helpers';
 
 type SupportedPlatforms = 'ios' | 'android';
 
@@ -66,7 +72,9 @@ jest.mock('react-native-cloud-storage', () => ({
     writeFile: jest.fn(),
     exists: jest.fn(),
     readFile: jest.fn(),
+    readdir: jest.fn(),
     rmdir: jest.fn(),
+    triggerSync: jest.fn(),
     isCloudAvailable: jest.fn(),
   },
   CloudStorageScope: {
@@ -132,6 +140,8 @@ describe('cloudBackup', () => {
     (GDrive as jest.Mock).mockImplementation(() => mockGDriveInstance);
     (ethers.Mnemonic.isValidMnemonic as jest.Mock).mockReturnValue(true);
     (CloudStorage.isCloudAvailable as jest.Mock).mockResolvedValue(true);
+    (CloudStorage.readdir as jest.Mock).mockResolvedValue([]);
+    (CloudStorage.triggerSync as jest.Mock).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -524,6 +534,114 @@ describe('cloudBackup', () => {
           reason: 'backup_read_failed',
         });
       });
+
+      it('reports a backup that never finishes syncing as not synced', async () => {
+        // Placeholder visible, plain file never materialises.
+        (CloudStorage.exists as jest.Mock).mockImplementation(
+          async (path: string) => path === PLACEHOLDER_FILE_PATH,
+        );
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(
+          await rejectionReason(() =>
+            result.current.download({ syncTimeoutMs: 50, pollIntervalMs: 10 }),
+          ),
+        ).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_not_synced',
+        });
+      });
+
+      it('treats a placeholder found via the folder listing as not synced, not absent', async () => {
+        (CloudStorage.exists as jest.Mock).mockResolvedValue(false);
+        (CloudStorage.readdir as jest.Mock).mockResolvedValue([
+          `.${FILE_NAME}.icloud`,
+        ]);
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(
+          await rejectionReason(() =>
+            result.current.download({ syncTimeoutMs: 50, pollIntervalMs: 10 }),
+          ),
+        ).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_not_synced',
+        });
+      });
+
+      it('reports no backup when the folder lists only unrelated files', async () => {
+        (CloudStorage.exists as jest.Mock).mockResolvedValue(false);
+        (CloudStorage.readdir as jest.Mock).mockResolvedValue([
+          'unrelated-file',
+        ]);
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(await rejectionReason(result.current.download)).toEqual({
+          name: 'CloudBackupError',
+          reason: 'no_backup_found',
+        });
+        expect(CloudStorage.triggerSync).not.toHaveBeenCalled();
+      });
+
+      it('reports no backup when the folder listing keeps failing', async () => {
+        // ERR_READ_ERROR is what a never-created folder throws; after the
+        // probe budget it must read as "no backup", not as a read failure.
+        (CloudStorage.exists as jest.Mock).mockResolvedValue(false);
+        (CloudStorage.readdir as jest.Mock).mockRejectedValue(
+          Object.assign(new Error('read failed'), { code: 'ERR_READ_ERROR' }),
+        );
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(
+          await rejectionReason(() =>
+            result.current.download({
+              remoteProbeAttempts: 1,
+              pollIntervalMs: 10,
+            }),
+          ),
+        ).toEqual({
+          name: 'CloudBackupError',
+          reason: 'no_backup_found',
+        });
+      });
+
+      it('aborts the sync wait when the exists check itself rejects', async () => {
+        // The container going nil mid-poll (signed out) is structural, not
+        // transient — the user must not wait out the full budget for it.
+        let plainExistsCalls = 0;
+        (CloudStorage.exists as jest.Mock).mockImplementation(
+          async (path: string) => {
+            if (path === PLACEHOLDER_FILE_PATH) {
+              return true;
+            }
+            plainExistsCalls += 1;
+            if (plainExistsCalls === 1) {
+              return false;
+            }
+            throw Object.assign(new Error('container gone'), {
+              code: 'ERR_DIRECTORY_NOT_FOUND',
+            });
+          },
+        );
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(
+          await rejectionReason(() =>
+            result.current.download({
+              syncTimeoutMs: 500,
+              pollIntervalMs: 10,
+            }),
+          ),
+        ).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_read_failed',
+        });
+      });
     });
 
     describe('Android', () => {
@@ -582,6 +700,97 @@ describe('cloudBackup', () => {
           reason: 'backup_read_failed',
         });
       });
+    });
+  });
+
+  describe('iOS sync wait', () => {
+    beforeEach(() => {
+      mockPlatform.OS = 'ios';
+    });
+
+    it('triggers the iCloud download for a placeholder and reads the file once it lands', async () => {
+      let materialized = false;
+      (CloudStorage.exists as jest.Mock).mockImplementation(
+        async (path: string) =>
+          path === PLACEHOLDER_FILE_PATH ? !materialized : materialized,
+      );
+      let syncCalls = 0;
+      (CloudStorage.triggerSync as jest.Mock).mockImplementation(async () => {
+        syncCalls += 1;
+        // Two paths are synced per tick; land the file on the second tick.
+        if (syncCalls >= 4) {
+          materialized = true;
+        }
+      });
+      (CloudStorage.readFile as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      const downloaded = await result.current.download({
+        syncTimeoutMs: 500,
+        pollIntervalMs: 10,
+      });
+
+      expect(downloaded).toEqual(mockMnemonic);
+      // Apple doesn't document which of the two paths isUbiquitousItem
+      // accepts for a non-materialised item, so both must be requested.
+      expect(CloudStorage.triggerSync).toHaveBeenCalledWith(
+        ENCRYPTED_FILE_PATH,
+      );
+      expect(CloudStorage.triggerSync).toHaveBeenCalledWith(
+        PLACEHOLDER_FILE_PATH,
+      );
+    });
+
+    it('still restores when the sync request is rejected but the file lands anyway', async () => {
+      let plainExistsCalls = 0;
+      (CloudStorage.exists as jest.Mock).mockImplementation(
+        async (path: string) => {
+          if (path === PLACEHOLDER_FILE_PATH) {
+            return true;
+          }
+          plainExistsCalls += 1;
+          return plainExistsCalls >= 2;
+        },
+      );
+      (CloudStorage.triggerSync as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('not downloadable'), {
+          code: 'ERR_FILE_NOT_DOWNLOADABLE',
+        }),
+      );
+      (CloudStorage.readFile as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(
+        result.current.download({ syncTimeoutMs: 500, pollIntervalMs: 10 }),
+      ).resolves.toEqual(mockMnemonic);
+    });
+
+    it('skips the sync machinery entirely when the file is already local', async () => {
+      (CloudStorage.exists as jest.Mock).mockResolvedValue(true);
+      (CloudStorage.readFile as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.download()).resolves.toEqual(mockMnemonic);
+      expect(CloudStorage.readdir).not.toHaveBeenCalled();
+      expect(CloudStorage.triggerSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backup path constants', () => {
+    it('keeps the placeholder, file and folder paths on the same file', () => {
+      // disableBackup rmdirs FOLDER; upload writes ENCRYPTED_FILE_PATH; the
+      // placeholder probe reads PLACEHOLDER_FILE_PATH. All three must agree.
+      expect(ENCRYPTED_FILE_PATH).toBe(`/${FOLDER}/${FILE_NAME}`);
+      expect(PLACEHOLDER_FILE_PATH).toBe(`/${FOLDER}/.${FILE_NAME}.icloud`);
     });
   });
 


### PR DESCRIPTION
Closes [SELF-3933](https://linear.app/selfprotocol/issue/SELF-3933/ios-restore-fails-when-the-icloud-backup-file-has-not-downloaded-yet).

**Stack: #2272 → #2273 → this.** Base is `self-3932-restore-failure-visibility`; retarget as the stack merges.

## Problem

`ios.ts download()` gated on `CloudStorage.exists()` — natively a plain `FileManager.fileExists(atPath:)`. iCloud syncs metadata eagerly but file contents lazily: on a fresh device the backup exists only as a `.encrypted-private-key.icloud` placeholder until something calls `startDownloadingUbiquitousItem`. Nothing ever did (`triggerSync()` was unused), so `exists` stayed false and the user was told "no backup found" — on a fresh install, exactly when restore matters (SELF-2486's repro).

## Changes

- **`hasRemoteBackup()` discriminator** — after the local-file check fails: probe `exists(PLACEHOLDER_FILE_PATH)` (throw-free), then fall back to `readdir(FOLDER)` matching any entry containing the filename (tolerates placeholder-naming variants). A *successful* listing is authoritative; a *rejected* listing is ambiguous — native `contentsOfDirectory` throws the same `ERR_READ_ERROR` for "folder never created" and a genuine read failure — so rejection gets `remoteProbeAttempts` re-probes before concluding "no backup", giving a fresh device's folder metadata a window to arrive instead of a false terminal "no backup found".
- **`waitForBackupFile()` sync wait** — fires `triggerSync` at **both** the plain and placeholder paths (`Promise.allSettled`) on every poll tick, then polls `exists` against a deadline. Both paths because Apple doesn't document which URL `isUbiquitousItem` accepts for a non-materialized item and the wrong one throws instead of enqueueing; every tick because the enqueue is idempotent and a single dropped request must not strand the user in a dead retry loop. The poll is the arbiter regardless of what `triggerSync` reports.
- **New `backup_not_synced` reason + copy** — "Your backup is still syncing from iCloud. Keep the app open and try again in a moment." Distinct from `no_backup_found` in both UI and the analytics `reason` (AC3). Flows through the choice screen automatically via the `CloudBackupErrorReason` union from #2273.
- **`PLACEHOLDER_FILE_PATH` in helpers.ts**, adjacent to `ENCRYPTED_FILE_PATH` (now derived from `FILE_NAME` so they can't diverge).
- **`IosDownloadOptions`** (`syncTimeoutMs` 30s / `pollIntervalMs` 1s / `remoteProbeAttempts` 3) forwarded by `index.ts` on the iOS branch only — production callers pass nothing; tests inject tiny budgets instead of fake timers.

## AC status

- AC1 (isCloudAvailable guard): shipped in #2273, unchanged here.
- AC2: **deliberate deviation** — the AC says triggerSync/exists/readFile "all inside `withRetries`". `withRetries` retries on throw and destroys the original error at exhaustion; it can't express a boolean poll and would erase the error codes classification needs. Instead the bounded 30s deadline poll *is* the retry for `exists` (vs `withRetries`' ~9s — satisfying the AC's intent, "a budget suited to first sync"), `triggerSync` is repeated fire-and-forget with the poll as arbiter, and `readFile` keeps `withRetries` as before.
- AC3: `backup_not_synced` vs `no_backup_found` in copy + `reason`.
- AC4: verified moot — native `FileUtils.sanitizePath` strips `^/+`, so the `//` vs `/` JS constants resolve to the same container path; a JS-layer path-consistency test pins the three constants to the same folder/filename.

## Assumptions / notes for reviewers

- Placeholder naming `.name.icloud` is Apple convention, not contract. The `readdir` `includes(FILE_NAME)` fallback tolerates variants; if both probes miss, behavior degrades to today's (no regression).
- Whether `isUbiquitousItem` accepts the plain path for a placeholder is undocumented — the double-fire makes it moot in code, but only fresh-device QA proves materialization end-to-end.
- Metadata lag beyond the ~3s probe budget still reads as "no backup found"; not closable without NSMetadataQuery, which this library doesn't expose. Code comment in `hasRemoteBackup`.
- Worst-case UX ≈ 40s of "Recovering…" (30s poll + ~9s readFile retries) before `backup_not_synced`.
- Future cheap add (not scope): a `syncWaited` property on `CLOUD_RESTORE_SUCCESS` to size this fix's impact.

## Validation

```
pnpm --filter @selfxyz/mobile-app run test    # 1271 passed, 111 suites (10 net new)
pnpm --filter @selfxyz/mobile-app run types   # clean
pnpm --filter @selfxyz/mobile-app run lint    # 0 errors
```

All 31 pre-existing cloud-backup tests pass with zero body edits (mock factory + beforeEach defaults only). New coverage: placeholder → triggerSync at both paths → materializes → restores; never materializes → `backup_not_synced`; `triggerSync` rejected but file lands → still restores; placeholder found via folder listing → sync wait; unrelated listing → instant `no_backup_found` with `triggerSync` never called; persistent listing failure → probes exhaust → `no_backup_found`; already-local file skips the sync machinery entirely; `exists` rejecting mid-poll aborts to `backup_read_failed`; path-constant consistency.

**Device QA required — unit tests cannot substitute** (simulator iCloud is flaky; real devices only):
1. Backup on device A → fresh install on device B (same Apple ID) → restore immediately. Must succeed, never "did you back it up previously?". This is the test that proves placeholder naming, `triggerSync` materialization and the 30s budget.
2. Signed out of iCloud → "sign in to iCloud" (shipped in #2273, re-verify).
3. Never backed up → "no backup found".
4. Enable then disable backup → restore → "no backup found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iCloud backup recovery when a backup exists but has not finished syncing to the device.
  * The app now waits briefly for the backup to become available and provides a clear retry message if syncing remains incomplete.
  * Distinguishes between unavailable backups and backups still downloading from iCloud.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->