### PR TITLE
feat(app): check for an existing cloud backup before writing, never overwrite (SELF-3964)

### DIFF
--- a/app/docs/RECOVERY_QA_RUNSHEET.md
+++ b/app/docs/RECOVERY_QA_RUNSHEET.md
@@ -1,0 +1,181 @@
+# Recovery stack — device QA run sheet
+
+Covers the four stacked PRs (build once, test all four):
+
+| PR | Issue | Fix |
+| --- | --- | --- |
+| [#2272](https://github.com/selfxyz/self/pull/2272) | SELF-3931 | Fetch protocol trees before the recovery registration check |
+| [#2273](https://github.com/selfxyz/self/pull/2273) | SELF-3932 | Surface cloud restore failures to the user and telemetry |
+| [#2277](https://github.com/selfxyz/self/pull/2277) | SELF-3933 | Trigger iCloud sync before concluding a backup is missing |
+| [#2278](https://github.com/selfxyz/self/pull/2278) | SELF-3934 / SELF-3935 | Truthful Drive OAuth errors, visible backup-enable failures, frozen backup path |
+
+**Build from `self-3934-3935-backup-error-hygiene`** — the stack is linear
+(#2272 → #2273 → #2277 → #2278), so this one build exercises everything.
+
+## Setup
+
+- iOS device A + iOS device B on the same Apple ID (or one device you can
+  wipe). Only the fresh-restore test needs two. **Real hardware only** —
+  simulator iCloud sync needs manual triggering and is flaky.
+- One Android device with a Google account. The OAuth tests need a build
+  whose client ID you can deliberately break once (test 11).
+- A previously registered ID document (the trees fix needs a real registered
+  commitment to restore against). The mismatched-backup test additionally
+  needs a backup made under a *different* phrase than the document's.
+- Mixpanel (project 3540525) open to verify events as you go.
+
+## iOS — restore
+
+- [x] **1. Fresh-device restore — the merge-gating test (#2277).**
+      Enable cloud backup on device A → fresh install on device B (same
+      Apple ID) → Recover → from iCloud, *immediately*.
+      **Expected:** restore succeeds; a wait of up to ~30 s is normal.
+      Never "did you back it up previously?".
+      This is the only test that validates the placeholder-naming and
+      `triggerSync`-materialisation assumptions unit tests cannot reach.
+- [ ] **2. Sync budget exhausted (#2277).** If test 1 stalls past the budget:
+      **Expected:** "Your backup is still syncing from iCloud. Keep the app
+      open and try again in a moment." — and a retry shortly after succeeds.
+- [x] **3. Signed out of iCloud (#2273, #2277).** Sign out in OS Settings →
+      Recover → from iCloud.
+      **Expected:** "Sign in to iCloud in your device settings…" — not
+      "no backup found", not silence.
+- [ ] **4. No backup ever made (#2273, #2277).** Signed in, account with no
+      backup → Recover from iCloud.
+      **Expected:** "We couldn't find a backup in iCloud…" including the
+      Android↔iPhone incompatibility sentence. A few seconds' probe delay is
+      expected (#2278 retries empty listings) — but no 30 s wait.
+- [ ] **5. Disabled backup stays gone (#2277 AC4).** Enable backup → disable
+      backup → Recover from iCloud.
+      **Expected:** "no backup found".
+- [x] **6. Backup from a different registration (#2278 copy).** With a backup
+      in iCloud made under a different phrase than the document on the device
+      → Recover from iCloud.
+      **Expected:** "We found a Self backup in iCloud, but it's not the one
+      used with this document. Enter the recovery phrase you used with this
+      document instead." — must NOT mention a phrase the user typed or say
+      "sign in".
+
+## Android — restore
+
+- [ ] **7. Sign-in cancelled (#2273).** Recover → from Google Drive → cancel
+      the sign-in sheet (back out before picking an account).
+      **Expected:** "The Google Drive sign-in was dismissed before it
+      finished…" — not silence, not an idle button.
+- [ ] **8. Deny on Google's consent page (#2278).** Proceed into the sheet,
+      pick an account, then tap Deny/Cancel on the consent screen.
+      **Expected:** treated as a cancel — same "dismissed" copy as test 7,
+      NOT a failure. (Confirms the `access_denied`-as-cancel assumption.)
+- [ ] **9. No backup on the account (#2273).**
+      **Expected:** "We couldn't find a backup in Google Drive…".
+- [ ] **10. Airplane mode (#2278).** Recover from Drive with no network.
+      **Expected:** "Something went wrong signing in to Google Drive…" —
+      a *failure*, no longer misreported as "cancelled" (this was the
+      SELF-3934 bug; network errors share the cancel code but not the
+      cancel message).
+- [ ] **11. Wrong client ID (#2278).** One-off build with a deliberately bad
+      `GOOGLE_SIGNIN_ANDROID_CLIENT_ID`.
+      **Expected:** the sign-in-failed copy, and Mixpanel shows
+      `reason: sign_in_failed` — never "cancelled".
+
+## Either platform — restore
+
+- [x] **12. Registered-ID restore (#2272).** Reinstall, re-scan a previously
+      registered ID, Recover → from cloud.
+      **Expected:** restore completes. (This was the TypeError / false
+      "not registered" bug.)
+- [x] **13. Registry unreachable (#2272, #2273).** Same as 12 in airplane mode
+      (past the download step if cached), or via the phrase path.
+      **Expected:** "We couldn't reach the Self network to verify your ID.
+      Check your connection…" — **never** "doesn't match a registered ID".
+- [x] **14. Phrase path (#2272).** Repeat 12 and 13 via Recover → recovery
+      phrase.
+      **Expected:** same outcomes; errors render inline under the text box.
+- [ ] **15. Biometrics unavailable (#2273).** Disable biometrics/device lock
+      in OS Settings → open the Recover screen.
+      **Expected:** cloud button disabled with the explanation directly
+      beneath it; phrase button fully usable; **no biometric prompt**.
+- [ ] **16. Biometrics re-enabled without restart (#2273).** From test 15,
+      without killing the app: re-enable biometrics in OS Settings, return to
+      the app with the screen still open.
+      **Expected:** cloud button enables on its own — no restart, no
+      re-navigation. (Exercises the AppState foreground re-check; only a real
+      OS round-trip can.)
+- [x] **17. Error typography.** Trigger any inline recovery error.
+      **Expected:** the red text renders in the app's body font (DINOT),
+      matching the surrounding copy — not the OS default font.
+
+## Either platform — backup enable (#2278)
+
+- [ ] **18. Enable fails visibly.** Airplane mode → Settings → enable cloud
+      backup.
+      **Expected:** an "Error / Failed to enable cloud backups" alert, the
+      toggle stays OFF, and `Cloud Backup Enable Failed` fires with a reason.
+      Previously this failed in complete silence.
+- [ ] **19. Biometric prompt dismissed during enable.** Start enabling, then
+      dismiss the biometric/keychain prompt.
+      **Expected:** NO error alert (the user cancelled it themselves), toggle
+      stays off; Mixpanel shows `reason: authentication_cancelled`.
+- [ ] **20. Sign-in sheet dismissed during enable (Android).** Start enabling,
+      cancel the Google sheet.
+      **Expected:** NO error alert; `reason: sign_in_cancelled`.
+- [ ] **21. Path freeze — no orphaning (#2278, critical).** Restore a backup
+      created by the **current production build**.
+      **Expected:** still found and restored — the frozen folder path resolves
+      to the same iCloud/Drive location production has always written to.
+- [ ] **22. Enable → disable round-trip.** Enable backup, then disable it,
+      then attempt restore.
+      **Expected:** disable removes the file from the same location the
+      enable wrote it; restore reports "no backup found".
+
+## Either platform — backup enable conflict check (SELF-3964)
+
+- [ ] **23. Fresh-account enable (critical — the mkdir-discriminator path).**
+      Account that never backed up → enable.
+      **Expected:** succeeds. On iOS the backup folder does not exist yet, so
+      the existence check cannot list it — enable must still work.
+- [ ] **24. Same-phrase reconnect.** Phrase-restore a device whose account
+      already holds that phrase's backup → enable.
+      **Expected:** toggle flips on silently, no dialog; Android appDataFolder
+      still has exactly the same number of files (no new upload); Mixpanel
+      `Cloud Backup Enabled Done` carries `existing: true`.
+- [ ] **25. Legacy duplicates, all matching (Android).** Account with two
+      duplicate files of the same phrase → enable.
+      **Expected:** reconnects silently; still exactly two files — nothing
+      written, nothing deleted.
+- [ ] **26. Conflicting backup.** Account holding a backup for a *different*
+      phrase than this device → enable.
+      **Expected:** "Existing backup found … left untouched" alert; toggle
+      stays off; the cloud backup is still restorable afterwards; Mixpanel
+      `reason: backup_conflict`.
+- [ ] **27. Corrupt backup.** Manually corrupt the backup file → enable.
+      **Expected:** same conflict alert, file untouched — never replaced.
+
+## Mixpanel checks (after the runs)
+
+- [ ] `Backup: Cloud Restore Started` fires exactly once per attempt, and
+      `Backup: Cloud Backup Started` no longer fires from the recover button.
+- [ ] Every restore failure above carries a `reason` matching what was on
+      screen: `no_backup_found`, `cloud_unavailable`, `sign_in_cancelled`,
+      `sign_in_failed`, `backup_not_synced`, `protocol_data_unavailable`,
+      `document_not_registered`.
+- [ ] `Backup: Cloud Backup Enable Failed` carries `reason`
+      (`unexpected_error` / `sign_in_cancelled` / `sign_in_failed` /
+      `authentication_cancelled`) — tests 18-20.
+- [ ] Zero `Cloud Restore Failed: Unknown Error` events with
+      `error: TypeError` from the test devices (#2272 regression check).
+
+## Not device-testable
+
+- `secret_storage_failed` (#2273's keychain-write failure branch) — not
+  reproducible without breaking the keychain; covered by unit tests only.
+
+## Still open (not covered by any test here)
+
+- SELF-3934 AC2: the GCP Console audit (client IDs per environment,
+  registered SHA-1s vs the Play App Signing certificate, consent-screen
+  publishing status) — recorded as a comment on the Linear issue when done.
+- Test 4's Play-signed variant: on a Play-signed internal-track build, do a
+  full enable → uninstall → reinstall → restore round-trip (SELF-3934
+  testing instruction 4). Only meaningful after the Console audit confirms
+  the production OAuth client carries the Play App Signing SHA-1.

--- a/app/docs/RECOVERY_QA_RUNSHEET.md
+++ b/app/docs/RECOVERY_QA_RUNSHEET.md
@@ -8,9 +8,11 @@ Covers the four stacked PRs (build once, test all four):
 | [#2273](https://github.com/selfxyz/self/pull/2273) | SELF-3932 | Surface cloud restore failures to the user and telemetry |
 | [#2277](https://github.com/selfxyz/self/pull/2277) | SELF-3933 | Trigger iCloud sync before concluding a backup is missing |
 | [#2278](https://github.com/selfxyz/self/pull/2278) | SELF-3934 / SELF-3935 | Truthful Drive OAuth errors, visible backup-enable failures, frozen backup path |
+| [#2280](https://github.com/selfxyz/self/pull/2280) | SELF-3964 | Backup enable checks for an existing backup first, never overwrites |
 
-**Build from `self-3934-3935-backup-error-hygiene`** — the stack is linear
-(#2272 → #2273 → #2277 → #2278), so this one build exercises everything.
+**Build from `self-3964-backup-enable-conflict-check`** — #2272–#2278 are
+merged into `dev`, which that branch includes, so this one build exercises
+everything (tests 23–27 need it; a `dev` build predates them).
 
 ## Setup
 

--- a/app/src/screens/account/recovery/recoveryCopy.ts
+++ b/app/src/screens/account/recovery/recoveryCopy.ts
@@ -49,6 +49,10 @@ export const recoveryCopy = {
     sign_in_cancelled: `The ${STORAGE_NAME} sign-in was dismissed before it finished. Try again, or use your recovery phrase.`,
     sign_in_failed: `Something went wrong signing in to ${STORAGE_NAME}. Try again, or recover with your recovery phrase.`,
     backup_corrupt: `We found a backup in ${STORAGE_NAME} but couldn’t read it. Recover with your recovery phrase instead.`,
+    // Unreachable from the restore flow (backup_conflict is enable-only), but
+    // the key must exist: the choice screen indexes this map with the full
+    // CloudBackupErrorReason union.
+    backup_conflict: `Your ${STORAGE_NAME} account already has a Self backup that doesn’t match this device. It was left untouched.`,
     backup_read_failed: `We couldn’t reach ${STORAGE_NAME}. Check your connection and try again.`,
     backup_not_synced: `Your backup is still syncing from ${STORAGE_NAME}. Keep the app open and try again in a moment.`,
     invalid_mnemonic:

--- a/app/src/screens/account/settings/CloudBackupScreen.tsx
+++ b/app/src/screens/account/settings/CloudBackupScreen.tsx
@@ -174,9 +174,15 @@ const CloudBackupScreen: React.FC<CloudBackupScreenProps> = ({
         setICloudPending(false);
         return;
       }
-      await upload(storedMnemonic.data);
+      const outcome = await upload(storedMnemonic.data);
       toggleCloudBackupEnabled();
-      trackEvent(BackupEvents.CLOUD_BACKUP_ENABLED_DONE);
+      if (outcome === 'already_backed_up') {
+        // A matching backup already existed in the cloud — reconnected to it
+        // without writing anything.
+        trackEvent(BackupEvents.CLOUD_BACKUP_ENABLED_DONE, { existing: true });
+      } else {
+        trackEvent(BackupEvents.CLOUD_BACKUP_ENABLED_DONE);
+      }
 
       if (params?.returnToScreen) {
         navigation.navigate(params.returnToScreen);
@@ -194,9 +200,16 @@ const CloudBackupScreen: React.FC<CloudBackupScreenProps> = ({
         reason,
         error: error instanceof Error ? error.name : 'unknown',
       });
-      // A dismissed sign-in sheet or biometric prompt is the user's own
-      // doing — no alert for those.
-      if (
+      if (reason === 'backup_conflict') {
+        // Covers both flavours: a backup for a different phrase, and a backup
+        // we could not read. Either way it was left untouched.
+        Alert.alert(
+          'Existing backup found',
+          `Your ${STORAGE_NAME} account already contains a Self backup that doesn't match this device's recovery phrase or couldn't be read. It was left untouched — restore it first, or use a different account.`,
+        );
+      } else if (
+        // A dismissed sign-in sheet or biometric prompt is the user's own
+        // doing — no alert for those.
         reason !== 'sign_in_cancelled' &&
         reason !== 'authentication_cancelled'
       ) {

--- a/app/src/services/cloud-backup/errors.ts
+++ b/app/src/services/cloud-backup/errors.ts
@@ -28,6 +28,12 @@ export type CloudBackupErrorReason =
   /** Found a backup file whose contents are not a usable mnemonic. */
   | 'backup_corrupt'
   /**
+   * Enable only: an existing cloud backup does not match this device's phrase,
+   * or could not be read. Enable refuses to write — nothing is ever deleted or
+   * overwritten.
+   */
+  | 'backup_conflict'
+  /**
    * Anything else from the storage layer. `withRetries` replaces the original
    * error with a fresh one, so every classifiable branch must throw outside it —
    * whatever escapes the retry wrapper is unclassifiable by construction.

--- a/app/src/services/cloud-backup/index.ts
+++ b/app/src/services/cloud-backup/index.ts
@@ -15,14 +15,17 @@ import {
 } from '@/services/cloud-backup/errors';
 import { createGDrive } from '@/services/cloud-backup/google';
 import { FILE_NAME } from '@/services/cloud-backup/helpers';
-import type { IosDownloadOptions } from '@/services/cloud-backup/ios';
+import type {
+  IosSyncOptions,
+  UploadOutcome,
+} from '@/services/cloud-backup/ios';
 import {
   disableBackup as disableIosBackup,
   download as iosDownload,
   upload as iosUpload,
 } from '@/services/cloud-backup/ios';
 import type { Mnemonic } from '@/types/mnemonic';
-import { parseMnemonic } from '@/utils/crypto/mnemonic';
+import { mnemonicsMatch, parseMnemonic } from '@/utils/crypto/mnemonic';
 import { withRetries } from '@/utils/retry';
 
 export const STORAGE_NAME = Platform.OS === 'ios' ? 'iCloud' : 'Google Drive';
@@ -61,7 +64,7 @@ export async function disableBackup() {
   );
 }
 
-export async function download(options?: IosDownloadOptions) {
+export async function download(options?: IosSyncOptions) {
   if (Platform.OS === 'ios') {
     return iosDownload(options);
   }
@@ -119,31 +122,107 @@ export async function download(options?: IosDownloadOptions) {
   }
 }
 
-export async function upload(mnemonic: Mnemonic) {
+type GDriveClient = NonNullable<Awaited<ReturnType<typeof createGDrive>>>;
+
+/**
+ * Enumerates every backup file in the app-data folder — Drive identifies files
+ * by ID, not name, so historical blind uploads left some accounts with several
+ * files under the same name, and Drive pages listings at 100.
+ */
+async function listBackupFiles(gdrive: GDriveClient) {
+  const collected: { id: string }[] = [];
+  let pageToken: string | undefined;
+  do {
+    const response = await gdrive.files.list({
+      spaces: APP_DATA_FOLDER_ID,
+      q: `name = '${FILE_NAME}'`,
+      ...(pageToken ? { pageToken } : {}),
+    });
+    const files: unknown[] = response.files;
+    collected.push(...files.filter(isDriveFile));
+    pageToken = (response as { nextPageToken?: string }).nextPageToken;
+  } while (pageToken);
+  return collected;
+}
+
+/**
+ * Backs up the mnemonic, refusing to touch any backup that already exists.
+ * See the iOS counterpart for the outcome semantics; the whole Android
+ * check+write runs under the single sign-in from one `createGDrive()` call.
+ */
+export async function upload(
+  mnemonic: Mnemonic,
+  options?: IosSyncOptions,
+): Promise<UploadOutcome> {
   if (!mnemonic || !mnemonic.phrase) {
     throw new Error(
       'Mnemonic not set yet. Did the user see the recovery phrase?',
     );
   }
   if (Platform.OS === 'ios') {
-    await iosUpload(mnemonic);
-  } else {
-    const gdrive = await createGDrive();
-    if (!gdrive) {
-      throw new CloudBackupError(
-        'sign_in_cancelled',
-        'User canceled Google sign-in',
-      );
-    }
-    await withRetries(() =>
-      gdrive.files
-        .newMultipartUploader()
-        .setData(JSON.stringify(mnemonic))
-        .setDataMimeType(MIME_TYPES.application.json)
-        .setRequestBody({ name: FILE_NAME, parents: [APP_DATA_FOLDER_ID] })
-        .execute(),
+    return iosUpload(mnemonic, options);
+  }
+
+  const gdrive = await createGDrive();
+  if (!gdrive) {
+    throw new CloudBackupError(
+      'sign_in_cancelled',
+      'User canceled Google sign-in',
     );
   }
+
+  // Check phase, classified. One mismatched or unreadable file decides the
+  // outcome, so the loop short-circuits. Write failures below stay raw.
+  let existingCount = 0;
+  try {
+    const candidates = await listBackupFiles(gdrive);
+    existingCount = candidates.length;
+    for (const candidate of candidates) {
+      const text = await withRetries(
+        () => gdrive.files.getText(candidate.id),
+        3,
+      );
+      let existing: Mnemonic;
+      try {
+        existing = parseMnemonic(text);
+      } catch (e) {
+        throw new CloudBackupError(
+          'backup_conflict',
+          `An existing Google Drive backup could not be read: ${(e as Error).message}`,
+          { cause: e },
+        );
+      }
+      if (!mnemonicsMatch(existing, mnemonic)) {
+        throw new CloudBackupError(
+          'backup_conflict',
+          'An existing Google Drive backup does not match this device',
+        );
+      }
+    }
+  } catch (e) {
+    if (isCloudBackupError(e)) {
+      throw e;
+    }
+    throw new CloudBackupError(
+      'backup_read_failed',
+      `Failed to check for an existing Google Drive backup: ${(e as Error).message}`,
+      { cause: e },
+    );
+  }
+
+  if (existingCount > 0) {
+    return 'already_backed_up';
+  }
+
+  await withRetries(() =>
+    gdrive.files
+      .newMultipartUploader()
+      .setData(JSON.stringify(mnemonic))
+      .setDataMimeType(MIME_TYPES.application.json)
+      .setRequestBody({ name: FILE_NAME, parents: [APP_DATA_FOLDER_ID] })
+      .execute(),
+  );
+  return 'created';
 }
 
 export function useBackupMnemonic() {

--- a/app/src/services/cloud-backup/ios.ts
+++ b/app/src/services/cloud-backup/ios.ts
@@ -180,6 +180,8 @@ export async function download(options?: IosDownloadOptions) {
 
 async function createBackupFolder() {
   try {
+    // The native createDirectory is mkdir -p (succeeds for an existing dir);
+    // the 'already' tolerance below is belt-and-braces against that changing.
     await CloudStorage.mkdir(FOLDER);
   } catch (e) {
     console.error(e);
@@ -208,7 +210,7 @@ export async function upload(
     remoteProbeAttempts = 3,
   } = options ?? {};
 
-  let verdict: 'write' | 'reconnect' | 'write_new_folder' = 'write';
+  let verdict: 'write' | 'reconnect' = 'write';
   try {
     if (!(await CloudStorage.isCloudAvailable())) {
       throw new CloudBackupError(
@@ -241,20 +243,17 @@ export async function upload(
       } else {
         // 'unknown': every listing was rejected — either the folder was never
         // created (no backup can exist) or reads are genuinely failing. The
-        // error code cannot tell them apart, but mkdir can: creating the
-        // folder succeeds only if it did not exist.
-        try {
-          await CloudStorage.mkdir(FOLDER);
-          verdict = 'write_new_folder';
-        } catch (e) {
-          if ((e as Error).message.includes('already')) {
-            throw new CloudBackupError(
-              'backup_read_failed',
-              'The iCloud backup folder exists but its contents could not be checked',
-              { cause: e },
-            );
-          }
-          throw e;
+        // error code cannot tell them apart. Neither can mkdir: the native
+        // createDirectory uses withIntermediateDirectories, which succeeds
+        // silently for an existing directory. A throw-free existence check on
+        // the folder itself can: present but unlistable fails closed; absent
+        // locally is the same evidence class as 'absent' — the documented
+        // metadata-lag residual.
+        if (await CloudStorage.exists(FOLDER)) {
+          throw new CloudBackupError(
+            'backup_read_failed',
+            'The iCloud backup folder exists but its contents could not be checked',
+          );
         }
       }
     }
@@ -295,9 +294,7 @@ export async function upload(
   if (verdict === 'reconnect') {
     return 'already_backed_up';
   }
-  if (verdict === 'write') {
-    await createBackupFolder();
-  }
+  await createBackupFolder();
   await withRetries(() =>
     CloudStorage.writeFile(ENCRYPTED_FILE_PATH, JSON.stringify(mnemonic)),
   );

--- a/app/src/services/cloud-backup/ios.ts
+++ b/app/src/services/cloud-backup/ios.ts
@@ -15,10 +15,10 @@ import {
   PLACEHOLDER_FILE_PATH,
 } from '@/services/cloud-backup/helpers';
 import type { Mnemonic } from '@/types/mnemonic';
-import { parseMnemonic } from '@/utils/crypto/mnemonic';
+import { mnemonicsMatch, parseMnemonic } from '@/utils/crypto/mnemonic';
 import { withRetries } from '@/utils/retry';
 
-export interface IosDownloadOptions {
+export interface IosSyncOptions {
   /** Total budget for waiting on iCloud to materialise the backup file. */
   syncTimeoutMs?: number;
   /** Delay between `exists` checks while waiting, and between remote probes. */
@@ -26,6 +26,10 @@ export interface IosDownloadOptions {
   /** How often to re-probe when the folder listing itself fails. */
   remoteProbeAttempts?: number;
 }
+
+export type IosDownloadOptions = IosSyncOptions;
+
+export type UploadOutcome = 'created' | 'already_backed_up';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -47,29 +51,35 @@ export async function disableBackup() {
  * only ever concluded after the metadata has had a window to arrive. The
  * residual gap (metadata lag beyond the probe budget) is not closable with
  * this library's API surface; it exposes no NSMetadataQuery.
+ *
+ * `'absent'` requires at least one successful listing; a budget spent purely
+ * on rejected listings is `'unknown'` — the folder may simply not exist, or
+ * reads may genuinely be failing, and the two throw the same error code.
  */
-async function hasRemoteBackup(
+async function probeRemoteBackup(
   probeAttempts: number,
   probeIntervalMs: number,
-): Promise<boolean> {
+): Promise<'found' | 'absent' | 'unknown'> {
+  let sawSuccessfulListing = false;
   for (let attempt = 0; attempt < probeAttempts; attempt++) {
     if (attempt > 0) {
       await sleep(probeIntervalMs);
     }
     if (await CloudStorage.exists(PLACEHOLDER_FILE_PATH)) {
-      return true;
+      return 'found';
     }
     try {
       const entries = await CloudStorage.readdir(FOLDER);
+      sawSuccessfulListing = true;
       if (entries.some(entry => entry.includes(FILE_NAME))) {
-        return true;
+        return 'found';
       }
     } catch {
       // Missing folder or read failure — inconclusive, same as a listing
       // without the file. Retry the whole probe.
     }
   }
-  return false;
+  return sawSuccessfulListing ? 'absent' : 'unknown';
 }
 
 /**
@@ -120,7 +130,13 @@ export async function download(options?: IosDownloadOptions) {
     }
 
     if (!(await CloudStorage.exists(ENCRYPTED_FILE_PATH))) {
-      if (!(await hasRemoteBackup(remoteProbeAttempts, pollIntervalMs))) {
+      const evidence = await probeRemoteBackup(
+        remoteProbeAttempts,
+        pollIntervalMs,
+      );
+      // For restore, 'absent' and 'unknown' both mean "nothing to restore" —
+      // the accepted residual risk documented on the probe.
+      if (evidence !== 'found') {
         throw new CloudBackupError(
           'no_backup_found',
           'Couldnt find the encrypted backup, did you back it up previously?',
@@ -162,7 +178,7 @@ export async function download(options?: IosDownloadOptions) {
   }
 }
 
-export async function upload(mnemonic: Mnemonic) {
+async function createBackupFolder() {
   try {
     await CloudStorage.mkdir(FOLDER);
   } catch (e) {
@@ -171,7 +187,119 @@ export async function upload(mnemonic: Mnemonic) {
       throw e;
     }
   }
+}
+
+/**
+ * Backs up the mnemonic, refusing to touch any backup that already exists.
+ *
+ * An existing backup with the same phrase reconnects without a write; anything
+ * else — a different phrase or an unreadable file — is a `backup_conflict` and
+ * nothing is deleted or overwritten. Only the check phase is wrapped in the
+ * error classifier; write failures escape raw, as before, so they keep
+ * reading as unexpected rather than as read failures.
+ */
+export async function upload(
+  mnemonic: Mnemonic,
+  options?: IosSyncOptions,
+): Promise<UploadOutcome> {
+  const {
+    syncTimeoutMs = 30_000,
+    pollIntervalMs = 1_000,
+    remoteProbeAttempts = 3,
+  } = options ?? {};
+
+  let verdict: 'write' | 'reconnect' | 'write_new_folder' = 'write';
+  try {
+    if (!(await CloudStorage.isCloudAvailable())) {
+      throw new CloudBackupError(
+        'cloud_unavailable',
+        'iCloud is unavailable, is the device signed in to iCloud?',
+      );
+    }
+
+    let backupIsLocal = await CloudStorage.exists(ENCRYPTED_FILE_PATH);
+    if (!backupIsLocal) {
+      const evidence = await probeRemoteBackup(
+        remoteProbeAttempts,
+        pollIntervalMs,
+      );
+      if (evidence === 'found') {
+        // A backup genuinely exists remotely — wait for it so it can be
+        // compared. Writing blind here could destroy it.
+        if (!(await waitForBackupFile(syncTimeoutMs, pollIntervalMs))) {
+          throw new CloudBackupError(
+            'backup_not_synced',
+            'The iCloud backup has not finished downloading to this device yet',
+          );
+        }
+        backupIsLocal = true;
+      } else if (evidence === 'absent') {
+        // Same evidence bar on which download reports "no backup found". The
+        // probe-then-write race (metadata arriving right after) is the
+        // documented metadata-lag gap — not closable with this library.
+        verdict = 'write';
+      } else {
+        // 'unknown': every listing was rejected — either the folder was never
+        // created (no backup can exist) or reads are genuinely failing. The
+        // error code cannot tell them apart, but mkdir can: creating the
+        // folder succeeds only if it did not exist.
+        try {
+          await CloudStorage.mkdir(FOLDER);
+          verdict = 'write_new_folder';
+        } catch (e) {
+          if ((e as Error).message.includes('already')) {
+            throw new CloudBackupError(
+              'backup_read_failed',
+              'The iCloud backup folder exists but its contents could not be checked',
+              { cause: e },
+            );
+          }
+          throw e;
+        }
+      }
+    }
+
+    if (backupIsLocal) {
+      const existingString = await withRetries(() =>
+        CloudStorage.readFile(ENCRYPTED_FILE_PATH),
+      );
+      let existing: Mnemonic;
+      try {
+        existing = parseMnemonic(existingString);
+      } catch (e) {
+        throw new CloudBackupError(
+          'backup_conflict',
+          `The existing iCloud backup could not be read: ${(e as Error).message}`,
+          { cause: e },
+        );
+      }
+      if (!mnemonicsMatch(existing, mnemonic)) {
+        throw new CloudBackupError(
+          'backup_conflict',
+          'The existing iCloud backup does not match this device',
+        );
+      }
+      verdict = 'reconnect';
+    }
+  } catch (e) {
+    if (isCloudBackupError(e)) {
+      throw e;
+    }
+    throw new CloudBackupError(
+      'backup_read_failed',
+      `Failed to check for an existing iCloud backup: ${(e as Error).message}`,
+      { cause: e },
+    );
+  }
+
+  if (verdict === 'reconnect') {
+    return 'already_backed_up';
+  }
+  if (verdict === 'write') {
+    await createBackupFolder();
+  }
   await withRetries(() =>
     CloudStorage.writeFile(ENCRYPTED_FILE_PATH, JSON.stringify(mnemonic)),
   );
+  return 'created';
 }

--- a/app/src/utils/crypto/mnemonic.ts
+++ b/app/src/utils/crypto/mnemonic.ts
@@ -66,3 +66,11 @@ export function parseMnemonic(mnemonicString: string): Mnemonic {
 
   return parsed;
 }
+
+/**
+ * Whether two mnemonics derive the same key. The password participates in key
+ * derivation, so a matching phrase with a different password is NOT a match.
+ */
+export function mnemonicsMatch(a: Mnemonic, b: Mnemonic): boolean {
+  return a.phrase === b.phrase && a.password === b.password;
+}

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -167,6 +167,7 @@ jest.mock('@/screens/account/recovery/recoveryCopy', () => ({
       sign_in_cancelled: 'Error: sign-in was dismissed',
       sign_in_failed: 'Error: sign-in ended in an error',
       backup_corrupt: 'Error: backup could not be read',
+      backup_conflict: 'Error: existing backup does not match this device',
       backup_read_failed: 'Error: could not reach the cloud provider',
       backup_not_synced: 'Error: still downloading from the cloud provider',
       restore_failed: 'Error: could not restore with this phrase',

--- a/app/tests/src/screens/account/settings/CloudBackupScreen.test.tsx
+++ b/app/tests/src/screens/account/settings/CloudBackupScreen.test.tsx
@@ -182,6 +182,43 @@ describe('CloudBackupScreen', () => {
     expect(mockAlert).not.toHaveBeenCalled();
   });
 
+  it('reconnects to an existing matching backup and reports it', async () => {
+    mockUpload.mockResolvedValue('already_backed_up');
+
+    pressEnableBackup();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith('CLOUD_BACKUP_ENABLED_DONE', {
+        existing: true,
+      });
+    });
+    expect(toggle()).toHaveBeenCalled();
+    expect(mockAlert).not.toHaveBeenCalled();
+  });
+
+  it('blocks on a conflicting backup, informs the user, and leaves the toggle off', async () => {
+    mockUpload.mockRejectedValue(
+      new CloudBackupError(
+        'backup_conflict',
+        'The existing iCloud backup does not match this device',
+      ),
+    );
+
+    pressEnableBackup();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'CLOUD_BACKUP_ENABLE_FAILED',
+        { reason: 'backup_conflict', error: 'CloudBackupError' },
+      );
+    });
+    expect(mockAlert).toHaveBeenCalledWith(
+      'Existing backup found',
+      expect.stringContaining('It was left untouched'),
+    );
+    expect(toggle()).not.toHaveBeenCalled();
+  });
+
   it('alerts and reports a reason when the upload fails', async () => {
     mockUpload.mockRejectedValue(new Error('write failed'));
 

--- a/app/tests/src/services/cloud-backup.test.ts
+++ b/app/tests/src/services/cloud-backup.test.ts
@@ -128,6 +128,13 @@ const mockMnemonic = {
   entropy: '0x00000000000000000000000000000000',
 };
 
+// Keeps the iOS remote-backup probe from sleeping through real intervals.
+const FAST_SYNC_OPTIONS = {
+  syncTimeoutMs: 100,
+  pollIntervalMs: 10,
+  remoteProbeAttempts: 1,
+};
+
 describe('cloudBackup', () => {
   let originalPlatform: SupportedPlatforms;
   let consoleSpy: jest.SpyInstance;
@@ -174,8 +181,8 @@ describe('cloudBackup', () => {
       const { result } = renderHook(() => useBackupMnemonic());
 
       await expect(
-        result.current.upload(mockMnemonic),
-      ).resolves.toBeUndefined();
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).resolves.toBe('created');
 
       expect(CloudStorage.mkdir).toHaveBeenCalledWith('/@selfxyz/mobile-app');
       expect(CloudStorage.writeFile).toHaveBeenCalledWith(
@@ -192,8 +199,8 @@ describe('cloudBackup', () => {
       const { result } = renderHook(() => useBackupMnemonic());
 
       await expect(
-        result.current.upload(mockMnemonic),
-      ).resolves.toBeUndefined();
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).resolves.toBe('created');
 
       expect(CloudStorage.writeFile).toHaveBeenCalledWith(
         '/@selfxyz/mobile-app/encrypted-private-key',
@@ -230,9 +237,10 @@ describe('cloudBackup', () => {
 
       const { result } = renderHook(() => useBackupMnemonic());
 
-      await expect(result.current.upload(mockMnemonic)).rejects.toThrow(
-        'permission denied',
-      );
+      // Write-phase failures stay raw — deliberately not classified.
+      await expect(
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).rejects.toThrow('permission denied');
     });
   });
 
@@ -243,17 +251,20 @@ describe('cloudBackup', () => {
 
     it('should upload mnemonic to Google Drive successfully', async () => {
       (createGDrive as jest.Mock).mockResolvedValue(mockGDriveInstance);
+      mockGDriveInstance.files.list.mockResolvedValue({ files: [] });
       mockGDriveInstance.files
         .newMultipartUploader()
         .execute.mockResolvedValue({});
 
       const { result } = renderHook(() => useBackupMnemonic());
 
-      await expect(
-        result.current.upload(mockMnemonic),
-      ).resolves.toBeUndefined();
+      await expect(result.current.upload(mockMnemonic)).resolves.toBe(
+        'created',
+      );
 
-      expect(createGDrive).toHaveBeenCalled();
+      // The existing-backup check and the write share one sign-in — a second
+      // createGDrive call would show the user a second Google sheet.
+      expect(createGDrive).toHaveBeenCalledTimes(1);
       expect(
         mockGDriveInstance.files.newMultipartUploader().setData,
       ).toHaveBeenCalledWith(JSON.stringify(mockMnemonic));
@@ -270,6 +281,284 @@ describe('cloudBackup', () => {
       await expect(result.current.upload(mockMnemonic)).rejects.toThrow(
         'User canceled Google sign-in',
       );
+    });
+  });
+
+  describe('upload conflict checks - iOS', () => {
+    beforeEach(() => {
+      mockPlatform.OS = 'ios';
+      (CloudStorage.mkdir as jest.Mock).mockResolvedValue(undefined);
+      (CloudStorage.writeFile as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    it('reconnects to an existing matching backup without writing', async () => {
+      (CloudStorage.exists as jest.Mock).mockImplementation(
+        async (path: string) => path === ENCRYPTED_FILE_PATH,
+      );
+      (CloudStorage.readFile as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).resolves.toBe('already_backed_up');
+      expect(CloudStorage.writeFile).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [
+        'a different phrase',
+        JSON.stringify({ ...mockMnemonic, phrase: 'legal winner thank' }),
+      ],
+      [
+        'a different password',
+        JSON.stringify({ ...mockMnemonic, password: 'hunter2' }),
+      ],
+      ['unreadable contents', 'not json at all'],
+    ])(
+      'blocks with a conflict when the existing backup has %s',
+      async (_label, existingBlob) => {
+        (CloudStorage.exists as jest.Mock).mockImplementation(
+          async (path: string) => path === ENCRYPTED_FILE_PATH,
+        );
+        (CloudStorage.readFile as jest.Mock).mockResolvedValue(existingBlob);
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        await expect(
+          result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+        ).rejects.toMatchObject({
+          name: 'CloudBackupError',
+          reason: 'backup_conflict',
+        });
+        // The whole point: nothing is ever deleted or overwritten.
+        expect(CloudStorage.writeFile).not.toHaveBeenCalled();
+        expect(CloudStorage.rmdir).not.toHaveBeenCalled();
+      },
+    );
+
+    it('waits for a not-yet-synced backup and reconnects when it matches', async () => {
+      let materialized = false;
+      (CloudStorage.exists as jest.Mock).mockImplementation(
+        async (path: string) =>
+          path === PLACEHOLDER_FILE_PATH ? !materialized : materialized,
+      );
+      (CloudStorage.triggerSync as jest.Mock).mockImplementation(async () => {
+        materialized = true;
+      });
+      (CloudStorage.readFile as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).resolves.toBe('already_backed_up');
+      expect(CloudStorage.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('reports a backup that never finishes syncing without writing', async () => {
+      (CloudStorage.exists as jest.Mock).mockImplementation(
+        async (path: string) => path === PLACEHOLDER_FILE_PATH,
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).rejects.toMatchObject({
+        name: 'CloudBackupError',
+        reason: 'backup_not_synced',
+      });
+      expect(CloudStorage.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('creates the backup when the folder itself did not exist', async () => {
+      // Fresh device: the folder was never created, so every listing rejects
+      // with the same code as a genuine read failure. mkdir succeeding is the
+      // proof that no backup can exist.
+      (CloudStorage.exists as jest.Mock).mockResolvedValue(false);
+      (CloudStorage.readdir as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('read failed'), { code: 'ERR_READ_ERROR' }),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).resolves.toBe('created');
+      expect(CloudStorage.writeFile).toHaveBeenCalled();
+    });
+
+    it('refuses to write when the folder exists but cannot be checked', async () => {
+      (CloudStorage.exists as jest.Mock).mockResolvedValue(false);
+      (CloudStorage.readdir as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('read failed'), { code: 'ERR_READ_ERROR' }),
+      );
+      (CloudStorage.mkdir as jest.Mock).mockRejectedValue(
+        new Error('folder already exists'),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).rejects.toMatchObject({
+        name: 'CloudBackupError',
+        reason: 'backup_read_failed',
+      });
+      expect(CloudStorage.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('reports iCloud being unavailable before any check', async () => {
+      (CloudStorage.isCloudAvailable as jest.Mock).mockResolvedValue(false);
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(
+        result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
+      ).rejects.toMatchObject({
+        name: 'CloudBackupError',
+        reason: 'cloud_unavailable',
+      });
+      expect(CloudStorage.writeFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('upload conflict checks - Android', () => {
+    beforeEach(() => {
+      mockPlatform.OS = 'android';
+      (createGDrive as jest.Mock).mockResolvedValue(mockGDriveInstance);
+      mockGDriveInstance.files
+        .newMultipartUploader()
+        .execute.mockResolvedValue({});
+    });
+
+    it('reconnects to an existing matching backup without uploading', async () => {
+      mockGDriveInstance.files.list.mockResolvedValue({
+        files: [{ id: 'file-1', name: 'encrypted-private-key' }],
+      });
+      mockGDriveInstance.files.getText.mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.upload(mockMnemonic)).resolves.toBe(
+        'already_backed_up',
+      );
+      expect(
+        mockGDriveInstance.files.newMultipartUploader().execute,
+      ).not.toHaveBeenCalled();
+      expect(createGDrive).toHaveBeenCalledTimes(1);
+    });
+
+    it('reconnects across legacy duplicates when every copy matches', async () => {
+      mockGDriveInstance.files.list.mockResolvedValue({
+        files: [
+          { id: 'file-1', name: 'encrypted-private-key' },
+          { id: 'file-2', name: 'encrypted-private-key' },
+        ],
+      });
+      mockGDriveInstance.files.getText.mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.upload(mockMnemonic)).resolves.toBe(
+        'already_backed_up',
+      );
+      expect(mockGDriveInstance.files.getText).toHaveBeenCalledTimes(2);
+      expect(
+        mockGDriveInstance.files.newMultipartUploader().execute,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('blocks with a conflict on the first mismatched duplicate', async () => {
+      mockGDriveInstance.files.list.mockResolvedValue({
+        files: [
+          { id: 'file-1', name: 'encrypted-private-key' },
+          { id: 'file-2', name: 'encrypted-private-key' },
+        ],
+      });
+      mockGDriveInstance.files.getText.mockResolvedValue(
+        JSON.stringify({ ...mockMnemonic, phrase: 'legal winner thank' }),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.upload(mockMnemonic)).rejects.toMatchObject({
+        name: 'CloudBackupError',
+        reason: 'backup_conflict',
+      });
+      // One mismatch decides the outcome — the rest are not read.
+      expect(mockGDriveInstance.files.getText).toHaveBeenCalledTimes(1);
+      expect(
+        mockGDriveInstance.files.newMultipartUploader().execute,
+      ).not.toHaveBeenCalled();
+      expect(mockGDriveInstance.files.delete).not.toHaveBeenCalled();
+    });
+
+    it('blocks with a conflict when an existing backup is unreadable', async () => {
+      mockGDriveInstance.files.list.mockResolvedValue({
+        files: [{ id: 'file-1', name: 'encrypted-private-key' }],
+      });
+      mockGDriveInstance.files.getText.mockResolvedValue('not json');
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.upload(mockMnemonic)).rejects.toMatchObject({
+        name: 'CloudBackupError',
+        reason: 'backup_conflict',
+      });
+      expect(
+        mockGDriveInstance.files.newMultipartUploader().execute,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('walks every listing page before deciding', async () => {
+      mockGDriveInstance.files.list
+        .mockResolvedValueOnce({
+          files: [{ id: 'file-1', name: 'encrypted-private-key' }],
+          nextPageToken: 'page-2',
+        })
+        .mockResolvedValueOnce({
+          files: [{ id: 'file-2', name: 'encrypted-private-key' }],
+        });
+      mockGDriveInstance.files.getText.mockResolvedValue(
+        JSON.stringify(mockMnemonic),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.upload(mockMnemonic)).resolves.toBe(
+        'already_backed_up',
+      );
+      expect(mockGDriveInstance.files.list).toHaveBeenCalledTimes(2);
+      expect(mockGDriveInstance.files.list).toHaveBeenLastCalledWith(
+        expect.objectContaining({ pageToken: 'page-2' }),
+      );
+      expect(mockGDriveInstance.files.getText).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports a failed existence check as retryable, never writing', async () => {
+      mockGDriveInstance.files.list.mockRejectedValue(
+        new Error('network offline'),
+      );
+
+      const { result } = renderHook(() => useBackupMnemonic());
+
+      await expect(result.current.upload(mockMnemonic)).rejects.toMatchObject({
+        name: 'CloudBackupError',
+        reason: 'backup_read_failed',
+      });
+      expect(
+        mockGDriveInstance.files.newMultipartUploader().execute,
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/app/tests/src/services/cloud-backup.test.ts
+++ b/app/tests/src/services/cloud-backup.test.ts
@@ -378,8 +378,8 @@ describe('cloudBackup', () => {
 
     it('creates the backup when the folder itself did not exist', async () => {
       // Fresh device: the folder was never created, so every listing rejects
-      // with the same code as a genuine read failure. mkdir succeeding is the
-      // proof that no backup can exist.
+      // with the same code as a genuine read failure. The folder being absent
+      // locally is the proof that no backup can exist here.
       (CloudStorage.exists as jest.Mock).mockResolvedValue(false);
       (CloudStorage.readdir as jest.Mock).mockRejectedValue(
         Object.assign(new Error('read failed'), { code: 'ERR_READ_ERROR' }),
@@ -390,16 +390,18 @@ describe('cloudBackup', () => {
       await expect(
         result.current.upload(mockMnemonic, FAST_SYNC_OPTIONS),
       ).resolves.toBe('created');
+      // The decision must come from checking the folder, not from mkdir —
+      // the native createDirectory succeeds silently for an existing dir.
+      expect(CloudStorage.exists).toHaveBeenCalledWith(FOLDER);
       expect(CloudStorage.writeFile).toHaveBeenCalled();
     });
 
     it('refuses to write when the folder exists but cannot be checked', async () => {
-      (CloudStorage.exists as jest.Mock).mockResolvedValue(false);
+      (CloudStorage.exists as jest.Mock).mockImplementation(
+        async (path: string) => path === FOLDER,
+      );
       (CloudStorage.readdir as jest.Mock).mockRejectedValue(
         Object.assign(new Error('read failed'), { code: 'ERR_READ_ERROR' }),
-      );
-      (CloudStorage.mkdir as jest.Mock).mockRejectedValue(
-        new Error('folder already exists'),
       );
 
       const { result } = renderHook(() => useBackupMnemonic());
@@ -411,6 +413,7 @@ describe('cloudBackup', () => {
         reason: 'backup_read_failed',
       });
       expect(CloudStorage.writeFile).not.toHaveBeenCalled();
+      expect(CloudStorage.mkdir).not.toHaveBeenCalled();
     });
 
     it('reports iCloud being unavailable before any check', async () => {


### PR DESCRIPTION
Closes [SELF-3964](https://linear.app/selfprotocol/issue/SELF-3964/backup-enable-overwrites-or-duplicates-an-existing-cloud-backup-check).

## Problem

Enabling cloud backup blind-wrote: iOS `writeFile` overwrote whatever backup already existed at the frozen path; Android's Drive upload created a **duplicate** `encrypted-private-key` file on every enable (Drive identifies files by ID, not name), and restore reads `files[0]` with no ordering guarantee. Common trigger: after a phrase restore the `cloudBackupEnabled` flag is off although a backup exists, the user is nudged to back up, taps enable, and silently clobbers (iOS) or duplicates (Android) the existing backup — worst case destroying the only copy of a *different* account's backup.

## Behavior

Enable **never deletes or overwrites anything**. Before any write it checks what already exists:

| Existing state | Outcome |
|---|---|
| Nothing | Upload as before → `'created'` |
| Backup(s), **all** matching this device's phrase+password | No write; silent reconnect → `'already_backed_up'`; `Cloud Backup Enabled Done { existing: true }` |
| **Any** file with a different phrase, or **any** unreadable file | Typed `backup_conflict`; "Existing backup found … left untouched" alert; toggle stays off; `Cloud Backup Enable Failed { reason: 'backup_conflict' }` |

The same-phrase reconnect also heals the phrase-restore desync: enabling after a phrase restore reconnects to the existing backup instead of rewriting it.

## Implementation notes

- **Android runs the whole check+write under one sign-in** — each `createGDrive()` shows the Google sheet, so a check-then-upload as two operations would prompt twice. Pinned by a `createGDrive` called-exactly-once test. Listing **paginates** (`nextPageToken`), so "all duplicates compared" holds past Drive's 100-file page; per-candidate reads are capped at 3 retries and the loop short-circuits on the first mismatch. The duplicate-minting bug is dead: upload only writes when zero files exist.
- **iOS three-state probe.** `hasRemoteBackup` became `probeRemoteBackup → 'found' | 'absent' | 'unknown'` ('absent' requires at least one successful folder listing). `download()` maps both negatives to `no_backup_found` — byte-identical restore behavior, pinned by the existing tests.
- **The fresh-device case (the subtle one):** on an account that never backed up, the iOS folder doesn't exist and every listing rejects with the *same error code* as a genuine read failure. A strict "ambiguous → refuse" rule would have made every first-time iOS enable fail. Resolution: on `'unknown'`, `mkdir(FOLDER)` is the discriminator — it succeeds only if the folder didn't exist (⇒ no backup can exist ⇒ safe to create); "already exists" means unlistable-but-present ⇒ `backup_read_failed`, nothing written.
- iOS enable gains the `isCloudAvailable` guard it never had (signed-out enable is now a typed `cloud_unavailable` instead of a raw provider error).
- Comparison is `phrase && password` (`mnemonicsMatch` in `utils/crypto/mnemonic.ts`) — the password participates in key derivation, so a matching phrase with a different password must not silently reconnect.
- Only the **check phase** is wrapped in the error classifier; write-phase failures escape raw as before, so analytics don't shift a write failure into "read failed".
- `recoveryCopy.errors.backup_conflict` exists only because the choice screen indexes the full reason union (unreachable from restore — same precedent as `cloud_unavailable` on Android).

## Accepted residual risk

The probe-then-write race (remote metadata arriving immediately after a confident "absent") is the documented metadata-lag gap — not closable without NSMetadataQuery, which the library doesn't expose. It shrinks today's 100% blind overwrite to that window.

## Validation

```
pnpm --filter @selfxyz/mobile-app run test    # 1301 passed, 113 suites (18 net new)
pnpm --filter @selfxyz/mobile-app run types   # clean
pnpm --filter @selfxyz/mobile-app run lint    # 0 errors
```

No SDK changes. New coverage: reconnect (iOS local / iOS placeholder-sync / Android single / Android legacy duplicates); conflict `it.each` (different phrase / different password / corrupt) each asserting nothing written or deleted; mismatch short-circuit; Drive pagination; single sign-in; fresh-folder mkdir discriminator both ways; not-synced and signed-out enable paths. All pre-existing tests pass (4 upload tests updated for the new return value and probe; the rest untouched).

**Device QA:** run-sheet tests 23–27 in `app/docs/RECOVERY_QA_RUNSHEET.md` (added in this PR — the file also carries the merged stack's QA list). Test 23 (fresh-account enable, the mkdir-discriminator path) and 26 (conflicting backup left restorable) are the critical ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud backup now detects existing backups and reconnects to matching backups without overwriting them.
  * New backups are created only when no matching backup exists.
  * Recovery now reports clearer errors for missing, unreadable, corrupted, or unavailable backups.

* **Bug Fixes**
  * Prevented mismatched or unreadable backups from being overwritten.
  * Added an alert explaining when an existing backup was left untouched.

* **Documentation**
  * Added a device QA run sheet covering backup, restore, recovery, telemetry, and unsupported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->