### PR TITLE
fix(app): truthful Drive OAuth errors, visible backup-enable failures, frozen backup path (SELF-3934, SELF-3935)

### DIFF
--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -928,6 +928,7 @@ jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
     CLOUD_BACKUP_DISABLED_DONE: 'Backup: Cloud Backup Disabled Done',
     CLOUD_BACKUP_DISABLE_STARTED: 'Backup: Cloud Backup Disable Started',
     CLOUD_BACKUP_ENABLED_DONE: 'Backup: Cloud Backup Enabled Done',
+    CLOUD_BACKUP_ENABLE_FAILED: 'Backup: Cloud Backup Enable Failed',
     CLOUD_BACKUP_ENABLE_STARTED: 'Backup: Cloud Backup Enable Started',
     CLOUD_BACKUP_STARTED: 'Backup: Cloud Backup Started',
     CLOUD_RESTORE_FAILED_AUTH:
@@ -935,6 +936,7 @@ jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
     CLOUD_RESTORE_FAILED_PASSPORT_NOT_REGISTERED:
       'Backup: Cloud Restore Failed: Passport Not Registered',
     CLOUD_RESTORE_FAILED_UNKNOWN: 'Backup: Cloud Restore Failed: Unknown Error',
+    CLOUD_RESTORE_STARTED: 'Backup: Cloud Restore Started',
     CLOUD_RESTORE_SUCCESS: 'Backup: Cloud Restore Success',
     TURNKEY_RESTORE_FAILED: 'Backup: Turnkey Restore Failed',
     CREATE_NEW_ACCOUNT: 'Backup: Create New Account',

--- a/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
@@ -59,7 +59,7 @@ import type { Mnemonic } from '@/types/mnemonic';
 type CloudRecoveryError =
   | CloudBackupErrorReason
   | 'secret_storage_failed'
-  | 'not_registered'
+  | 'backup_not_registered'
   | 'network_error'
   | 'unexpected_error';
 
@@ -149,7 +149,7 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
               hasCSCA: !!csca,
             },
           );
-          setError('not_registered');
+          setError('backup_not_registered');
           setRestoring(false);
           return false;
         }

--- a/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
@@ -4,7 +4,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
-import { Separator, Text, View, XStack, YStack } from 'tamagui';
+import { Separator, View, XStack, YStack } from 'tamagui';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
@@ -13,6 +13,7 @@ import {
   useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
 import {
+  BodyText,
   Caption,
   Description,
   PrimaryButton,
@@ -275,7 +276,9 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
           <Description>{recoveryCopy.choice.description}</Description>
 
           {error && (
-            <Text style={styles.errorText}>{recoveryCopy.errors[error]}</Text>
+            <BodyText style={styles.errorText}>
+              {recoveryCopy.errors[error]}
+            </BodyText>
           )}
 
           <YStack gap="$2.5" width="100%" paddingTop="$6">
@@ -302,9 +305,9 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
               {recoveryCopy.choice.actions.cloud(restoringFromCloud)}
             </PrimaryButton>
             {!biometricsAvailable && (
-              <Text style={styles.noticeText}>
+              <BodyText style={styles.noticeText}>
                 {recoveryCopy.choice.noBiometrics}
-              </Text>
+              </BodyText>
             )}
             <XStack gap={64} alignItems="center" justifyContent="space-between">
               <Separator flexGrow={1} />

--- a/app/src/screens/account/recovery/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/account/recovery/RecoverWithPhraseScreen.tsx
@@ -15,6 +15,7 @@ import {
   useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
 import {
+  BodyText,
   Description,
   SecondaryButton,
 } from '@selfxyz/mobile-sdk-alpha/components';
@@ -198,7 +199,9 @@ const RecoverWithPhraseScreen: React.FC = () => {
       </View>
 
       {error && (
-        <Text style={styles.errorText}>{recoveryCopy.errors[error]}</Text>
+        <BodyText style={styles.errorText}>
+          {recoveryCopy.errors[error]}
+        </BodyText>
       )}
 
       <SecondaryButton

--- a/app/src/screens/account/recovery/recoveryCopy.ts
+++ b/app/src/screens/account/recovery/recoveryCopy.ts
@@ -62,6 +62,10 @@ export const recoveryCopy = {
       'We found your backup but couldn’t save it securely on this device. Make sure your device lock is set up, then try again.',
     not_registered:
       'This recovery phrase doesn’t match a registered ID. If you registered with a different phrase, try that one instead.',
+    // The cloud path: a backup exists on the account, so Self was used
+    // before — just not with the document on this device. The app holds one
+    // secret per install, so the only usable exit is this document's phrase.
+    backup_not_registered: `We found a Self backup in ${STORAGE_NAME}, but it’s not the one used with this document. Enter the recovery phrase you used with this document instead.`,
     network_error:
       'We couldn’t reach the Self network to verify your ID. Check your connection and try again.',
     unexpected_error: 'Something went wrong. Please try again.',

--- a/app/src/screens/account/recovery/recoveryCopy.ts
+++ b/app/src/screens/account/recovery/recoveryCopy.ts
@@ -47,6 +47,7 @@ export const recoveryCopy = {
     no_backup_found: `We couldn’t find a backup in ${STORAGE_NAME}. Backups don’t move between platforms — one made on Android can’t be restored on iPhone, and one made on iPhone can’t be restored on Android. Use your recovery phrase instead.`,
     cloud_unavailable: `Sign in to ${STORAGE_NAME} in your device settings, then try again. You can also recover with your recovery phrase.`,
     sign_in_cancelled: `The ${STORAGE_NAME} sign-in was dismissed before it finished. Try again, or use your recovery phrase.`,
+    sign_in_failed: `Something went wrong signing in to ${STORAGE_NAME}. Try again, or recover with your recovery phrase.`,
     backup_corrupt: `We found a backup in ${STORAGE_NAME} but couldn’t read it. Recover with your recovery phrase instead.`,
     backup_read_failed: `We couldn’t reach ${STORAGE_NAME}. Check your connection and try again.`,
     backup_not_synced: `Your backup is still syncing from ${STORAGE_NAME}. Keep the app open and try again in a moment.`,

--- a/app/src/screens/account/settings/CloudBackupScreen.tsx
+++ b/app/src/screens/account/settings/CloudBackupScreen.tsx
@@ -33,6 +33,7 @@ import { buttonTap, confirmTap } from '@/integrations/haptics';
 import type { RootStackParamList } from '@/navigation';
 import { useAuth } from '@/providers/authProvider';
 import { STORAGE_NAME, useBackupMnemonic } from '@/services/cloud-backup';
+import { isCloudBackupError } from '@/services/cloud-backup/errors';
 import { useSettingStore } from '@/stores/settingStore';
 
 type NextScreen = keyof Pick<RootStackParamList, 'SaveRecoveryPhrase'>;
@@ -180,7 +181,21 @@ const CloudBackupScreen: React.FC<CloudBackupScreenProps> = ({
         navigation.navigate(params.returnToScreen);
       }
     } catch (error) {
-      console.error('iCloud backup error', error);
+      console.error('Cloud backup enable error', error);
+      const reason = isCloudBackupError(error)
+        ? error.reason
+        : 'unexpected_error';
+      trackEvent(BackupEvents.CLOUD_BACKUP_ENABLE_FAILED, {
+        reason,
+        error: error instanceof Error ? error.name : 'unknown',
+      });
+      // A dismissed sign-in sheet is the user's own doing — no alert for it.
+      if (reason !== 'sign_in_cancelled') {
+        Alert.alert(
+          'Error',
+          'Failed to enable cloud backups. Please try again.',
+        );
+      }
     } finally {
       setICloudPending(false);
     }

--- a/app/src/screens/account/settings/CloudBackupScreen.tsx
+++ b/app/src/screens/account/settings/CloudBackupScreen.tsx
@@ -35,6 +35,7 @@ import { useAuth } from '@/providers/authProvider';
 import { STORAGE_NAME, useBackupMnemonic } from '@/services/cloud-backup';
 import { isCloudBackupError } from '@/services/cloud-backup/errors';
 import { useSettingStore } from '@/stores/settingStore';
+import { isUserCancellation } from '@/utils/keychainErrors';
 
 type NextScreen = keyof Pick<RootStackParamList, 'SaveRecoveryPhrase'>;
 
@@ -182,15 +183,23 @@ const CloudBackupScreen: React.FC<CloudBackupScreenProps> = ({
       }
     } catch (error) {
       console.error('Cloud backup enable error', error);
+      // getOrCreateMnemonic rethrows raw keychain errors, so a dismissed
+      // biometric prompt arrives here untyped rather than as a CloudBackupError.
       const reason = isCloudBackupError(error)
         ? error.reason
-        : 'unexpected_error';
+        : isUserCancellation(error)
+          ? 'authentication_cancelled'
+          : 'unexpected_error';
       trackEvent(BackupEvents.CLOUD_BACKUP_ENABLE_FAILED, {
         reason,
         error: error instanceof Error ? error.name : 'unknown',
       });
-      // A dismissed sign-in sheet is the user's own doing — no alert for it.
-      if (reason !== 'sign_in_cancelled') {
+      // A dismissed sign-in sheet or biometric prompt is the user's own
+      // doing — no alert for those.
+      if (
+        reason !== 'sign_in_cancelled' &&
+        reason !== 'authentication_cancelled'
+      ) {
         Alert.alert(
           'Error',
           'Failed to enable cloud backups. Please try again.',

--- a/app/src/services/cloud-backup/errors.ts
+++ b/app/src/services/cloud-backup/errors.ts
@@ -10,6 +10,12 @@
 export type CloudBackupErrorReason =
   /** Android only: the Google sign-in sheet returned no account. */
   | 'sign_in_cancelled'
+  /**
+   * Android only: the Google sign-in ended in an error — misconfiguration,
+   * revoked consent or a network failure — rather than a completed sign-in
+   * or a user cancel.
+   */
+  | 'sign_in_failed'
   /** iOS only: iCloud Drive is off or the device is signed out of iCloud. */
   | 'cloud_unavailable'
   /** Reached the provider, but this account holds no backup file. */

--- a/app/src/services/cloud-backup/google.ts
+++ b/app/src/services/cloud-backup/google.ts
@@ -12,6 +12,7 @@ import {
   googleOAuthAuthorizationEndpoint,
   googleOAuthTokenEndpoint,
 } from '@/consts/links';
+import { CloudBackupError } from '@/services/cloud-backup/errors';
 
 // Ensure the client ID is available at runtime (skip in test environment)
 const isTestEnvironment =
@@ -47,11 +48,38 @@ export async function createGDrive() {
   return gdrive;
 }
 
+/**
+ * A user cancel is only recognisable by its message on Android ("User
+ * cancelled flow"), except tapping Deny on Google's consent page, which
+ * arrives as the OAuth code `access_denied`. iOS dismissals produce a generic
+ * "error -3" message this cannot match — acceptable, since backup routes iOS
+ * to iCloud and never reaches this flow.
+ */
+function isSignInCancellation(error: unknown): boolean {
+  if ((error as { code?: unknown })?.code === 'access_denied') {
+    return true;
+  }
+  return error instanceof Error && /cancel/i.test(error.message);
+}
+
+/**
+ * @returns the authorization result, or null when the user cancelled. Any
+ * other failure — misconfiguration, revoked consent, no network — throws,
+ * so it is never mistaken for a cancel.
+ */
 export async function googleSignIn(): Promise<AuthorizeResult | null> {
   try {
     return await authorize(config);
   } catch (error) {
+    if (isSignInCancellation(error)) {
+      return null;
+    }
     console.error(error);
-    return null;
+    const code = (error as { code?: unknown })?.code;
+    throw new CloudBackupError(
+      'sign_in_failed',
+      `Google sign-in failed${typeof code === 'string' ? ` (${code})` : ''}`,
+      { cause: error },
+    );
   }
 }

--- a/app/src/services/cloud-backup/helpers.ts
+++ b/app/src/services/cloud-backup/helpers.ts
@@ -5,14 +5,14 @@
 import { Platform } from 'react-native';
 import { CloudStorage, CloudStorageScope } from 'react-native-cloud-storage';
 
-import { name } from '../../../package.json';
-
-const packageName = name?.startsWith('@') ? name : '@selfxyz/mobile-app';
-const folder = `/${packageName}`;
+// Frozen literal: backups live at this path in users' cloud accounts, so it
+// must never follow the package name (which has already changed once, from
+// `openpassport`). Renaming the app must not move or orphan existing backups.
+const folder = '/@selfxyz/mobile-app';
 export const FILE_NAME = 'encrypted-private-key';
-export const ENCRYPTED_FILE_PATH = `/${folder}/${FILE_NAME}`;
+export const ENCRYPTED_FILE_PATH = `${folder}/${FILE_NAME}`;
 // The name iOS gives a not-yet-downloaded iCloud item in directory listings.
-export const PLACEHOLDER_FILE_PATH = `/${folder}/.${FILE_NAME}.icloud`;
+export const PLACEHOLDER_FILE_PATH = `${folder}/.${FILE_NAME}.icloud`;
 export const FOLDER = folder;
 
 if (Platform.OS === 'ios') {

--- a/app/src/services/cloud-backup/index.ts
+++ b/app/src/services/cloud-backup/index.ts
@@ -71,8 +71,8 @@ export async function download(options?: IosDownloadOptions) {
   try {
     const gdrive = await createGDrive();
     if (!gdrive) {
-      // `googleSignIn` swallows every `authorize` failure, so a genuine auth or
-      // network error is indistinguishable from a cancel here.
+      // `googleSignIn` only returns null for an actual user cancellation;
+      // every other failure throws a typed `sign_in_failed` before this.
       throw new CloudBackupError(
         'sign_in_cancelled',
         'User canceled Google sign-in',

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -162,6 +162,7 @@ jest.mock('@/screens/account/recovery/recoveryCopy', () => ({
       no_backup_found: 'Error: no backup found',
       cloud_unavailable: 'Error: sign in to the cloud provider',
       sign_in_cancelled: 'Error: sign-in was dismissed',
+      sign_in_failed: 'Error: sign-in ended in an error',
       backup_corrupt: 'Error: backup could not be read',
       backup_read_failed: 'Error: could not reach the cloud provider',
       backup_not_synced: 'Error: still downloading from the cloud provider',
@@ -409,6 +410,7 @@ describe('AccountRecoveryChoiceScreen', () => {
 
   describe.each([
     ['sign_in_cancelled'],
+    ['sign_in_failed'],
     ['cloud_unavailable'],
     ['no_backup_found'],
     ['backup_not_synced'],

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -63,6 +63,9 @@ jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
 }));
 
 jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  BodyText: ({ children, ...props }: any) => (
+    <mock-text {...props}>{children}</mock-text>
+  ),
   Caption: ({ children, ...props }: any) => (
     <mock-text {...props}>{children}</mock-text>
   ),

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -171,7 +171,7 @@ jest.mock('@/screens/account/recovery/recoveryCopy', () => ({
       backup_not_synced: 'Error: still downloading from the cloud provider',
       restore_failed: 'Error: could not restore with this phrase',
       secret_storage_failed: 'Error: could not save securely on this device',
-      not_registered: 'Error: phrase does not match a registered ID',
+      backup_not_registered: 'Error: backup not used with this document',
       network_error: 'Error: could not reach the Self network',
       unexpected_error: 'Error: something went wrong',
     },
@@ -367,7 +367,9 @@ describe('AccountRecoveryChoiceScreen', () => {
     // Must read as retryable, never as "your document isn't registered" — the
     // registry was never reached, so registration was never actually checked.
     expect(renderedText()).toContain(recoveryCopy.errors.network_error);
-    expect(renderedText()).not.toContain(recoveryCopy.errors.not_registered);
+    expect(renderedText()).not.toContain(
+      recoveryCopy.errors.backup_not_registered,
+    );
     expect(mockToggleCloudBackupEnabled()).not.toHaveBeenCalled();
     expect(mockRestoreSuccessNavigation).not.toHaveBeenCalled();
     expect(markCurrentDocumentAsRegistered).not.toHaveBeenCalled();
@@ -455,7 +457,7 @@ describe('AccountRecoveryChoiceScreen', () => {
     expect(renderedText()).not.toContain(recoveryCopy.errors.restore_failed);
   });
 
-  it('explains an unregistered document without blaming the network', async () => {
+  it('explains a mismatched backup without blaming the network or a phrase', async () => {
     mockCheckRegistration.mockResolvedValue({
       isRegistered: false,
       csca: null,
@@ -469,7 +471,9 @@ describe('AccountRecoveryChoiceScreen', () => {
         { reason: 'document_not_registered', hasCSCA: false },
       );
     });
-    expect(renderedText()).toContain(recoveryCopy.errors.not_registered);
+    // The user typed nothing on this path — the copy must speak about the
+    // backup, not about a recovery phrase they never entered.
+    expect(renderedText()).toContain(recoveryCopy.errors.backup_not_registered);
     expect(renderedText()).not.toContain(recoveryCopy.errors.network_error);
   });
 

--- a/app/tests/src/screens/account/recovery/RecoverWithPhraseScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/RecoverWithPhraseScreen.test.tsx
@@ -87,6 +87,9 @@ jest.mock('@/proving/checkRestoredDocumentRegistration', () => {
 });
 
 jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  BodyText: ({ children, ...props }: any) => (
+    <mock-text {...props}>{children}</mock-text>
+  ),
   Description: ({ children, ...props }: any) => (
     <mock-text {...props}>{children}</mock-text>
   ),

--- a/app/tests/src/screens/account/settings/CloudBackupScreen.test.tsx
+++ b/app/tests/src/screens/account/settings/CloudBackupScreen.test.tsx
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import CloudBackupScreen from '@/screens/account/settings/CloudBackupScreen';
+// The real error class, so `isCloudBackupError` is exercised rather than stubbed.
+import { CloudBackupError } from '@/services/cloud-backup/errors';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'mock-view': any;
+      'mock-text': any;
+      'mock-stack': any;
+      'mock-button': any;
+      'mock-icon': any;
+    }
+  }
+}
+
+// The global react-native mock (jest.setup.js) exports no Alert; patch one onto
+// the mocked module object — babel resolves `Alert.alert` at call time.
+const mockAlert = jest.fn();
+(jest.requireMock('react-native') as { Alert?: unknown }).Alert = {
+  alert: mockAlert,
+};
+
+jest.mock('tamagui', () => ({
+  __esModule: true,
+  YStack: ({ children, ...props }: any) => (
+    <mock-stack {...props}>{children}</mock-stack>
+  ),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(() => ({ navigate: jest.fn() })),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  hasAnyValidRegisteredDocument: jest.fn(),
+  useSelfClient: jest.fn(),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  PrimaryButton: ({ children, onPress, disabled, ...props }: any) => (
+    <mock-button onPress={onPress} disabled={disabled} {...props}>
+      {children}
+    </mock-button>
+  ),
+  SecondaryButton: ({ children, onPress, disabled, ...props }: any) => (
+    <mock-button onPress={onPress} disabled={disabled} {...props}>
+      {children}
+    </mock-button>
+  ),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
+  BackupEvents: {
+    CLOUD_BACKUP_CANCELLED: 'CLOUD_BACKUP_CANCELLED',
+    CLOUD_BACKUP_CONTINUE: 'CLOUD_BACKUP_CONTINUE',
+    CLOUD_BACKUP_DISABLED_DONE: 'CLOUD_BACKUP_DISABLED_DONE',
+    CLOUD_BACKUP_DISABLE_STARTED: 'CLOUD_BACKUP_DISABLE_STARTED',
+    CLOUD_BACKUP_ENABLED_DONE: 'CLOUD_BACKUP_ENABLED_DONE',
+    CLOUD_BACKUP_ENABLE_FAILED: 'CLOUD_BACKUP_ENABLE_FAILED',
+    CLOUD_BACKUP_ENABLE_STARTED: 'CLOUD_BACKUP_ENABLE_STARTED',
+    MANUAL_RECOVERY_SELECTED: 'MANUAL_RECOVERY_SELECTED',
+  },
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/colors', () => ({
+  black: '#000',
+  blue600: '#00f',
+  slate200: '#ccc',
+  slate500: '#555',
+  white: '#fff',
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/fonts', () => ({
+  advercase: 'Advercase',
+  dinot: 'DINOT',
+}));
+
+jest.mock('@/hooks/useModal', () => ({
+  // Imports navigationRef and drags in the whole navigation tree otherwise.
+  useModal: jest.fn(() => ({ showModal: jest.fn(), dismissModal: jest.fn() })),
+}));
+
+jest.mock('@/integrations/haptics', () => ({
+  buttonTap: jest.fn(),
+  confirmTap: jest.fn(),
+}));
+
+jest.mock('@/providers/authProvider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/services/cloud-backup', () => ({
+  STORAGE_NAME: 'iCloud',
+  useBackupMnemonic: jest.fn(),
+}));
+
+jest.mock('@/stores/settingStore', () => {
+  const { create } = jest.requireActual('zustand');
+  return {
+    useSettingStore: create(
+      (set: (partial: Record<string, unknown>) => void) => ({
+        cloudBackupEnabled: false,
+        toggleCloudBackupEnabled: jest.fn(),
+        biometricsAvailable: true,
+        setBiometricsAvailable: (biometricsAvailable: boolean) =>
+          set({ biometricsAvailable }),
+      }),
+    ),
+  };
+});
+
+const { useSelfClient, hasAnyValidRegisteredDocument } = jest.requireMock(
+  '@selfxyz/mobile-sdk-alpha',
+) as { useSelfClient: jest.Mock; hasAnyValidRegisteredDocument: jest.Mock };
+const { useAuth } = jest.requireMock('@/providers/authProvider') as {
+  useAuth: jest.Mock;
+};
+const { useBackupMnemonic } = jest.requireMock('@/services/cloud-backup') as {
+  useBackupMnemonic: jest.Mock;
+};
+const { useSettingStore } = jest.requireMock('@/stores/settingStore') as {
+  useSettingStore: {
+    getState: () => { toggleCloudBackupEnabled: jest.Mock };
+    setState: (partial: Record<string, unknown>) => void;
+  };
+};
+
+describe('CloudBackupScreen', () => {
+  const mockTrackEvent = jest.fn();
+  const mockUpload = jest.fn();
+  const mockGetOrCreateMnemonic = jest.fn();
+  const toggle = () => useSettingStore.getState().toggleCloudBackupEnabled;
+
+  function pressEnableBackup() {
+    const utils = render(
+      <CloudBackupScreen route={{ params: undefined }} {...({} as any)} />,
+    );
+    // With cloudBackupEnabled false, the first pressable is the enable option.
+    // (The global RN mock renders Pressable as the string component 'Pressable'.)
+    fireEvent.press(utils.UNSAFE_getAllByType('Pressable' as any)[0]);
+    return utils;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAlert.mockClear();
+    useSelfClient.mockReturnValue({ trackEvent: mockTrackEvent });
+    hasAnyValidRegisteredDocument.mockResolvedValue(true);
+    useAuth.mockReturnValue({
+      getOrCreateMnemonic: mockGetOrCreateMnemonic,
+      loginWithBiometrics: jest.fn(),
+    });
+    useBackupMnemonic.mockReturnValue({
+      upload: mockUpload,
+      disableBackup: jest.fn(),
+    });
+    useSettingStore.setState({
+      cloudBackupEnabled: false,
+      toggleCloudBackupEnabled: jest.fn(),
+      biometricsAvailable: true,
+    });
+    mockGetOrCreateMnemonic.mockResolvedValue({ data: { phrase: 'words' } });
+  });
+
+  it('enables backup and reports success', async () => {
+    mockUpload.mockResolvedValue(undefined);
+
+    pressEnableBackup();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith('CLOUD_BACKUP_ENABLED_DONE');
+    });
+    expect(toggle()).toHaveBeenCalled();
+    expect(mockAlert).not.toHaveBeenCalled();
+  });
+
+  it('alerts and reports a reason when the upload fails', async () => {
+    mockUpload.mockRejectedValue(new Error('write failed'));
+
+    pressEnableBackup();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_BACKUP_ENABLE_FAILED',
+        { reason: 'unexpected_error', error: 'Error' },
+      );
+    });
+    expect(mockAlert).toHaveBeenCalledWith(
+      'Error',
+      'Failed to enable cloud backups. Please try again.',
+    );
+    // A failed enable must leave the toggle off and never read as success.
+    expect(toggle()).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      'CLOUD_BACKUP_ENABLED_DONE',
+    );
+  });
+
+  it('reports a cancelled sign-in without nagging the user', async () => {
+    mockUpload.mockRejectedValue(
+      new CloudBackupError('sign_in_cancelled', 'User canceled Google sign-in'),
+    );
+
+    pressEnableBackup();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_BACKUP_ENABLE_FAILED',
+        { reason: 'sign_in_cancelled', error: 'CloudBackupError' },
+      );
+    });
+    // The user dismissed the sheet themselves — an error alert would be noise.
+    expect(mockAlert).not.toHaveBeenCalled();
+    expect(toggle()).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/src/screens/account/settings/CloudBackupScreen.test.tsx
+++ b/app/tests/src/screens/account/settings/CloudBackupScreen.test.tsx
@@ -204,6 +204,27 @@ describe('CloudBackupScreen', () => {
     );
   });
 
+  it('reports a dismissed biometric prompt without nagging the user', async () => {
+    // getOrCreateMnemonic rethrows the raw keychain cancellation — it is not
+    // a CloudBackupError, but it must not read as a failure either.
+    mockGetOrCreateMnemonic.mockRejectedValue(
+      Object.assign(new Error('User canceled the operation'), {
+        code: 'USER_CANCELED',
+      }),
+    );
+
+    pressEnableBackup();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_BACKUP_ENABLE_FAILED',
+        { reason: 'authentication_cancelled', error: 'Error' },
+      );
+    });
+    expect(mockAlert).not.toHaveBeenCalled();
+    expect(toggle()).not.toHaveBeenCalled();
+  });
+
   it('reports a cancelled sign-in without nagging the user', async () => {
     mockUpload.mockRejectedValue(
       new CloudBackupError('sign_in_cancelled', 'User canceled Google sign-in'),

--- a/app/tests/src/services/cloud-backup-google.test.ts
+++ b/app/tests/src/services/cloud-backup-google.test.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { authorize } from 'react-native-app-auth';
+
+import { isCloudBackupError } from '@/services/cloud-backup/errors';
+import { googleSignIn } from '@/services/cloud-backup/google';
+
+// Rejections shaped like react-native-app-auth's native promise.reject(code, message).
+function nativeAuthError(message: string, code: string) {
+  return Object.assign(new Error(message), { code });
+}
+
+describe('googleSignIn', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('returns the authorization result on success', async () => {
+    (authorize as jest.Mock).mockResolvedValue({ accessToken: 'token' });
+
+    await expect(googleSignIn()).resolves.toEqual({ accessToken: 'token' });
+  });
+
+  it('returns null when the user dismisses the sign-in flow', async () => {
+    (authorize as jest.Mock).mockRejectedValue(
+      nativeAuthError('User cancelled flow', 'authentication_error'),
+    );
+
+    await expect(googleSignIn()).resolves.toBeNull();
+  });
+
+  it('returns null when the user denies consent', async () => {
+    (authorize as jest.Mock).mockRejectedValue(
+      nativeAuthError('access_denied', 'access_denied'),
+    );
+
+    await expect(googleSignIn()).resolves.toBeNull();
+  });
+
+  it.each([
+    ['browser_not_found', 'No suitable browser found'],
+    ['service_configuration_fetch_error', 'Failed to fetch configuration'],
+    // Network failures share the cancel code but not the cancel message, so
+    // they must surface as failures rather than hide behind "cancelled".
+    ['authentication_error', 'Network error'],
+  ])('rethrows %s as a typed sign-in failure', async (code, message) => {
+    const cause = nativeAuthError(message, code);
+    (authorize as jest.Mock).mockRejectedValue(cause);
+
+    const rejection = await googleSignIn().then(
+      () => {
+        throw new Error('expected googleSignIn to reject');
+      },
+      (error: unknown) => error,
+    );
+
+    expect(isCloudBackupError(rejection)).toBe(true);
+    expect((rejection as { reason: string }).reason).toBe('sign_in_failed');
+    expect((rejection as Error).message).toContain(code);
+    expect((rejection as { cause?: unknown }).cause).toBe(cause);
+  });
+});

--- a/app/tests/src/services/cloud-backup.test.ts
+++ b/app/tests/src/services/cloud-backup.test.ts
@@ -179,7 +179,7 @@ describe('cloudBackup', () => {
 
       expect(CloudStorage.mkdir).toHaveBeenCalledWith('/@selfxyz/mobile-app');
       expect(CloudStorage.writeFile).toHaveBeenCalledWith(
-        '//@selfxyz/mobile-app/encrypted-private-key',
+        '/@selfxyz/mobile-app/encrypted-private-key',
         JSON.stringify(mockMnemonic),
       );
     });
@@ -196,7 +196,7 @@ describe('cloudBackup', () => {
       ).resolves.toBeUndefined();
 
       expect(CloudStorage.writeFile).toHaveBeenCalledWith(
-        '//@selfxyz/mobile-app/encrypted-private-key',
+        '/@selfxyz/mobile-app/encrypted-private-key',
         JSON.stringify(mockMnemonic),
       );
     });
@@ -289,10 +289,10 @@ describe('cloudBackup', () => {
       const downloaded = await result.current.download();
 
       expect(CloudStorage.exists).toHaveBeenCalledWith(
-        '//@selfxyz/mobile-app/encrypted-private-key',
+        '/@selfxyz/mobile-app/encrypted-private-key',
       );
       expect(CloudStorage.readFile).toHaveBeenCalledWith(
-        '//@selfxyz/mobile-app/encrypted-private-key',
+        '/@selfxyz/mobile-app/encrypted-private-key',
       );
       expect(downloaded).toEqual(mockMnemonic);
       expect(ethers.Mnemonic.isValidMnemonic).toHaveBeenCalledWith(
@@ -843,8 +843,18 @@ describe('cloudBackup', () => {
     it('keeps the placeholder, file and folder paths on the same file', () => {
       // disableBackup rmdirs FOLDER; upload writes ENCRYPTED_FILE_PATH; the
       // placeholder probe reads PLACEHOLDER_FILE_PATH. All three must agree.
-      expect(ENCRYPTED_FILE_PATH).toBe(`/${FOLDER}/${FILE_NAME}`);
-      expect(PLACEHOLDER_FILE_PATH).toBe(`/${FOLDER}/.${FILE_NAME}.icloud`);
+      expect(ENCRYPTED_FILE_PATH).toBe(`${FOLDER}/${FILE_NAME}`);
+      expect(PLACEHOLDER_FILE_PATH).toBe(`${FOLDER}/.${FILE_NAME}.icloud`);
+    });
+
+    it('resolves to the exact path production backups already live at', () => {
+      // The native layer strips leading slashes before resolving, so THIS is
+      // the effective path in users' cloud accounts. It is frozen: neither a
+      // package rename nor slash-count cleanup may ever change it, or every
+      // existing backup is orphaned.
+      expect(ENCRYPTED_FILE_PATH.replace(/^\/+/, '')).toBe(
+        '@selfxyz/mobile-app/encrypted-private-key',
+      );
     });
   });
 

--- a/packages/mobile-sdk-alpha/src/constants/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/constants/analytics.ts
@@ -42,6 +42,7 @@ export const BackupEvents = {
   CLOUD_BACKUP_DISABLED_DONE: 'Backup: Cloud Backup Disabled Done',
   CLOUD_BACKUP_DISABLE_STARTED: 'Backup: Cloud Backup Disable Started',
   CLOUD_BACKUP_ENABLED_DONE: 'Backup: Cloud Backup Enabled Done',
+  CLOUD_BACKUP_ENABLE_FAILED: 'Backup: Cloud Backup Enable Failed',
   CLOUD_BACKUP_ENABLE_STARTED: 'Backup: Cloud Backup Enable Started',
   CLOUD_BACKUP_STARTED: 'Backup: Cloud Backup Started',
   CLOUD_RESTORE_FAILED_AUTH: 'Backup: Cloud Restore Failed: Authentication Failed',


### PR DESCRIPTION
Closes [SELF-3935](https://linear.app/selfprotocol/issue/SELF-3935/backup-enable-failures-are-silent-freeze-the-backup-folder-path). Part of [SELF-3934](https://linear.app/selfprotocol/issue/SELF-3934/android-every-drive-oauth-error-is-reported-as-user-cancelled) — its AC2 (GCP Console audit: client IDs per environment, registered SHA-1s vs the Play App Signing certificate, consent-screen status) cannot be done from the repo and stays open on the issue.

**Stack: #2272 → #2273 → #2277 → this.** Base is `self-3933-icloud-sync-restore`; retarget as the stack merges. Combined per reviewer agreement: the two issues touch the same files and share one theme.

## SELF-3934 — every Drive OAuth error read as "user cancelled"

`googleSignIn()` caught everything `authorize()` threw and returned null; callers then reported "sign-in cancelled". Android carries 635 of 701 unique restore-failure users, and misconfiguration was invisible inside the cancel bucket.

- `googleSignIn()` now returns null **only** for an actual cancellation, detected two ways (verified against RNAppAuthModule.java): message match (`/cancel/i` — Android cancel arrives as `authentication_error` / "User cancelled flow") and OAuth code `access_denied` (the user tapping Deny on Google's consent page — no "cancel" substring, but it IS a user cancel).
- Everything else rethrows `CloudBackupError('sign_in_failed')` with the native code embedded in the message and the original error as `cause`. **Network failures share the cancel code but not the cancel message** (`authentication_error` / "Network error"), so they now surface as failures — pinned by a test.
- The reason flows into the recovery choice screen (copy + analytics `reason`) through the existing `CloudBackupErrorReason` union — no screen changes.

## SELF-3935 — silent enable failures + fragile backup path

- **Enable failures surface.** The catch in `CloudBackupScreen` (previously `console.error` only — ~400 users in 30 days got nothing) now emits `CLOUD_BACKUP_ENABLE_FAILED { reason, error }` and shows an alert, matching the disable path's precedent. No alert when `reason` is `sign_in_cancelled` — the user dismissed the sheet themselves. The toggle already stayed off on failure (it flips only after the awaited upload); a test now pins that.
- **Frozen path.** The backup folder is a literal `'/@selfxyz/mobile-app'`, no longer derived from `package.json`'s `name` (which already changed once, from `openpassport` — a rename would silently orphan every backup). Double leading slash removed; the effective resolved path is byte-identical (native `sanitizePath` strips `^/+`), pinned by a test asserting the exact production path `@selfxyz/mobile-app/encrypted-private-key`. The iOS `setProviderOptions(AppData)` side effect is preserved.
- New SDK event `CLOUD_BACKUP_ENABLE_FAILED` (additive; also added to the jest.setup analytics mock — along with `CLOUD_RESTORE_STARTED`, which #2273 missed there).

## Notes for reviewers

- iOS sign-in cancels are not message-detectable (generic "error -3") — moot in production since backup routes iOS to iCloud and never reaches the Google flow; documented on the matcher.
- Side effect: real auth failures during *disable* now alert instead of silently "succeeding".
- Deliberately untouched (pre-existing): cancel-during-disable flips the toggle without deleting the Drive file; `CLOUD_BACKUP_DISABLE_STARTED` double-fire (button prop + handler); iOS upload has no `isCloudAvailable` pre-check (cloud-off enable fails as `unexpected_error` after retries); `getOrCreateMnemonic` returning null still exits silently after ENABLE_STARTED.

## Validation

```
pnpm --filter @selfxyz/mobile-sdk-alpha test/types/build   # 528 passed; madge clean
pnpm --filter @selfxyz/mobile-app run test                  # 1283 passed, 113 suites (11 net new)
pnpm --filter @selfxyz/mobile-app run types                 # clean
pnpm --filter @selfxyz/mobile-app run lint                  # 0 errors
```

New coverage: googleSignIn cancel/deny → null, coded failures → typed `sign_in_failed` with cause (incl. the network-shares-cancel-code case); CloudBackupScreen success/failure/cancel — alert shown or suppressed, event reasons, toggle untouched on failure; frozen-path pin; `sign_in_failed` rendering on the recovery screen.

**Device QA** (extends the run sheet in `app/docs/RECOVERY_QA_RUNSHEET.md`): Android — cancel the sign-in sheet → "dismissed" copy, `reason: sign_in_cancelled`; **Deny on the consent page** → also a cancel (confirms the `access_denied` assumption); wrong-client-ID build → `sign_in_failed` with a code, not "cancelled"; airplane mode → `sign_in_failed`. Either platform — airplane-mode enable → alert + `CLOUD_BACKUP_ENABLE_FAILED`, toggle stays off; restore a production-build backup after the path freeze → still found; enable → disable → file removed from the same location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)