### PR TITLE
bump version to 2.9.29

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -160,7 +160,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 170
-        versionName "2.9.28"
+        versionName "2.9.29"
         manifestPlaceholders = [appAuthRedirectScheme: 'com.proofofpassportapp']
         // Tesseract OCR fallback when ML Kit yields no check-digit-valid MRZ (SELF-3447).
         buildConfigField "boolean", "TESSERACT_MRZ_FALLBACK", "true"

--- a/app/app.json
+++ b/app/app.json
@@ -4,7 +4,7 @@
   "expo": {
     "name": "Self App",
     "slug": "self-app",
-    "version": "2.9.28",
+    "version": "2.9.29",
     "platforms": ["ios", "android"],
     "ios": {
       "bundleIdentifier": "com.proofofpassportapp"

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.9.28;
+				MARKETING_VERSION = 2.9.29;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -764,7 +764,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.9.28;
+				MARKETING_VERSION = 2.9.29;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/app/ios/Self/Info.plist
+++ b/app/ios/Self/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.28</string>
+	<string>2.9.29</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/mobile-app",
-  "version": "2.9.28",
+  "version": "2.9.29",
   "private": true,
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `pnpm lint && pnpm types` pass
- [ ] Bridge contract tests pass: `cd app && pnpm jest:run` and `pnpm --filter @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `pnpm --filter @selfxyz/mobile-sdk-alpha test && pnpm --filter @selfxyz/mobile-sdk-alpha types` pass
- [ ] Diff of `.kt`/`.swift` reviewed - no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent - flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) - relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) - **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the app version to **2.9.29** across Android, iOS, Expo, and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->