### PR TITLE
fix(app): staging-review findings on the cloud backup and recovery paths

### DIFF
--- a/app/src/proving/checkRestoredDocumentRegistration.ts
+++ b/app/src/proving/checkRestoredDocumentRegistration.ts
@@ -94,20 +94,27 @@ async function fetchProtocolData(
     return undefined;
   }
 
-  // Unlike passport/id_card these reject, and they reject for the whole batch —
-  // including deployed circuits, DNS mapping and OFAC, none of which this check
-  // needs. Let the commitment tree decide rather than blocking recovery on an
-  // unrelated endpoint.
+  // Fetch exactly what the check needs: the identity tree (required) and the
+  // public keys (key material, tolerated to fail — the tree decides). fetch_all
+  // batches five endpoints with Promise.all, so a fast failure from deployed
+  // circuits, DNS mapping or OFAC — none of which this check needs — would
+  // reject while the identity tree is still in flight, spuriously blocking
+  // recovery even though the tree lands moments later.
+  const publicKeysFailure = protocolState[documentCategory]
+    .fetch_public_keys(environment)
+    .catch((error: unknown) => error);
   try {
-    await protocolState[documentCategory].fetch_all(environment);
+    await protocolState[documentCategory].fetch_identity_tree(environment);
   } catch (error) {
     console.warn(
       `Protocol fetch for ${documentCategory} did not complete in full:`,
       error,
     );
+    // Settle before returning — the catch above means it can never reject.
+    await publicKeysFailure;
     return error;
   }
-  return undefined;
+  return await publicKeysFailure;
 }
 
 /**

--- a/app/src/screens/account/settings/CloudBackupScreen.tsx
+++ b/app/src/screens/account/settings/CloudBackupScreen.tsx
@@ -28,6 +28,7 @@ import {
 import { advercase, dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
 import Cloud from '@/assets/icons/logo_cloud_backup.svg';
+import { useBiometricsAvailability } from '@/hooks/useBiometricsAvailability';
 import { useModal } from '@/hooks/useModal';
 import { buttonTap, confirmTap } from '@/integrations/haptics';
 import type { RootStackParamList } from '@/navigation';
@@ -59,10 +60,13 @@ const CloudBackupScreen: React.FC<CloudBackupScreenProps> = ({
   const {
     cloudBackupEnabled,
     toggleCloudBackupEnabled,
-    biometricsAvailable,
     // DISABLED FOR NOW: Turnkey functionality
     // turnkeyBackupEnabled,
   } = useSettingStore();
+  // Re-checked on focus and foreground: the value is no longer persisted, so a
+  // transient failure of the splash-screen capability query must not leave the
+  // backup controls dead for the whole session.
+  const biometricsAvailable = useBiometricsAvailability();
   const { upload, disableBackup } = useBackupMnemonic();
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();

--- a/app/src/services/cloud-backup/ios.ts
+++ b/app/src/services/cloud-backup/ios.ts
@@ -52,14 +52,17 @@ export async function disableBackup() {
  * residual gap (metadata lag beyond the probe budget) is not closable with
  * this library's API surface; it exposes no NSMetadataQuery.
  *
- * `'absent'` requires at least one successful listing; a budget spent purely
- * on rejected listings is `'unknown'` — the folder may simply not exist, or
- * reads may genuinely be failing, and the two throw the same error code.
+ * `'absent'` requires either a successful listing or the folder itself being
+ * absent locally. A budget spent purely on rejected listings for a folder that
+ * IS present is `'unreadable'` — the contents may hold a backup that simply
+ * could not be checked, so callers must treat it as a read failure rather
+ * than as absence. (mkdir cannot make this distinction: the native
+ * createDirectory succeeds silently for an existing directory.)
  */
 async function probeRemoteBackup(
   probeAttempts: number,
   probeIntervalMs: number,
-): Promise<'found' | 'absent' | 'unknown'> {
+): Promise<'found' | 'absent' | 'unreadable'> {
   let sawSuccessfulListing = false;
   for (let attempt = 0; attempt < probeAttempts; attempt++) {
     if (attempt > 0) {
@@ -79,7 +82,10 @@ async function probeRemoteBackup(
       // without the file. Retry the whole probe.
     }
   }
-  return sawSuccessfulListing ? 'absent' : 'unknown';
+  if (sawSuccessfulListing) {
+    return 'absent';
+  }
+  return (await CloudStorage.exists(FOLDER)) ? 'unreadable' : 'absent';
 }
 
 /**
@@ -134,9 +140,15 @@ export async function download(options?: IosDownloadOptions) {
         remoteProbeAttempts,
         pollIntervalMs,
       );
-      // For restore, 'absent' and 'unknown' both mean "nothing to restore" —
-      // the accepted residual risk documented on the probe.
-      if (evidence !== 'found') {
+      if (evidence === 'unreadable') {
+        // The folder is there but could not be listed — telling the user they
+        // have no backup would be a lie; this is a retryable read failure.
+        throw new CloudBackupError(
+          'backup_read_failed',
+          'The iCloud backup folder exists but its contents could not be checked',
+        );
+      }
+      if (evidence === 'absent') {
         throw new CloudBackupError(
           'no_backup_found',
           'Couldnt find the encrypted backup, did you back it up previously?',
@@ -235,27 +247,16 @@ export async function upload(
           );
         }
         backupIsLocal = true;
-      } else if (evidence === 'absent') {
-        // Same evidence bar on which download reports "no backup found". The
-        // probe-then-write race (metadata arriving right after) is the
-        // documented metadata-lag gap — not closable with this library.
-        verdict = 'write';
-      } else {
-        // 'unknown': every listing was rejected — either the folder was never
-        // created (no backup can exist) or reads are genuinely failing. The
-        // error code cannot tell them apart. Neither can mkdir: the native
-        // createDirectory uses withIntermediateDirectories, which succeeds
-        // silently for an existing directory. A throw-free existence check on
-        // the folder itself can: present but unlistable fails closed; absent
-        // locally is the same evidence class as 'absent' — the documented
-        // metadata-lag residual.
-        if (await CloudStorage.exists(FOLDER)) {
-          throw new CloudBackupError(
-            'backup_read_failed',
-            'The iCloud backup folder exists but its contents could not be checked',
-          );
-        }
+      } else if (evidence === 'unreadable') {
+        // Present but unlistable — fail closed, never write blind.
+        throw new CloudBackupError(
+          'backup_read_failed',
+          'The iCloud backup folder exists but its contents could not be checked',
+        );
       }
+      // 'absent': same evidence bar on which download reports "no backup
+      // found". The probe-then-write race (metadata arriving right after) is
+      // the documented metadata-lag gap — not closable with this library.
     }
 
     if (backupIsLocal) {

--- a/app/tests/src/proving/checkRestoredDocumentRegistration.test.ts
+++ b/app/tests/src/proving/checkRestoredDocumentRegistration.test.ts
@@ -72,7 +72,8 @@ function keySlice() {
   return {
     commitment_tree: null as string | null,
     public_keys: null as string[] | null,
-    fetch_all: jest.fn(),
+    fetch_identity_tree: jest.fn(async () => undefined),
+    fetch_public_keys: jest.fn(async () => undefined),
   };
 }
 
@@ -315,7 +316,7 @@ describe('checkRestoredDocumentRegistration', () => {
   it('checks aadhaar documents without an AKI and without stored public keys', async () => {
     // The validator seeds the document own public key, so a null public_keys
     // list must not block the check.
-    protocolState.aadhaar.fetch_all = populates('aadhaar');
+    protocolState.aadhaar.fetch_identity_tree = populates('aadhaar');
 
     const result = await checkRestoredDocumentRegistration(
       selfClient,
@@ -323,8 +324,13 @@ describe('checkRestoredDocumentRegistration', () => {
       'secret',
     );
 
-    expect(protocolState.aadhaar.fetch_all).toHaveBeenCalledWith('prod');
-    expect(protocolState.aadhaar.fetch_all).toHaveBeenCalledTimes(1);
+    expect(protocolState.aadhaar.fetch_identity_tree).toHaveBeenCalledWith(
+      'prod',
+    );
+    expect(protocolState.aadhaar.fetch_identity_tree).toHaveBeenCalledTimes(1);
+    expect(protocolState.aadhaar.fetch_public_keys).toHaveBeenCalledWith(
+      'prod',
+    );
     expect(mockFetchAllTreesAndCircuits).not.toHaveBeenCalled();
     expect(mockIsUserRegisteredWithAlternativeCSCA).toHaveBeenCalled();
     // csca must stay null for aadhaar: the validator returns the matched public
@@ -333,14 +339,14 @@ describe('checkRestoredDocumentRegistration', () => {
     expect(result).toEqual({ isRegistered: true, csca: null });
   });
 
-  it('proceeds when an unrelated aadhaar fetch fails but the tree arrived', async () => {
-    // fetch_all batches deployed circuits, DNS mapping and OFAC alongside the
-    // identity tree and rejects for the whole batch. Recovery must not be
-    // blocked by an endpoint this check does not use.
-    protocolState.aadhaar.fetch_all = jest.fn(async () => {
-      protocolState.aadhaar.commitment_tree = TREE;
-      throw new Error('ofac endpoint down');
-    });
+  it('proceeds when the public-key fetch fails but the tree arrived', async () => {
+    // Only the identity tree is required. A fast failure from the public-key
+    // endpoint must not reject before the tree lands — the fetch_all batch
+    // used to fast-fail exactly that way and spuriously blocked recovery.
+    protocolState.aadhaar.fetch_identity_tree = populates('aadhaar');
+    protocolState.aadhaar.fetch_public_keys = jest
+      .fn()
+      .mockRejectedValue(new Error('public keys endpoint down'));
 
     const result = await checkRestoredDocumentRegistration(
       selfClient,
@@ -354,7 +360,7 @@ describe('checkRestoredDocumentRegistration', () => {
   it('falls back to the document commitment when aadhaar public keys are empty', async () => {
     // validate.ts returns early for an empty public key map, before it can seed
     // the document's own key, so the single-commitment path has to cover it.
-    protocolState.aadhaar.fetch_all = populates('aadhaar');
+    protocolState.aadhaar.fetch_identity_tree = populates('aadhaar');
     mockIsUserRegisteredWithAlternativeCSCA.mockResolvedValue({
       isRegistered: false,
       csca: null,
@@ -371,7 +377,7 @@ describe('checkRestoredDocumentRegistration', () => {
   });
 
   it('checks kyc documents even though public keys are always null', async () => {
-    protocolState.kyc.fetch_all = populates('kyc');
+    protocolState.kyc.fetch_identity_tree = populates('kyc');
 
     const result = await checkRestoredDocumentRegistration(
       selfClient,
@@ -385,7 +391,7 @@ describe('checkRestoredDocumentRegistration', () => {
 
   it('does not run a redundant fallback for kyc documents', async () => {
     // The validator already routes kyc through isUserRegistered.
-    protocolState.kyc.fetch_all = populates('kyc');
+    protocolState.kyc.fetch_identity_tree = populates('kyc');
     mockIsUserRegisteredWithAlternativeCSCA.mockResolvedValue({
       isRegistered: false,
       csca: null,
@@ -401,9 +407,11 @@ describe('checkRestoredDocumentRegistration', () => {
     expect(result).toEqual({ isRegistered: false, csca: null });
   });
 
-  it('wraps an aadhaar fetch rejection in ProtocolDataUnavailableError', async () => {
+  it('wraps an aadhaar tree-fetch rejection in ProtocolDataUnavailableError', async () => {
     const cause = new Error('network down');
-    protocolState.aadhaar.fetch_all = jest.fn().mockRejectedValue(cause);
+    protocolState.aadhaar.fetch_identity_tree = jest
+      .fn()
+      .mockRejectedValue(cause);
 
     const error = await checkRestoredDocumentRegistration(
       selfClient,

--- a/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
+++ b/app/tests/src/screens/account/recovery/AccountRecoveryChoiceScreen.test.tsx
@@ -3,6 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import React from 'react';
+import * as MockReact from 'react';
 import { AppState } from 'react-native';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
@@ -41,15 +42,14 @@ jest.mock('tamagui', () => ({
 }));
 
 // Focus maps onto mount/unmount here: the screen under test is focused for as
-// long as it is rendered, and the cleanup still runs on unmount.
-jest.mock('@react-navigation/native', () => {
-  const react = jest.requireActual('react');
-  return {
-    useNavigation: jest.fn(),
-    useFocusEffect: (callback: () => void | (() => void)) =>
-      react.useEffect(callback, [callback]),
-  };
-});
+// long as it is rendered, and the cleanup still runs on unmount. React comes
+// from the top-level import (the app test rules ban requiring it in mocks);
+// the Mock prefix satisfies jest's out-of-scope factory check.
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+  useFocusEffect: (callback: () => void | (() => void)) =>
+    MockReact.useEffect(callback, [callback]),
+}));
 
 const appStateListeners: Array<(state: string) => void> = [];
 

--- a/app/tests/src/screens/account/settings/CloudBackupScreen.test.tsx
+++ b/app/tests/src/screens/account/settings/CloudBackupScreen.test.tsx
@@ -3,6 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import React from 'react';
+import * as MockReact from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
 import CloudBackupScreen from '@/screens/account/settings/CloudBackupScreen';
@@ -35,8 +36,12 @@ jest.mock('tamagui', () => ({
   ),
 }));
 
+// Focus maps onto mount/unmount; React comes from the top-level import (the
+// app test rules ban requiring it in mocks).
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(() => ({ navigate: jest.fn() })),
+  useFocusEffect: (callback: () => void | (() => void)) =>
+    MockReact.useEffect(callback, [callback]),
 }));
 
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
@@ -137,6 +142,7 @@ describe('CloudBackupScreen', () => {
   const mockTrackEvent = jest.fn();
   const mockUpload = jest.fn();
   const mockGetOrCreateMnemonic = jest.fn();
+  const mockCheckBiometricsAvailable = jest.fn();
   const toggle = () => useSettingStore.getState().toggleCloudBackupEnabled;
 
   function pressEnableBackup() {
@@ -157,6 +163,7 @@ describe('CloudBackupScreen', () => {
     useAuth.mockReturnValue({
       getOrCreateMnemonic: mockGetOrCreateMnemonic,
       loginWithBiometrics: jest.fn(),
+      checkBiometricsAvailable: mockCheckBiometricsAvailable,
     });
     useBackupMnemonic.mockReturnValue({
       upload: mockUpload,
@@ -167,6 +174,7 @@ describe('CloudBackupScreen', () => {
       toggleCloudBackupEnabled: jest.fn(),
       biometricsAvailable: true,
     });
+    mockCheckBiometricsAvailable.mockResolvedValue(true);
     mockGetOrCreateMnemonic.mockResolvedValue({ data: { phrase: 'words' } });
   });
 
@@ -180,6 +188,25 @@ describe('CloudBackupScreen', () => {
     });
     expect(toggle()).toHaveBeenCalled();
     expect(mockAlert).not.toHaveBeenCalled();
+  });
+
+  it('repairs a stale unavailable flag by re-checking on focus', async () => {
+    // The value is no longer persisted: if the splash-screen capability query
+    // failed transiently, the store says false for the whole session. Opening
+    // this screen must re-check and unlock the controls.
+    useSettingStore.setState({ biometricsAvailable: false });
+    mockCheckBiometricsAvailable.mockResolvedValue(true);
+
+    const { UNSAFE_getAllByType } = render(
+      <CloudBackupScreen route={{ params: undefined }} {...({} as any)} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        (UNSAFE_getAllByType('Pressable' as any)[0] as any).props.disabled,
+      ).toBe(false);
+    });
+    expect(mockCheckBiometricsAvailable).toHaveBeenCalled();
   });
 
   it('reconnects to an existing matching backup and reports it', async () => {

--- a/app/tests/src/services/cloud-backup.test.ts
+++ b/app/tests/src/services/cloud-backup.test.ts
@@ -897,6 +897,31 @@ describe('cloudBackup', () => {
         expect(CloudStorage.readdir).toHaveBeenCalledTimes(2);
       });
 
+      it('reports an unlistable-but-present folder as a read failure, not absence', async () => {
+        // The folder exists, so a backup may exist inside it — "no backup
+        // found" would be a lie; the user must be told to retry instead.
+        (CloudStorage.exists as jest.Mock).mockImplementation(
+          async (path: string) => path === FOLDER,
+        );
+        (CloudStorage.readdir as jest.Mock).mockRejectedValue(
+          Object.assign(new Error('read failed'), { code: 'ERR_READ_ERROR' }),
+        );
+
+        const { result } = renderHook(() => useBackupMnemonic());
+
+        expect(
+          await rejectionReason(() =>
+            result.current.download({
+              remoteProbeAttempts: 1,
+              pollIntervalMs: 10,
+            }),
+          ),
+        ).toEqual({
+          name: 'CloudBackupError',
+          reason: 'backup_read_failed',
+        });
+      });
+
       it('reports no backup when the folder listing keeps failing', async () => {
         // ERR_READ_ERROR is what a never-created folder throws; after the
         // probe budget it must read as "no backup", not as a read failure.


### PR DESCRIPTION
Remediates four of the five bot findings from the v2.9.29 staging release cut ([#2283 review comments](https://github.com/selfxyz/self/pull/2283)). No Linear issue — review remediation on already-merged work (SELF-3931…3935, SELF-3964).

## The four fixes

**1. Restore no longer calls a present-but-unlistable iCloud folder "no backup found"** (`ios.ts`). `probeRemoteBackup` now returns `'found' | 'absent' | 'unreadable'` — the old ambiguous state resolves inside the probe via a throw-free `exists(FOLDER)`: folder present but every listing rejected → `'unreadable'`. `download()` maps it to a retryable `backup_read_failed`; `upload()`'s inline discriminator branch collapsed into the probe (identical semantics, DRY). Fresh-device / never-backed-up behavior is byte-identical (`'absent'` → `no_backup_found`), pinned by the pre-existing tests.

**2. Aadhaar/KYC recovery no longer races unrelated endpoints** (`checkRestoredDocumentRegistration.ts`). `fetch_all` is a `Promise.all` over five endpoints; a fast failure from circuits/DNS/OFAC rejected the batch while `fetch_identity_tree` was in flight → spurious retryable `ProtocolDataUnavailableError`. Recovery now awaits exactly what the check needs: the identity tree (required), with `fetch_public_keys` best-effort (the tree decides; a keys-only failure degrades to the existing fallback). **`protocolStore.ts` is untouched** — this changes which existing store fetchers the recovery-only helper calls; the proving machine keeps calling `fetch_all` and always fetches for itself before reading circuits/DNS/OFAC, so nothing outside recovery can observe the change. The passport/id_card branch is untouched (its fetchers swallow internally, so its batch can't fast-fail — the asymmetry #2272 documented).

**3. `CloudBackupScreen` re-checks biometric availability** via `useBiometricsAvailability()` instead of reading the raw store flag. Post-de-persistence, one transient splash capability-query failure left the enable/disable controls dead for the whole session with no repair path; the screen now re-checks on focus and foreground like the recovery screen. New test pins the session-repair behavior.

**4. Banned React-loading pattern removed from test mocks.** The `useFocusEffect` mocks used `jest.requireActual('react')` inside the `jest.mock` factory — the nested-loading pattern `app/AGENTS.md` prohibits (CI OOM class) that the lint guard doesn't catch. Both test files now use a top-level `import * as MockReact from 'react'` (jest's `mock`-prefix factory exemption).

## The consciously ignored fifth

"Fail closed on all `'unknown'`" — this is the metadata-lag residual documented in #2280's *Accepted residual risk* section. Its remedy would make **every fresh-device iOS enable fail** (the folder never exists before the first backup, so every listing rejects). The `'unreadable'`/`'absent'` split in fix 1 is the fraction of that comment that is safely actionable; the rest remains accepted, with `backup_conflict` telemetry as the tripwire for revisiting.

## Validation

```
pnpm --filter @selfxyz/mobile-app run test   # 1303 passed, 113 suites
pnpm --filter @selfxyz/mobile-app run types  # clean
pnpm --filter @selfxyz/mobile-app run lint   # 0 errors
```

New coverage: unlistable-but-present folder → `backup_read_failed` on restore (and still on enable); aadhaar public-key fast-fail with the tree landing → recovery proceeds; tree-fetch rejection → `ProtocolDataUnavailableError` with cause (re-pointed from the old `fetch_all` stubs); CloudBackupScreen stale-flag repair on focus. `protocolStore` untouched; no SDK changes.

Note for the release: #2283 was cut before this — the staging branch needs updating/re-cutting once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document recovery for Aadhaar and KYC documents when public-key services are unavailable.
  * Biometric availability now refreshes when returning to the Cloud Backup screen.
  * Cloud backups now distinguish missing folders from unreadable folders, preventing unsafe uploads and providing clearer download errors.
* **Tests**
  * Added coverage for recovery, biometric refresh, and unreadable backup-folder scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->