### PR TITLE
feat(app): store review prompt after verified proofs and Google USAT …

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -109,6 +109,8 @@ PODS:
     - React-Core
     - React-runtimescheduler
     - ReactCommon
+  - ExpoStoreReview (55.0.17):
+    - ExpoModulesCore
   - fast_float (8.0.0)
   - FBLazyVector (0.83.9)
   - Firebase/Analytics (11.11.0):
@@ -3726,6 +3728,7 @@ DEPENDENCIES:
   - "ExpoLogBox (from `../../node_modules/@expo/log-box`)"
   - ExpoModulesCore (from `../../node_modules/expo-modules-core`)
   - ExpoModulesJSI (from `../../node_modules/expo-modules-core`)
+  - ExpoStoreReview (from `../../node_modules/expo-store-review/ios`)
   - fast_float (from `../../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../../node_modules/react-native/third-party-podspecs/fmt.podspec`)
@@ -3921,6 +3924,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/expo-modules-core"
   ExpoModulesJSI:
     :path: "../../node_modules/expo-modules-core"
+  ExpoStoreReview:
+    :path: "../../node_modules/expo-store-review/ios"
   fast_float:
     :podspec: "../../node_modules/react-native/third-party-podspecs/fast_float.podspec"
   FBLazyVector:
@@ -4186,6 +4191,7 @@ SPEC CHECKSUMS:
   ExpoLogBox: 617da77cbc083627692b2ea050a3666808aef2cd
   ExpoModulesCore: dfa76e2009e1b6b602bd7b4c2a5ed0a59ce33a6c
   ExpoModulesJSI: bbd6d912b19ba7455d95b2c2fd3bc73459f8cba9
+  ExpoStoreReview: 895668d2c4f503286ef2100b431d9561d7039d1a
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 3bcb3055086e5d90a12f0fe1668e79f6eceabc17
   Firebase: 6a8f201c61eda24e98f1ce2b44b1b9c2caf525cc

--- a/app/jest.config.cjs
+++ b/app/jest.config.cjs
@@ -46,6 +46,7 @@ module.exports = {
     '^expo-file-system$': '<rootDir>/tests/__setup__/expoFileSystemMock.js',
     '^expo-document-picker$':
       '<rootDir>/tests/__setup__/expoDocumentPickerMock.js',
+    '^expo-store-review$': '<rootDir>/tests/__setup__/expoStoreReviewMock.js',
     // Avoid loading lottie-react-native's nested react-native runtime in Jest.
     '^lottie-react-native$': '<rootDir>/tests/__setup__/lottieMock.js',
     // Mock react-native-blur-effect: under pnpm hoisted, it ships a nested

--- a/app/package.json
+++ b/app/package.json
@@ -130,6 +130,7 @@
     "expo-camera": "55.0.17",
     "expo-document-picker": "55.0.14",
     "expo-file-system": "55.0.22",
+    "expo-store-review": "55.0.17",
     "lottie-react-native": "7.3.6",
     "node-forge": "^1.4.0",
     "pkijs": "^3.4.0",

--- a/app/src/components/KycFaucetNoticeModal.tsx
+++ b/app/src/components/KycFaucetNoticeModal.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import React, { useEffect, useMemo } from 'react';
+
+import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
+import { KycEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+
+import AlertModal, { type AlertModalParams } from '@/components/AlertModal';
+import { KYC_FAUCET_NOTICE_COPY } from '@/integrations/kyc/faucetNotice';
+import { useKycFaucetNoticeStore } from '@/stores/kycFaucetNoticeStore';
+
+const KycFaucetNoticeModal: React.FC = () => {
+  const selfClient = useSelfClient();
+  const isOpen = useKycFaucetNoticeStore(state => state.isOpen);
+  const isContinuing = useKycFaucetNoticeStore(state => state.isContinuing);
+  const close = useKycFaucetNoticeStore(state => state.close);
+
+  useEffect(() => {
+    if (isOpen) {
+      selfClient.trackEvent(KycEvents.FAUCET_NOTICE_SHOWN);
+    }
+  }, [isOpen, selfClient]);
+
+  const modalParams = useMemo<AlertModalParams>(() => {
+    const decline = () => {
+      selfClient.trackEvent(KycEvents.FAUCET_NOTICE_DECLINED);
+      useKycFaucetNoticeStore.getState().onDecline?.();
+    };
+    return {
+      titleText: KYC_FAUCET_NOTICE_COPY.titleText,
+      bodyText: KYC_FAUCET_NOTICE_COPY.bodyText,
+      buttonText: isContinuing
+        ? KYC_FAUCET_NOTICE_COPY.loadingText
+        : KYC_FAUCET_NOTICE_COPY.continueText,
+      secondaryButtonText: isContinuing
+        ? undefined
+        : KYC_FAUCET_NOTICE_COPY.goBackText,
+      disablePrimaryButton: isContinuing,
+      preventDismiss: isContinuing,
+      onButtonPress: async () => {
+        const { onContinue, markContinuing } =
+          useKycFaucetNoticeStore.getState();
+        selfClient.trackEvent(KycEvents.FAUCET_NOTICE_CONTINUED);
+        markContinuing();
+        await onContinue?.();
+      },
+      onSecondaryButtonPress: decline,
+      onModalDismiss: decline,
+    };
+  }, [isContinuing, selfClient]);
+
+  if (!isOpen) return null;
+
+  return <AlertModal visible modalParams={modalParams} onHideModal={close} />;
+};
+
+export default KycFaucetNoticeModal;

--- a/app/src/hooks/useKycLauncher.ts
+++ b/app/src/hooks/useKycLauncher.ts
@@ -22,6 +22,7 @@ import {
   KYC_PROVIDER,
   launchKycVerification as startKycVerification,
 } from '@/integrations/kyc';
+import { confirmKycFaucetNotice } from '@/integrations/kyc/faucetNotice';
 import type { KycVerificationResult } from '@/integrations/kyc/types';
 import type { RootStackParamList } from '@/navigation';
 import { useFeedback } from '@/providers/feedbackProvider';
@@ -63,10 +64,11 @@ export interface UseKycLauncherOptions {
  * Custom hook for launching KYC verification with consistent error handling.
  *
  * Abstracts the common pattern of:
- * 1. Creating a session
- * 2. Launching the provider SDK
- * 3. Handling errors by navigating to fallback screen
- * 4. Managing loading state
+ * 1. Running the pre-launch checks and the faucet-incompatibility notice
+ * 2. Creating a session
+ * 3. Launching the provider SDK
+ * 4. Handling errors by navigating to fallback screen
+ * 5. Managing loading state
  *
  * @example
  * ```tsx
@@ -93,60 +95,10 @@ export const useKycLauncher = (options: UseKycLauncherOptions) => {
   const selfClient = useSelfClient();
   const [isLoading, setIsLoading] = useState(false);
 
-  const launchKycVerification = useCallback(async () => {
-    const hasPendingOrProcessingKyc = () =>
-      usePendingKycStore
-        .getState()
-        .pendingVerifications.some(
-          verification =>
-            verification.status === 'pending' ||
-            verification.status === 'processing',
-        );
-
-    setIsLoading(true);
+  const runKycProviderFlow = useCallback(async () => {
     const sessionRequestedAt = Date.now();
     let providerOpenedAt: number | null = null;
     try {
-      if (hasPendingOrProcessingKyc()) {
-        showModal({
-          titleText: 'Verification in progress',
-          bodyText:
-            "You already have a KYC verification being processed. We'll notify you when it's ready.",
-          buttonText: 'Dismiss',
-          onButtonPress: () => {},
-        });
-        return;
-      }
-
-      let kycDocumentCount: number;
-      try {
-        kycDocumentCount = await getKycDocumentCount();
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        const safeError = sanitizeErrorMessage(errorMessage);
-        console.error('Unable to verify KYC document count:', safeError);
-        showModal({
-          titleText: 'Unable to verify verification limit',
-          bodyText:
-            "We couldn't confirm how many verified IDs are stored. Please try again.",
-          buttonText: 'Dismiss',
-          onButtonPress: () => {},
-        });
-        return;
-      }
-
-      if (kycDocumentCount >= 3) {
-        showModal({
-          titleText: 'Maximum verifications reached',
-          bodyText:
-            'You can have up to 3 verified IDs. Remove one before starting a new verification.',
-          buttonText: 'Dismiss',
-          onButtonPress: () => {},
-        });
-        return;
-      }
-
       trackBranchEvent(selfClient, KycEvents.SESSION_REQUESTED, {
         provider: KYC_PROVIDER,
       });
@@ -243,18 +195,70 @@ export const useKycLauncher = (options: UseKycLauncherOptions) => {
       } else {
         navigation.navigate('KycConnectionError', { countryCode });
       }
+    }
+  }, [navigation, selfClient, countryCode, onSuccess, onCancel, onError]);
+
+  const launchKycVerification = useCallback(async () => {
+    const hasPendingOrProcessingKyc = () =>
+      usePendingKycStore
+        .getState()
+        .pendingVerifications.some(
+          verification =>
+            verification.status === 'pending' ||
+            verification.status === 'processing',
+        );
+
+    setIsLoading(true);
+    try {
+      if (hasPendingOrProcessingKyc()) {
+        showModal({
+          titleText: 'Verification in progress',
+          bodyText:
+            "You already have a KYC verification being processed. We'll notify you when it's ready.",
+          buttonText: 'Dismiss',
+          onButtonPress: () => {},
+        });
+        return;
+      }
+
+      let kycDocumentCount: number;
+      try {
+        kycDocumentCount = await getKycDocumentCount();
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        const safeError = sanitizeErrorMessage(errorMessage);
+        console.error('Unable to verify KYC document count:', safeError);
+        showModal({
+          titleText: 'Unable to verify verification limit',
+          bodyText:
+            "We couldn't confirm how many verified IDs are stored. Please try again.",
+          buttonText: 'Dismiss',
+          onButtonPress: () => {},
+        });
+        return;
+      }
+
+      if (kycDocumentCount >= 3) {
+        showModal({
+          titleText: 'Maximum verifications reached',
+          bodyText:
+            'You can have up to 3 verified IDs. Remove one before starting a new verification.',
+          buttonText: 'Dismiss',
+          onButtonPress: () => {},
+        });
+        return;
+      }
+
+      await confirmKycFaucetNotice(
+        showModal,
+        { onContinue: runKycProviderFlow },
+        selfClient,
+      );
     } finally {
       setIsLoading(false);
     }
-  }, [
-    navigation,
-    selfClient,
-    countryCode,
-    onSuccess,
-    onCancel,
-    onError,
-    showModal,
-  ]);
+  }, [runKycProviderFlow, selfClient, showModal]);
 
   const showKycFallbackModal = useCallback(
     (onDismiss: () => void) => {

--- a/app/src/hooks/useStoreReviewPrompt.ts
+++ b/app/src/hooks/useStoreReviewPrompt.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useCallback } from 'react';
+import { AppState } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+
+import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
+
+import { navigationRef } from '@/navigation';
+import { requestStoreReviewIfEligible } from '@/services/storeReview';
+import { useStoreReviewStore } from '@/stores/storeReviewStore';
+
+export const STORE_REVIEW_PROMPT_ROUTE = 'Home';
+// Lets the Home transition finish so the OS sheet lands on a settled screen.
+export const STORE_REVIEW_PROMPT_DELAY_MS = 1200;
+
+/**
+ * Consumes a store-review prompt armed by a verified proof once the host
+ * screen is focused and settled. Mount on the Home screen only.
+ */
+export function useStoreReviewPrompt() {
+  const selfClient = useSelfClient();
+  const promptArmed = useStoreReviewStore(state => state.promptArmed);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!promptArmed) return;
+
+      const timer = setTimeout(() => {
+        // Another route (backup or update Modal) or a backgrounded app means
+        // this is not a good moment; stay armed and retry on the next focus.
+        if (AppState.currentState !== 'active') return;
+        if (
+          navigationRef.getCurrentRoute?.()?.name !== STORE_REVIEW_PROMPT_ROUTE
+        ) {
+          return;
+        }
+        useStoreReviewStore.getState().disarmPrompt();
+        requestStoreReviewIfEligible(selfClient).catch(() => undefined);
+      }, STORE_REVIEW_PROMPT_DELAY_MS);
+
+      return () => clearTimeout(timer);
+    }, [promptArmed, selfClient]),
+  );
+}

--- a/app/src/integrations/kyc/faucetNotice.ts
+++ b/app/src/integrations/kyc/faucetNotice.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { SelfClient } from '@selfxyz/mobile-sdk-alpha';
+import { KycEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+
+import type { AlertModalParams } from '@/components/AlertModal';
+
+export const KYC_FAUCET_NOTICE_COPY = {
+  titleText: 'Not compatible with the Google USAT faucet',
+  bodyText:
+    'IDs verified through our third-party partner cannot be used to claim from the Google USAT mainnet faucet. To claim from the faucet, verify a passport or an NFC-enabled ID instead.',
+  continueText: 'Continue anyway',
+  goBackText: 'Go back',
+  loadingText: 'Loading...',
+} as const;
+
+export interface KycFaucetNoticeHandlers {
+  onContinue: () => Promise<void> | void;
+  onDecline?: () => void;
+}
+
+export type KycFaucetNoticeTracker = Pick<SelfClient, 'trackEvent'>;
+
+/**
+ * Shows the faucet-incompatibility notice through an alert modal `showModal`
+ * and resolves with `true` after `onContinue` settles, or `false` when the user
+ * backs out. While `onContinue` runs the same modal switches to a locked
+ * loading state, so callers that were themselves launched from an alert modal
+ * never stack a second RN Modal.
+ */
+export function confirmKycFaucetNotice(
+  showModal: (params: AlertModalParams) => void,
+  { onContinue, onDecline }: KycFaucetNoticeHandlers,
+  tracker?: KycFaucetNoticeTracker,
+): Promise<boolean> {
+  return new Promise<boolean>(resolve => {
+    let settled = false;
+    const settle = (accepted: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(accepted);
+    };
+    const decline = () => {
+      if (settled) return;
+      tracker?.trackEvent(KycEvents.FAUCET_NOTICE_DECLINED);
+      onDecline?.();
+      settle(false);
+    };
+
+    tracker?.trackEvent(KycEvents.FAUCET_NOTICE_SHOWN);
+    showModal({
+      titleText: KYC_FAUCET_NOTICE_COPY.titleText,
+      bodyText: KYC_FAUCET_NOTICE_COPY.bodyText,
+      buttonText: KYC_FAUCET_NOTICE_COPY.continueText,
+      secondaryButtonText: KYC_FAUCET_NOTICE_COPY.goBackText,
+      onButtonPress: async () => {
+        tracker?.trackEvent(KycEvents.FAUCET_NOTICE_CONTINUED);
+        showModal({
+          titleText: KYC_FAUCET_NOTICE_COPY.titleText,
+          bodyText: KYC_FAUCET_NOTICE_COPY.bodyText,
+          buttonText: KYC_FAUCET_NOTICE_COPY.loadingText,
+          disablePrimaryButton: true,
+          preventDismiss: true,
+          onButtonPress: () => {},
+        });
+        try {
+          await onContinue();
+        } finally {
+          settle(true);
+        }
+      },
+      onSecondaryButtonPress: decline,
+      onModalDismiss: decline,
+    });
+  });
+}

--- a/app/src/navigation/index.tsx
+++ b/app/src/navigation/index.tsx
@@ -15,6 +15,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
 
+import KycFaucetNoticeModal from '@/components/KycFaucetNoticeModal';
 import { DefaultNavBar } from '@/components/navbar';
 import VerificationGateModal from '@/components/VerificationGateModal';
 import { usePendingKycRecovery } from '@/hooks/usePendingKycRecovery';
@@ -109,6 +110,7 @@ const NavigationWithTracking = () => {
     <GestureHandlerRootView>
       <Navigation ref={navigationRef} onStateChange={trackScreen} />
       <VerificationGateModal />
+      <KycFaucetNoticeModal />
     </GestureHandlerRootView>
   );
 };

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -50,6 +50,7 @@ import {
   type InjectedErrorType,
   useErrorInjectionStore,
 } from '@/stores/errorInjectionStore';
+import { showKycFaucetNotice } from '@/stores/kycFaucetNoticeStore';
 import { useSettingStore } from '@/stores/settingStore';
 import { IS_DEV_MODE } from '@/utils/devUtils';
 import {
@@ -358,163 +359,165 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
               }
               break;
             case 'kyc':
-              (async () => {
-                const sessionRequestedAt = Date.now();
-                let providerOpenedAt = 0;
-                const trackEventClient = { trackEvent };
-                try {
-                  if (
-                    useErrorInjectionStore
-                      .getState()
-                      .shouldTrigger('kyc_initialization')
-                  ) {
-                    console.log('[DEV] Injecting KYC initialization error');
-                    throw new Error(
-                      'Injected KYC initialization error for testing',
+              showKycFaucetNotice({
+                onContinue: async () => {
+                  const sessionRequestedAt = Date.now();
+                  let providerOpenedAt = 0;
+                  const trackEventClient = { trackEvent };
+                  try {
+                    if (
+                      useErrorInjectionStore
+                        .getState()
+                        .shouldTrigger('kyc_initialization')
+                    ) {
+                      console.log('[DEV] Injecting KYC initialization error');
+                      throw new Error(
+                        'Injected KYC initialization error for testing',
+                      );
+                    }
+
+                    // SCAN_STARTED must fire before any KYC branch event so the
+                    // funnel attempt is bootstrapped — trackBranchEvent no-ops
+                    // when currentAttempt is null. See ANA-12 Path C invariant
+                    // (specs/projects/sdk/workstreams/analytics/plans/
+                    // ANA-12-branch-specific-funnel-events.md).
+                    trackOnboardingStep(
+                      trackEventClient,
+                      OnboardingEvents.SCAN_STARTED,
+                      { branch: 'kyc' },
                     );
-                  }
+                    trackBranchEvent(
+                      trackEventClient,
+                      KycEvents.SESSION_REQUESTED,
+                      { provider: KYC_PROVIDER },
+                    );
+                    const session = await createKycSession({
+                      country: countryCode,
+                      nationality: countryCode,
+                    });
+                    trackBranchEvent(
+                      trackEventClient,
+                      KycEvents.SESSION_CREATED,
+                      {
+                        provider: KYC_PROVIDER,
+                        duration_seconds: parseFloat(
+                          ((Date.now() - sessionRequestedAt) / 1000).toFixed(2),
+                        ),
+                      },
+                    );
+                    providerOpenedAt = Date.now();
+                    trackBranchEvent(
+                      trackEventClient,
+                      KycEvents.PROVIDER_OPENED,
+                      { provider: KYC_PROVIDER },
+                    );
+                    const result = await launchKycVerification(
+                      session.sessionToken,
+                    );
+                    const providerDurationSeconds = parseFloat(
+                      ((Date.now() - providerOpenedAt) / 1000).toFixed(2),
+                    );
 
-                  // SCAN_STARTED must fire before any KYC branch event so the
-                  // funnel attempt is bootstrapped — trackBranchEvent no-ops
-                  // when currentAttempt is null. See ANA-12 Path C invariant
-                  // (specs/projects/sdk/workstreams/analytics/plans/
-                  // ANA-12-branch-specific-funnel-events.md).
-                  trackOnboardingStep(
-                    trackEventClient,
-                    OnboardingEvents.SCAN_STARTED,
-                    { branch: 'kyc' },
-                  );
-                  trackBranchEvent(
-                    trackEventClient,
-                    KycEvents.SESSION_REQUESTED,
-                    { provider: KYC_PROVIDER },
-                  );
-                  const session = await createKycSession({
-                    country: countryCode,
-                    nationality: countryCode,
-                  });
-                  trackBranchEvent(
-                    trackEventClient,
-                    KycEvents.SESSION_CREATED,
-                    {
-                      provider: KYC_PROVIDER,
-                      duration_seconds: parseFloat(
-                        ((Date.now() - sessionRequestedAt) / 1000).toFixed(2),
-                      ),
-                    },
-                  );
-                  providerOpenedAt = Date.now();
-                  trackBranchEvent(
-                    trackEventClient,
-                    KycEvents.PROVIDER_OPENED,
-                    { provider: KYC_PROVIDER },
-                  );
-                  const result = await launchKycVerification(
-                    session.sessionToken,
-                  );
-                  const providerDurationSeconds = parseFloat(
-                    ((Date.now() - providerOpenedAt) / 1000).toFixed(2),
-                  );
+                    console.log('[KYC] Result type:', result.type);
 
-                  console.log('[KYC] Result type:', result.type);
+                    if (result.type === 'cancelled') {
+                      trackBranchEvent(
+                        trackEventClient,
+                        KycEvents.PROVIDER_CLOSED,
+                        {
+                          provider: KYC_PROVIDER,
+                          outcome: 'cancelled',
+                          duration_seconds: providerDurationSeconds,
+                        },
+                      );
+                      console.log(
+                        '[KYC] User cancelled or closed without completing',
+                      );
+                      return;
+                    }
 
-                  if (result.type === 'cancelled') {
+                    const shouldInjectVerificationError = useErrorInjectionStore
+                      .getState()
+                      .shouldTrigger('kyc_verification');
+
+                    if (
+                      result.type === 'failed' ||
+                      shouldInjectVerificationError
+                    ) {
+                      if (shouldInjectVerificationError) {
+                        console.log('[DEV] Injecting KYC verification error');
+                      } else {
+                        const safeError = sanitizeErrorMessage(
+                          result.error?.message ||
+                            result.error?.type ||
+                            'unknown_error',
+                        );
+                        console.error('KYC provider failed:', safeError);
+                      }
+                      trackBranchEvent(
+                        trackEventClient,
+                        KycEvents.PROVIDER_CLOSED,
+                        {
+                          provider: KYC_PROVIDER,
+                          outcome: 'failed',
+                          error_code: result.error?.type,
+                          duration_seconds: providerDurationSeconds,
+                        },
+                      );
+                      if (navigationRef.isReady()) {
+                        navigationRef.navigate('KycFailure', {
+                          countryCode,
+                          canRetry: true,
+                        });
+                      }
+                      return;
+                    }
+
                     trackBranchEvent(
                       trackEventClient,
                       KycEvents.PROVIDER_CLOSED,
                       {
                         provider: KYC_PROVIDER,
-                        outcome: 'cancelled',
+                        outcome: 'completed',
                         duration_seconds: providerDurationSeconds,
                       },
                     );
                     console.log(
-                      '[KYC] User cancelled or closed without completing',
-                    );
-                    return;
-                  }
-
-                  const shouldInjectVerificationError = useErrorInjectionStore
-                    .getState()
-                    .shouldTrigger('kyc_verification');
-
-                  if (
-                    result.type === 'failed' ||
-                    shouldInjectVerificationError
-                  ) {
-                    if (shouldInjectVerificationError) {
-                      console.log('[DEV] Injecting KYC verification error');
-                    } else {
-                      const safeError = sanitizeErrorMessage(
-                        result.error?.message ||
-                          result.error?.type ||
-                          'unknown_error',
-                      );
-                      console.error('KYC provider failed:', safeError);
-                    }
-                    trackBranchEvent(
-                      trackEventClient,
-                      KycEvents.PROVIDER_CLOSED,
-                      {
-                        provider: KYC_PROVIDER,
-                        outcome: 'failed',
-                        error_code: result.error?.type,
-                        duration_seconds: providerDurationSeconds,
-                      },
+                      '[KYC] Verification submitted, status:',
+                      result.session?.status,
                     );
                     if (navigationRef.isReady()) {
-                      navigationRef.navigate('KycFailure', {
-                        countryCode,
-                        canRetry: true,
+                      navigationRef.navigate('KycSuccess', {
+                        sessionId: session.sessionId,
                       });
                     }
-                    return;
-                  }
-
-                  trackBranchEvent(
-                    trackEventClient,
-                    KycEvents.PROVIDER_CLOSED,
-                    {
-                      provider: KYC_PROVIDER,
-                      outcome: 'completed',
-                      duration_seconds: providerDurationSeconds,
-                    },
-                  );
-                  console.log(
-                    '[KYC] Verification submitted, status:',
-                    result.session?.status,
-                  );
-                  if (navigationRef.isReady()) {
-                    navigationRef.navigate('KycSuccess', {
-                      sessionId: session.sessionId,
-                    });
-                  }
-                } catch (error) {
-                  if (providerOpenedAt > 0) {
-                    trackBranchEvent(
-                      trackEventClient,
-                      KycEvents.PROVIDER_CLOSED,
-                      {
-                        provider: KYC_PROVIDER,
-                        outcome: 'failed',
-                        error_code: 'exception',
-                        duration_seconds: parseFloat(
-                          ((Date.now() - providerOpenedAt) / 1000).toFixed(2),
-                        ),
-                      },
+                  } catch (error) {
+                    if (providerOpenedAt > 0) {
+                      trackBranchEvent(
+                        trackEventClient,
+                        KycEvents.PROVIDER_CLOSED,
+                        {
+                          provider: KYC_PROVIDER,
+                          outcome: 'failed',
+                          error_code: 'exception',
+                          duration_seconds: parseFloat(
+                            ((Date.now() - providerOpenedAt) / 1000).toFixed(2),
+                          ),
+                        },
+                      );
+                    }
+                    const safeInitError = sanitizeErrorMessage(
+                      error instanceof Error ? error.message : String(error),
                     );
+                    console.error('Error in KYC flow:', safeInitError);
+                    if (navigationRef.isReady()) {
+                      navigationRef.navigate('KycConnectionError', {
+                        countryCode,
+                      });
+                    }
                   }
-                  const safeInitError = sanitizeErrorMessage(
-                    error instanceof Error ? error.message : String(error),
-                  );
-                  console.error('Error in KYC flow:', safeInitError);
-                  if (navigationRef.isReady()) {
-                    navigationRef.navigate('KycConnectionError', {
-                      countryCode,
-                    });
-                  }
-                }
-              })();
+                },
+              });
               break;
             default:
               if (countryCode) {

--- a/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
+++ b/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
@@ -42,6 +42,7 @@ import {
   KYC_PROVIDER,
   launchKycVerification,
 } from '@/integrations/kyc';
+import { confirmKycFaucetNotice } from '@/integrations/kyc/faucetNotice';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
 import type { RootStackParamList } from '@/navigation';
 import { useFeedback } from '@/providers/feedbackProvider';
@@ -65,6 +66,108 @@ const LogoConfirmationScreen: React.FC = () => {
     navigateToOnboarding();
   }, [navigateToOnboarding]);
 
+  const runKycFlow = useCallback(async () => {
+    let scanStarted = false;
+    const sessionRequestedAt = Date.now();
+    let providerOpenedAt: number | null = null;
+    try {
+      trackBranchEvent(selfClient, KycEvents.SESSION_REQUESTED, {
+        provider: KYC_PROVIDER,
+      });
+      const session = await createKycSession({
+        country: countryCode,
+        nationality: countryCode,
+      });
+      trackBranchEvent(selfClient, KycEvents.SESSION_CREATED, {
+        provider: KYC_PROVIDER,
+        duration_seconds: parseFloat(
+          ((Date.now() - sessionRequestedAt) / 1000).toFixed(2),
+        ),
+      });
+      trackOnboardingStep(selfClient, OnboardingEvents.SCAN_STARTED, {
+        branch: 'kyc',
+      });
+      scanStarted = true;
+      providerOpenedAt = Date.now();
+      trackBranchEvent(selfClient, KycEvents.PROVIDER_OPENED, {
+        provider: KYC_PROVIDER,
+      });
+      const result = await launchKycVerification(session.sessionToken);
+      const providerDurationSeconds = parseFloat(
+        ((Date.now() - providerOpenedAt) / 1000).toFixed(2),
+      );
+
+      // User cancelled/dismissed without completing verification
+      if (result.type === 'cancelled') {
+        trackBranchEvent(selfClient, KycEvents.PROVIDER_CLOSED, {
+          provider: KYC_PROVIDER,
+          outcome: 'cancelled',
+          duration_seconds: providerDurationSeconds,
+        });
+        failOnboardingAttempt(selfClient, 'scan_started', 'kyc_cancelled');
+        return;
+      }
+
+      // Verification failed (provider error/rejection)
+      if (result.type === 'failed') {
+        console.error(
+          'KYC verification failed:',
+          result.error?.type ?? 'unknown',
+        );
+        trackBranchEvent(selfClient, KycEvents.PROVIDER_CLOSED, {
+          provider: KYC_PROVIDER,
+          outcome: 'failed',
+          error_code: result.error?.type,
+          duration_seconds: providerDurationSeconds,
+        });
+        failOnboardingAttempt(
+          selfClient,
+          'scan_started',
+          `kyc_failed:${result.error?.type ?? 'unknown'}`,
+        );
+        navigation.navigate('KycFailure', {
+          countryCode,
+          canRetry: true,
+        });
+        return;
+      }
+
+      // Verification succeeded - navigate to KycSuccessScreen
+      trackBranchEvent(selfClient, KycEvents.PROVIDER_CLOSED, {
+        provider: KYC_PROVIDER,
+        outcome: 'completed',
+        duration_seconds: providerDurationSeconds,
+      });
+      trackOnboardingStep(selfClient, OnboardingEvents.SCAN_SUCCEEDED, {
+        branch: 'kyc',
+      });
+      navigation.navigate('KycSuccess', { sessionId: session.sessionId });
+    } catch {
+      if (providerOpenedAt !== null) {
+        trackBranchEvent(selfClient, KycEvents.PROVIDER_CLOSED, {
+          provider: KYC_PROVIDER,
+          outcome: 'failed',
+          error_code: 'launch_error',
+          duration_seconds: parseFloat(
+            ((Date.now() - providerOpenedAt) / 1000).toFixed(2),
+          ),
+        });
+      }
+      console.error('Error launching KYC verification');
+      failOnboardingAttempt(
+        selfClient,
+        scanStarted ? 'scan_started' : 'pre_start',
+        scanStarted ? 'kyc_launch_error' : 'kyc_session_error',
+      );
+      showModal({
+        titleText: 'Error',
+        bodyText: 'Unable to start verification. Please try again.',
+        buttonText: 'OK',
+        onButtonPress: () => {},
+      });
+    }
+  }, [countryCode, navigation, selfClient, showModal]);
+
   const handleNotFound = useCallback(() => {
     buttonTap();
     // "No" on the chip-symbol check routes through the KYC provider —
@@ -75,109 +178,14 @@ const LogoConfirmationScreen: React.FC = () => {
       bodyText:
         "To complete registration of a document without a biometric chip, you'll be redirected to our third party verification partner.",
       buttonText: 'Proceed with an external verifier',
-      onButtonPress: async () => {
-        let scanStarted = false;
-        const sessionRequestedAt = Date.now();
-        let providerOpenedAt: number | null = null;
-        try {
-          trackBranchEvent(selfClient, KycEvents.SESSION_REQUESTED, {
-            provider: KYC_PROVIDER,
-          });
-          const session = await createKycSession({
-            country: countryCode,
-            nationality: countryCode,
-          });
-          trackBranchEvent(selfClient, KycEvents.SESSION_CREATED, {
-            provider: KYC_PROVIDER,
-            duration_seconds: parseFloat(
-              ((Date.now() - sessionRequestedAt) / 1000).toFixed(2),
-            ),
-          });
-          trackOnboardingStep(selfClient, OnboardingEvents.SCAN_STARTED, {
-            branch: 'kyc',
-          });
-          scanStarted = true;
-          providerOpenedAt = Date.now();
-          trackBranchEvent(selfClient, KycEvents.PROVIDER_OPENED, {
-            provider: KYC_PROVIDER,
-          });
-          const result = await launchKycVerification(session.sessionToken);
-          const providerDurationSeconds = parseFloat(
-            ((Date.now() - providerOpenedAt) / 1000).toFixed(2),
-          );
-
-          // User cancelled/dismissed without completing verification
-          if (result.type === 'cancelled') {
-            trackBranchEvent(selfClient, KycEvents.PROVIDER_CLOSED, {
-              provider: KYC_PROVIDER,
-              outcome: 'cancelled',
-              duration_seconds: providerDurationSeconds,
-            });
-            failOnboardingAttempt(selfClient, 'scan_started', 'kyc_cancelled');
-            return;
-          }
-
-          // Verification failed (provider error/rejection)
-          if (result.type === 'failed') {
-            console.error(
-              'KYC verification failed:',
-              result.error?.type ?? 'unknown',
-            );
-            trackBranchEvent(selfClient, KycEvents.PROVIDER_CLOSED, {
-              provider: KYC_PROVIDER,
-              outcome: 'failed',
-              error_code: result.error?.type,
-              duration_seconds: providerDurationSeconds,
-            });
-            failOnboardingAttempt(
-              selfClient,
-              'scan_started',
-              `kyc_failed:${result.error?.type ?? 'unknown'}`,
-            );
-            navigation.navigate('KycFailure', {
-              countryCode,
-              canRetry: true,
-            });
-            return;
-          }
-
-          // Verification succeeded - navigate to KycSuccessScreen
-          trackBranchEvent(selfClient, KycEvents.PROVIDER_CLOSED, {
-            provider: KYC_PROVIDER,
-            outcome: 'completed',
-            duration_seconds: providerDurationSeconds,
-          });
-          trackOnboardingStep(selfClient, OnboardingEvents.SCAN_SUCCEEDED, {
-            branch: 'kyc',
-          });
-          navigation.navigate('KycSuccess', { sessionId: session.sessionId });
-        } catch {
-          if (providerOpenedAt !== null) {
-            trackBranchEvent(selfClient, KycEvents.PROVIDER_CLOSED, {
-              provider: KYC_PROVIDER,
-              outcome: 'failed',
-              error_code: 'launch_error',
-              duration_seconds: parseFloat(
-                ((Date.now() - providerOpenedAt) / 1000).toFixed(2),
-              ),
-            });
-          }
-          console.error('Error launching KYC verification');
-          failOnboardingAttempt(
-            selfClient,
-            scanStarted ? 'scan_started' : 'pre_start',
-            scanStarted ? 'kyc_launch_error' : 'kyc_session_error',
-          );
-          showModal({
-            titleText: 'Error',
-            bodyText: 'Unable to start verification. Please try again.',
-            buttonText: 'OK',
-            onButtonPress: () => {},
-          });
-        }
-      },
+      onButtonPress: () =>
+        confirmKycFaucetNotice(
+          showModal,
+          { onContinue: runKycFlow },
+          selfClient,
+        ),
     });
-  }, [countryCode, navigation, selfClient, showModal]);
+  }, [runKycFlow, selfClient, showModal]);
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={slate100}>

--- a/app/src/screens/home/HomeScreen.tsx
+++ b/app/src/screens/home/HomeScreen.tsx
@@ -51,6 +51,7 @@ import { useAppUpdates } from '@/hooks/useAppUpdates';
 import { useEarnPointsFlow } from '@/hooks/useEarnPointsFlow';
 import { usePoints } from '@/hooks/usePoints';
 import { useReferralConfirmation } from '@/hooks/useReferralConfirmation';
+import { useStoreReviewPrompt } from '@/hooks/useStoreReviewPrompt';
 import { useTestReferralFlow } from '@/hooks/useTestReferralFlow';
 import type { RootStackParamList } from '@/navigation';
 import { usePassport } from '@/providers/passportDataProvider';
@@ -193,6 +194,8 @@ const HomeScreen: React.FC = () => {
       showAppUpdateModal();
     }
   });
+
+  useStoreReviewPrompt();
 
   // Prevents back navigation
   usePreventRemove(true, () => {});

--- a/app/src/screens/verification/ProofRequestStatusScreen.tsx
+++ b/app/src/screens/verification/ProofRequestStatusScreen.tsx
@@ -51,6 +51,7 @@ import {
 import { getWhiteListedDisclosureAddresses } from '@/services/points/utils';
 import { useProofHistoryStore } from '@/stores/proofHistoryStore';
 import { ProofStatus } from '@/stores/proofTypes';
+import { useStoreReviewStore } from '@/stores/storeReviewStore';
 
 const PREREQ_CHECK_TIMEOUT_MS = 3000;
 // Give each active proving state a generous 90s window before exposing an
@@ -111,6 +112,9 @@ const SuccessScreen: React.FC = () => {
     // failure/error it is never populated, and blocking would trap the user.
     if (currentState === 'completed' && whitelistedPoints === undefined) return;
     buttonTap();
+    if (currentState === 'completed') {
+      useStoreReviewStore.getState().armPrompt();
+    }
     const completedSessionId = sessionId;
 
     const cleanupLater = () => {
@@ -270,12 +274,14 @@ const SuccessScreen: React.FC = () => {
             PROOF_TIMEOUT_REASON,
           );
         }
+        useStoreReviewStore.getState().recordProofFailure();
       }
     } else if (currentState === 'completed') {
       timedOutAnalyticsTrackedRef.current = false;
       notificationSuccess();
       if (sessionId) {
         updateProofStatus(sessionId, ProofStatus.SUCCESS);
+        useStoreReviewStore.getState().recordProofSuccess(sessionId);
       }
     } else if (currentState === 'failure' || currentState === 'error') {
       timedOutAnalyticsTrackedRef.current = false;
@@ -288,6 +294,7 @@ const SuccessScreen: React.FC = () => {
           reason ?? undefined,
         );
       }
+      useStoreReviewStore.getState().recordProofFailure();
     } else {
       timedOutAnalyticsTrackedRef.current = false;
     }

--- a/app/src/services/storeReview.ts
+++ b/app/src/services/storeReview.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import * as StoreReview from 'expo-store-review';
+
+import type { SelfClient } from '@selfxyz/mobile-sdk-alpha';
+import { AppEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+
+import { useStoreReviewStore } from '@/stores/storeReviewStore';
+import {
+  evaluateStoreReviewPrompt,
+  type StoreReviewSkipReason,
+} from '@/utils/storeReviewPolicy';
+
+export type StoreReviewRequestOutcome =
+  | { requested: true }
+  | {
+      requested: false;
+      reason: StoreReviewSkipReason | 'unavailable' | 'error';
+    };
+
+/**
+ * Asks the OS for its in-app rating sheet when the local policy allows it.
+ * The OS decides whether the sheet is actually shown and never reports back,
+ * so a request is recorded as a prompt before the native call is made.
+ */
+export async function requestStoreReviewIfEligible(
+  client?: Pick<SelfClient, 'trackEvent'>,
+  now: number = Date.now(),
+): Promise<StoreReviewRequestOutcome> {
+  const store = useStoreReviewStore.getState();
+  const decision = evaluateStoreReviewPrompt(store, now);
+  if (!decision.eligible) {
+    return { requested: false, reason: decision.reason };
+  }
+
+  try {
+    if (!(await StoreReview.isAvailableAsync())) {
+      return { requested: false, reason: 'unavailable' };
+    }
+    store.recordPromptShown(now);
+    await StoreReview.requestReview();
+    client?.trackEvent(AppEvents.STORE_REVIEW_REQUESTED, {
+      successful_proof_count: store.successfulProofCount,
+      prompt_count: useStoreReviewStore.getState().promptTimestamps.length,
+    });
+    return { requested: true };
+  } catch (error) {
+    console.warn(
+      'Store review request failed:',
+      error instanceof Error ? error.message : String(error),
+    );
+    return { requested: false, reason: 'error' };
+  }
+}

--- a/app/src/stores/kycFaucetNoticeStore.ts
+++ b/app/src/stores/kycFaucetNoticeStore.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { create } from 'zustand';
+
+import type { KycFaucetNoticeHandlers } from '@/integrations/kyc/faucetNotice';
+
+interface KycFaucetNoticeState {
+  isOpen: boolean;
+  isContinuing: boolean;
+  onContinue: KycFaucetNoticeHandlers['onContinue'] | null;
+  onDecline: (() => void) | null;
+  open: (handlers: KycFaucetNoticeHandlers) => void;
+  markContinuing: () => void;
+  close: () => void;
+}
+
+export const useKycFaucetNoticeStore = create<KycFaucetNoticeState>(set => ({
+  isOpen: false,
+  isContinuing: false,
+  onContinue: null,
+  onDecline: null,
+  open: ({ onContinue, onDecline }) =>
+    set({
+      isOpen: true,
+      isContinuing: false,
+      onContinue,
+      onDecline: onDecline ?? null,
+    }),
+  markContinuing: () => set({ isContinuing: true }),
+  close: () =>
+    set({
+      isOpen: false,
+      isContinuing: false,
+      onContinue: null,
+      onDecline: null,
+    }),
+}));
+
+/**
+ * Store-driven variant of the faucet notice for callers without access to the
+ * FeedbackProvider modal (anything mounted above it, e.g. selfClientProvider).
+ * Rendered by KycFaucetNoticeModal at the navigation root.
+ */
+export const showKycFaucetNotice = (handlers: KycFaucetNoticeHandlers) =>
+  useKycFaucetNoticeStore.getState().open(handlers);

--- a/app/src/stores/storeReviewStore.ts
+++ b/app/src/stores/storeReviewStore.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  pruneStoreReviewPrompts,
+  type StoreReviewSnapshot,
+} from '@/utils/storeReviewPolicy';
+
+interface PersistedStoreReviewState extends StoreReviewSnapshot {
+  lastCountedProofSessionId: string | null;
+}
+
+interface StoreReviewState extends PersistedStoreReviewState {
+  // Session-only. Armed when the user acknowledges a verified proof and
+  // consumed once Home has settled; never persisted so a killed app cannot
+  // resurrect a prompt detached from the success moment.
+  promptArmed: boolean;
+  recordProofSuccess: (sessionId: string) => void;
+  recordProofFailure: (now?: number) => void;
+  recordPromptShown: (now?: number) => void;
+  armPrompt: () => void;
+  disarmPrompt: () => void;
+}
+
+export const STORE_REVIEW_STORE_VERSION = 1;
+
+export const useStoreReviewStore = create<StoreReviewState>()(
+  persist(
+    set => ({
+      successfulProofCount: 0,
+      successfulProofCountAtLastPrompt: 0,
+      lastPromptAt: null,
+      promptTimestamps: [],
+      lastFailureAt: null,
+      lastCountedProofSessionId: null,
+      promptArmed: false,
+
+      recordProofSuccess: sessionId =>
+        set(state =>
+          state.lastCountedProofSessionId === sessionId
+            ? state
+            : {
+                successfulProofCount: state.successfulProofCount + 1,
+                lastCountedProofSessionId: sessionId,
+              },
+        ),
+      recordProofFailure: (now = Date.now()) =>
+        set({ lastFailureAt: now, promptArmed: false }),
+      recordPromptShown: (now = Date.now()) =>
+        set(state => ({
+          lastPromptAt: now,
+          successfulProofCountAtLastPrompt: state.successfulProofCount,
+          promptTimestamps: [
+            ...pruneStoreReviewPrompts(state.promptTimestamps, now),
+            now,
+          ],
+        })),
+      armPrompt: () => set({ promptArmed: true }),
+      disarmPrompt: () => set({ promptArmed: false }),
+    }),
+    {
+      name: 'store-review-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+      version: STORE_REVIEW_STORE_VERSION,
+      partialize: (state): PersistedStoreReviewState => ({
+        successfulProofCount: state.successfulProofCount,
+        successfulProofCountAtLastPrompt:
+          state.successfulProofCountAtLastPrompt,
+        lastPromptAt: state.lastPromptAt,
+        promptTimestamps: state.promptTimestamps,
+        lastFailureAt: state.lastFailureAt,
+        lastCountedProofSessionId: state.lastCountedProofSessionId,
+      }),
+    },
+  ),
+);

--- a/app/src/utils/storeReviewPolicy.ts
+++ b/app/src/utils/storeReviewPolicy.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Apple hard-caps SKStoreReviewController at 3 prompts per 365 days and Google
+// applies an undocumented quota; both silently swallow anything beyond that,
+// so the local cap keeps every request we make count.
+export const STORE_REVIEW_POLICY = {
+  minSuccessfulProofsForFirstPrompt: 2,
+  minSuccessfulProofsBetweenPrompts: 5,
+  minMsBetweenPrompts: 90 * DAY_MS,
+  maxPromptsPerRollingYear: 3,
+  rollingYearMs: 365 * DAY_MS,
+  failureCooldownMs: DAY_MS,
+} as const;
+
+export interface StoreReviewSnapshot {
+  successfulProofCount: number;
+  successfulProofCountAtLastPrompt: number;
+  lastPromptAt: number | null;
+  promptTimestamps: number[];
+  lastFailureAt: number | null;
+}
+
+export type StoreReviewSkipReason =
+  | 'not_enough_proofs'
+  | 'prompt_cooldown'
+  | 'yearly_cap'
+  | 'recent_failure';
+
+export type StoreReviewDecision =
+  | { eligible: true }
+  | { eligible: false; reason: StoreReviewSkipReason };
+
+export function pruneStoreReviewPrompts(
+  timestamps: number[],
+  now: number,
+): number[] {
+  return timestamps.filter(
+    timestamp => now - timestamp < STORE_REVIEW_POLICY.rollingYearMs,
+  );
+}
+
+export function evaluateStoreReviewPrompt(
+  snapshot: StoreReviewSnapshot,
+  now: number,
+): StoreReviewDecision {
+  const {
+    successfulProofCount,
+    successfulProofCountAtLastPrompt,
+    lastPromptAt,
+    lastFailureAt,
+  } = snapshot;
+
+  const proofsSinceLastPrompt =
+    lastPromptAt === null
+      ? successfulProofCount
+      : successfulProofCount - successfulProofCountAtLastPrompt;
+  const requiredProofs =
+    lastPromptAt === null
+      ? STORE_REVIEW_POLICY.minSuccessfulProofsForFirstPrompt
+      : STORE_REVIEW_POLICY.minSuccessfulProofsBetweenPrompts;
+  if (proofsSinceLastPrompt < requiredProofs) {
+    return { eligible: false, reason: 'not_enough_proofs' };
+  }
+
+  if (
+    lastPromptAt !== null &&
+    now - lastPromptAt < STORE_REVIEW_POLICY.minMsBetweenPrompts
+  ) {
+    return { eligible: false, reason: 'prompt_cooldown' };
+  }
+
+  if (
+    pruneStoreReviewPrompts(snapshot.promptTimestamps, now).length >=
+    STORE_REVIEW_POLICY.maxPromptsPerRollingYear
+  ) {
+    return { eligible: false, reason: 'yearly_cap' };
+  }
+
+  if (
+    lastFailureAt !== null &&
+    now - lastFailureAt < STORE_REVIEW_POLICY.failureCooldownMs
+  ) {
+    return { eligible: false, reason: 'recent_failure' };
+  }
+
+  return { eligible: true };
+}

--- a/app/tests/__setup__/expoStoreReviewMock.js
+++ b/app/tests/__setup__/expoStoreReviewMock.js
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+const isAvailableAsync = jest.fn(async () => true);
+const requestReview = jest.fn(async () => undefined);
+const hasAction = jest.fn(async () => false);
+const storeUrl = jest.fn(() => null);
+
+module.exports = { isAvailableAsync, requestReview, hasAction, storeUrl };

--- a/app/tests/src/components/KycFaucetNoticeModal.test.tsx
+++ b/app/tests/src/components/KycFaucetNoticeModal.test.tsx
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { act, render } from '@testing-library/react-native';
+
+import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
+import { KycEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+
+import AlertModal from '@/components/AlertModal';
+import KycFaucetNoticeModal from '@/components/KycFaucetNoticeModal';
+import { KYC_FAUCET_NOTICE_COPY } from '@/integrations/kyc/faucetNotice';
+import {
+  showKycFaucetNotice,
+  useKycFaucetNoticeStore,
+} from '@/stores/kycFaucetNoticeStore';
+
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  useSelfClient: jest.fn(),
+}));
+
+jest.mock('@/components/AlertModal', () => jest.fn(() => null));
+
+const mockAlertModal = AlertModal as jest.MockedFunction<typeof AlertModal>;
+const lastProps = () => mockAlertModal.mock.calls.at(-1)?.[0];
+
+describe('KycFaucetNoticeModal', () => {
+  const mockTrackEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useKycFaucetNoticeStore.getState().close();
+    (useSelfClient as jest.Mock).mockReturnValue({
+      trackEvent: mockTrackEvent,
+    });
+  });
+
+  it('renders nothing until the store opens it', () => {
+    render(<KycFaucetNoticeModal />);
+    expect(mockAlertModal).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('shows the notice copy and tracks the impression when opened', () => {
+    render(<KycFaucetNoticeModal />);
+    act(() => {
+      showKycFaucetNotice({ onContinue: jest.fn() });
+    });
+
+    expect(lastProps()?.visible).toBe(true);
+    expect(lastProps()?.modalParams).toMatchObject({
+      titleText: KYC_FAUCET_NOTICE_COPY.titleText,
+      buttonText: KYC_FAUCET_NOTICE_COPY.continueText,
+      secondaryButtonText: KYC_FAUCET_NOTICE_COPY.goBackText,
+      preventDismiss: false,
+    });
+    expect(mockTrackEvent).toHaveBeenCalledWith(KycEvents.FAUCET_NOTICE_SHOWN);
+  });
+
+  it('locks into loading while onContinue runs, then closes', async () => {
+    let finish: () => void = () => {};
+    const onContinue = jest.fn(
+      () =>
+        new Promise<void>(resolve => {
+          finish = resolve;
+        }),
+    );
+    render(<KycFaucetNoticeModal />);
+    act(() => {
+      showKycFaucetNotice({ onContinue });
+    });
+
+    let pressed: Promise<void> | void;
+    act(() => {
+      pressed = lastProps()?.modalParams?.onButtonPress();
+    });
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      KycEvents.FAUCET_NOTICE_CONTINUED,
+    );
+    expect(lastProps()?.modalParams).toMatchObject({
+      buttonText: KYC_FAUCET_NOTICE_COPY.loadingText,
+      disablePrimaryButton: true,
+      preventDismiss: true,
+    });
+
+    await act(async () => {
+      finish();
+      await pressed;
+    });
+    act(() => {
+      lastProps()?.onHideModal?.();
+    });
+    expect(useKycFaucetNoticeStore.getState().isOpen).toBe(false);
+  });
+
+  it('runs onDecline and tracks it when the user goes back', () => {
+    const onDecline = jest.fn();
+    render(<KycFaucetNoticeModal />);
+    act(() => {
+      showKycFaucetNotice({ onContinue: jest.fn(), onDecline });
+    });
+
+    lastProps()?.modalParams?.onSecondaryButtonPress?.();
+
+    expect(onDecline).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      KycEvents.FAUCET_NOTICE_DECLINED,
+    );
+  });
+});

--- a/app/tests/src/hooks/useKycLauncher.test.ts
+++ b/app/tests/src/hooks/useKycLauncher.test.ts
@@ -9,13 +9,18 @@ import {
   trackOnboardingStep,
   useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
-import { OnboardingEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+import {
+  KycEvents,
+  OnboardingEvents,
+} from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 
+import type { AlertModalParams } from '@/components/AlertModal';
 import { useKycLauncher } from '@/hooks/useKycLauncher';
 import {
   createKycSession,
   launchKycVerification as startKycVerification,
 } from '@/integrations/kyc';
+import { KYC_FAUCET_NOTICE_COPY } from '@/integrations/kyc/faucetNotice';
 import { useFeedback } from '@/providers/feedbackProvider';
 import { getKycDocumentCount } from '@/providers/passportDataProvider';
 
@@ -36,6 +41,9 @@ jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
 jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
   OnboardingEvents: { SCAN_STARTED: 'Onboarding: Document Scan Started' },
   KycEvents: {
+    FAUCET_NOTICE_CONTINUED: 'KYC: Faucet Notice Continued',
+    FAUCET_NOTICE_DECLINED: 'KYC: Faucet Notice Declined',
+    FAUCET_NOTICE_SHOWN: 'KYC: Faucet Notice Shown',
     SESSION_REQUESTED: 'KYC: Session Requested',
     SESSION_CREATED: 'KYC: Session Created',
     PROVIDER_OPENED: 'KYC: Provider Opened',
@@ -86,10 +94,20 @@ const mockGetKycDocumentCount = getKycDocumentCount as jest.MockedFunction<
 
 describe('useKycLauncher', () => {
   const selfClientStub = { trackEvent: jest.fn() };
-  const mockShowModal = jest.fn();
+  const mockShowModal = jest.fn<void, [AlertModalParams]>();
+  const noticeModals = () =>
+    mockShowModal.mock.calls
+      .map(([params]) => params)
+      .filter(params => params.titleText === KYC_FAUCET_NOTICE_COPY.titleText);
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: the user accepts the faucet notice so the provider flow runs.
+    mockShowModal.mockImplementation(params => {
+      if (params.buttonText === KYC_FAUCET_NOTICE_COPY.continueText) {
+        Promise.resolve(params.onButtonPress()).catch(() => undefined);
+      }
+    });
     mockUseSelfClient.mockReturnValue(
       selfClientStub as unknown as ReturnType<typeof useSelfClient>,
     );
@@ -391,5 +409,73 @@ describe('useKycLauncher', () => {
           "We couldn't confirm how many verified IDs are stored. Please try again.",
       }),
     );
+  });
+
+  it('shows the faucet notice after the pre-checks and before creating a session', async () => {
+    const callOrder: string[] = [];
+    mockShowModal.mockImplementation(params => {
+      if (params.buttonText === KYC_FAUCET_NOTICE_COPY.continueText) {
+        callOrder.push('notice');
+        Promise.resolve(params.onButtonPress()).catch(() => undefined);
+      }
+    });
+    mockCreateKycSession.mockImplementation(async () => {
+      callOrder.push('createKycSession');
+      return { sessionId: 'sess-1', sessionToken: 'tok-1' } as Awaited<
+        ReturnType<typeof createKycSession>
+      >;
+    });
+
+    const { result } = renderHook(() => useKycLauncher({ countryCode: 'US' }));
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(callOrder).toEqual(['notice', 'createKycSession']);
+    expect(noticeModals()[0]).toMatchObject({
+      bodyText: expect.stringContaining('Google USAT mainnet faucet'),
+      secondaryButtonText: KYC_FAUCET_NOTICE_COPY.goBackText,
+    });
+    expect(selfClientStub.trackEvent).toHaveBeenCalledWith(
+      KycEvents.FAUCET_NOTICE_SHOWN,
+    );
+    expect(selfClientStub.trackEvent).toHaveBeenCalledWith(
+      KycEvents.FAUCET_NOTICE_CONTINUED,
+    );
+  });
+
+  it('does not create a session when the user backs out of the faucet notice', async () => {
+    mockShowModal.mockImplementation(params => {
+      if (params.buttonText === KYC_FAUCET_NOTICE_COPY.continueText) {
+        Promise.resolve(params.onSecondaryButtonPress?.()).catch(
+          () => undefined,
+        );
+      }
+    });
+
+    const { result } = renderHook(() => useKycLauncher({ countryCode: 'US' }));
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(noticeModals()).toHaveLength(1);
+    expect(mockCreateKycSession).not.toHaveBeenCalled();
+    expect(mockStartKycVerification).not.toHaveBeenCalled();
+    expect(mockTrackBranchEvent).not.toHaveBeenCalled();
+    expect(selfClientStub.trackEvent).toHaveBeenCalledWith(
+      KycEvents.FAUCET_NOTICE_DECLINED,
+    );
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does not show the faucet notice when a pre-check blocks the launch', async () => {
+    mockGetKycDocumentCount.mockResolvedValue(3);
+
+    const { result } = renderHook(() => useKycLauncher({ countryCode: 'US' }));
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(noticeModals()).toHaveLength(0);
   });
 });

--- a/app/tests/src/hooks/useStoreReviewPrompt.test.ts
+++ b/app/tests/src/hooks/useStoreReviewPrompt.test.ts
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { AppState } from 'react-native';
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
+
+import {
+  STORE_REVIEW_PROMPT_DELAY_MS,
+  useStoreReviewPrompt,
+} from '@/hooks/useStoreReviewPrompt';
+import { requestStoreReviewIfEligible } from '@/services/storeReview';
+import { useStoreReviewStore } from '@/stores/storeReviewStore';
+
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  useSelfClient: jest.fn(),
+}));
+jest.mock('@/navigation', () => ({
+  navigationRef: global.mockNavigationRef,
+}));
+jest.mock('@/services/storeReview', () => ({
+  requestStoreReviewIfEligible: jest.fn(),
+}));
+
+const mockRequest = requestStoreReviewIfEligible as jest.Mock;
+const selfClientStub = { trackEvent: jest.fn() };
+
+describe('useStoreReviewPrompt', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    (useSelfClient as jest.Mock).mockReturnValue(selfClientStub);
+    mockRequest.mockResolvedValue({ requested: true });
+    global.mockNavigationRef.getCurrentRoute.mockReturnValue({ name: 'Home' });
+    (AppState as unknown as { currentState: string }).currentState = 'active';
+    useStoreReviewStore.setState({ promptArmed: false });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does nothing while no prompt is armed', () => {
+    renderHook(() => useStoreReviewPrompt());
+    act(() => {
+      jest.advanceTimersByTime(STORE_REVIEW_PROMPT_DELAY_MS);
+    });
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('requests a review once Home has settled and disarms the prompt', () => {
+    useStoreReviewStore.setState({ promptArmed: true });
+    renderHook(() => useStoreReviewPrompt());
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(STORE_REVIEW_PROMPT_DELAY_MS);
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(selfClientStub);
+    expect(useStoreReviewStore.getState().promptArmed).toBe(false);
+  });
+
+  it('stays armed when another route sits on top of Home', () => {
+    useStoreReviewStore.setState({ promptArmed: true });
+    global.mockNavigationRef.getCurrentRoute.mockReturnValue({ name: 'Modal' });
+    renderHook(() => useStoreReviewPrompt());
+
+    act(() => {
+      jest.advanceTimersByTime(STORE_REVIEW_PROMPT_DELAY_MS);
+    });
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(useStoreReviewStore.getState().promptArmed).toBe(true);
+  });
+
+  it('stays armed when the app is not in the foreground', () => {
+    useStoreReviewStore.setState({ promptArmed: true });
+    (AppState as unknown as { currentState: string }).currentState =
+      'background';
+    renderHook(() => useStoreReviewPrompt());
+
+    act(() => {
+      jest.advanceTimersByTime(STORE_REVIEW_PROMPT_DELAY_MS);
+    });
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(useStoreReviewStore.getState().promptArmed).toBe(true);
+  });
+});

--- a/app/tests/src/integrations/kyc/faucetNotice.test.ts
+++ b/app/tests/src/integrations/kyc/faucetNotice.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { KycEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+
+import type { AlertModalParams } from '@/components/AlertModal';
+import {
+  confirmKycFaucetNotice,
+  KYC_FAUCET_NOTICE_COPY,
+} from '@/integrations/kyc/faucetNotice';
+
+describe('confirmKycFaucetNotice', () => {
+  const showModal = jest.fn<void, [AlertModalParams]>();
+  const tracker = { trackEvent: jest.fn() };
+  const lastModal = () => showModal.mock.calls.at(-1)?.[0] as AlertModalParams;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the notice with continue and go-back actions', () => {
+    confirmKycFaucetNotice(showModal, { onContinue: jest.fn() }, tracker).catch(
+      () => undefined,
+    );
+
+    expect(lastModal()).toMatchObject({
+      titleText: KYC_FAUCET_NOTICE_COPY.titleText,
+      bodyText: expect.stringContaining('Google USAT mainnet faucet'),
+      buttonText: KYC_FAUCET_NOTICE_COPY.continueText,
+      secondaryButtonText: KYC_FAUCET_NOTICE_COPY.goBackText,
+    });
+    expect(tracker.trackEvent).toHaveBeenCalledWith(
+      KycEvents.FAUCET_NOTICE_SHOWN,
+    );
+  });
+
+  it('locks the modal into a loading state and resolves true after onContinue settles', async () => {
+    let finish: () => void = () => {};
+    const onContinue = jest.fn(
+      () =>
+        new Promise<void>(resolve => {
+          finish = resolve;
+        }),
+    );
+    const result = confirmKycFaucetNotice(showModal, { onContinue }, tracker);
+
+    const pressed = lastModal().onButtonPress();
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(lastModal()).toMatchObject({
+      buttonText: KYC_FAUCET_NOTICE_COPY.loadingText,
+      disablePrimaryButton: true,
+      preventDismiss: true,
+    });
+    expect(tracker.trackEvent).toHaveBeenCalledWith(
+      KycEvents.FAUCET_NOTICE_CONTINUED,
+    );
+
+    finish();
+    await pressed;
+    await expect(result).resolves.toBe(true);
+  });
+
+  it('resolves true even when onContinue rejects', async () => {
+    const onContinue = jest.fn().mockRejectedValue(new Error('boom'));
+    const result = confirmKycFaucetNotice(showModal, { onContinue });
+
+    await expect(lastModal().onButtonPress()).rejects.toThrow('boom');
+    await expect(result).resolves.toBe(true);
+  });
+
+  it('resolves false and never runs onContinue when the user goes back', async () => {
+    const onContinue = jest.fn();
+    const onDecline = jest.fn();
+    const result = confirmKycFaucetNotice(
+      showModal,
+      { onContinue, onDecline },
+      tracker,
+    );
+
+    await lastModal().onSecondaryButtonPress?.();
+
+    await expect(result).resolves.toBe(false);
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(onDecline).toHaveBeenCalledTimes(1);
+    expect(tracker.trackEvent).toHaveBeenCalledWith(
+      KycEvents.FAUCET_NOTICE_DECLINED,
+    );
+  });
+
+  it('treats closing the modal as declining', async () => {
+    const onContinue = jest.fn();
+    const result = confirmKycFaucetNotice(showModal, { onContinue }, tracker);
+
+    lastModal().onModalDismiss?.();
+
+    await expect(result).resolves.toBe(false);
+    expect(onContinue).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/src/providers/selfClientProvider.test.tsx
+++ b/app/tests/src/providers/selfClientProvider.test.tsx
@@ -6,6 +6,7 @@
 import type { ReactNode } from 'react';
 import { act, renderHook } from '@testing-library/react-native';
 
+import { useKycFaucetNoticeStore } from '@/stores/kycFaucetNoticeStore';
 import { useSettingStore } from '@/stores/settingStore';
 
 let mockSdkProviderProps: Record<string, unknown> | undefined;
@@ -301,6 +302,15 @@ describe('SelfClientProvider', () => {
         documentType: 'kyc',
         countryCode: 'US',
       });
+    });
+
+    // The faucet-incompatibility notice gates the provider launch; nothing
+    // runs until the user continues.
+    expect(useKycFaucetNoticeStore.getState().isOpen).toBe(true);
+    expect(callOrder).toEqual([]);
+
+    await act(async () => {
+      await useKycFaucetNoticeStore.getState().onContinue?.();
     });
 
     expect(callOrder).toEqual([

--- a/app/tests/src/screens/verification/ProofRequestStatusScreen.test.tsx
+++ b/app/tests/src/screens/verification/ProofRequestStatusScreen.test.tsx
@@ -155,6 +155,10 @@ jest.mock('@/stores/proofHistoryStore', () => ({
   useProofHistoryStore: jest.fn(),
 }));
 
+jest.mock('@/stores/storeReviewStore', () => ({
+  useStoreReviewStore: { getState: jest.fn() },
+}));
+
 const { Linking } = jest.requireMock('react-native') as {
   Linking: {
     openURL: jest.Mock;
@@ -190,6 +194,11 @@ const { useProofHistoryStore } = jest.requireMock(
 ) as {
   useProofHistoryStore: jest.Mock;
 };
+const { useStoreReviewStore } = jest.requireMock(
+  '@/stores/storeReviewStore',
+) as {
+  useStoreReviewStore: { getState: jest.Mock };
+};
 
 describe('ProofRequestStatusScreen', () => {
   const mockGoHome = jest.fn();
@@ -198,6 +207,9 @@ describe('ProofRequestStatusScreen', () => {
   const mockCleanSelfApp = jest.fn();
   const mockUpdateProofStatus = jest.fn();
   const mockCancelProof = jest.fn();
+  const mockRecordProofSuccess = jest.fn();
+  const mockRecordProofFailure = jest.fn();
+  const mockArmPrompt = jest.fn();
 
   let provingState: {
     currentState: string;
@@ -242,6 +254,11 @@ describe('ProofRequestStatusScreen', () => {
     useHapticNavigation.mockReturnValue(mockGoHome);
     useProofHistoryStore.mockReturnValue({
       updateProofStatus: mockUpdateProofStatus,
+    });
+    useStoreReviewStore.getState.mockReturnValue({
+      recordProofSuccess: mockRecordProofSuccess,
+      recordProofFailure: mockRecordProofFailure,
+      armPrompt: mockArmPrompt,
     });
     getWhiteListedDisclosureAddresses.mockResolvedValue([]);
     hasUserAnIdentityDocumentRegistered.mockResolvedValue(true);
@@ -294,6 +311,37 @@ describe('ProofRequestStatusScreen', () => {
 
     expect(mockCleanSelfApp).toHaveBeenCalledTimes(1);
     expect(notificationSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts the verified proof and arms the store review prompt on acknowledgement', async () => {
+    render(<ProofRequestStatusScreen />);
+
+    await waitFor(() => {
+      expect(mockRecordProofSuccess).toHaveBeenCalledWith('session-1');
+    });
+    expect(mockArmPrompt).not.toHaveBeenCalled();
+
+    fireEvent.press(screen.getByTestId('primary-button'));
+
+    expect(mockArmPrompt).toHaveBeenCalledTimes(1);
+    expect(mockRecordProofFailure).not.toHaveBeenCalled();
+  });
+
+  it('records a failed proof and never arms the store review prompt', async () => {
+    provingState.currentState = 'failure';
+    provingState.reason = 'InvalidRoot';
+
+    render(<ProofRequestStatusScreen />);
+
+    await waitFor(() => {
+      expect(mockRecordProofFailure).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.press(screen.getByTestId('primary-button'));
+
+    expect(mockArmPrompt).not.toHaveBeenCalled();
+    expect(mockRecordProofSuccess).not.toHaveBeenCalled();
+    expect(mockGoHome).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the button disabled on completed while whitelist fetch is pending', async () => {

--- a/app/tests/src/services/storeReview.test.ts
+++ b/app/tests/src/services/storeReview.test.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import * as StoreReview from 'expo-store-review';
+
+import { AppEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+
+import { requestStoreReviewIfEligible } from '@/services/storeReview';
+import { useStoreReviewStore } from '@/stores/storeReviewStore';
+
+const mockIsAvailableAsync = StoreReview.isAvailableAsync as jest.Mock;
+const mockRequestReview = StoreReview.requestReview as jest.Mock;
+
+const NOW = Date.UTC(2026, 8, 4);
+
+describe('requestStoreReviewIfEligible', () => {
+  const trackEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAvailableAsync.mockResolvedValue(true);
+    mockRequestReview.mockResolvedValue(undefined);
+    useStoreReviewStore.setState({
+      successfulProofCount: 3,
+      successfulProofCountAtLastPrompt: 0,
+      lastPromptAt: null,
+      promptTimestamps: [],
+      lastFailureAt: null,
+      lastCountedProofSessionId: null,
+      promptArmed: false,
+    });
+  });
+
+  it('requests the OS sheet, records the prompt and tracks it', async () => {
+    const outcome = await requestStoreReviewIfEligible({ trackEvent }, NOW);
+
+    expect(outcome).toEqual({ requested: true });
+    expect(mockRequestReview).toHaveBeenCalledTimes(1);
+    expect(useStoreReviewStore.getState()).toMatchObject({
+      lastPromptAt: NOW,
+      successfulProofCountAtLastPrompt: 3,
+      promptTimestamps: [NOW],
+    });
+    expect(trackEvent).toHaveBeenCalledWith(AppEvents.STORE_REVIEW_REQUESTED, {
+      successful_proof_count: 3,
+      prompt_count: 1,
+    });
+  });
+
+  it('skips without touching the OS when the policy says no', async () => {
+    useStoreReviewStore.setState({ successfulProofCount: 1 });
+
+    const outcome = await requestStoreReviewIfEligible({ trackEvent }, NOW);
+
+    expect(outcome).toEqual({ requested: false, reason: 'not_enough_proofs' });
+    expect(mockIsAvailableAsync).not.toHaveBeenCalled();
+    expect(mockRequestReview).not.toHaveBeenCalled();
+    expect(useStoreReviewStore.getState().lastPromptAt).toBeNull();
+  });
+
+  it('skips and leaves the budget untouched when the store is unavailable', async () => {
+    mockIsAvailableAsync.mockResolvedValue(false);
+
+    const outcome = await requestStoreReviewIfEligible({ trackEvent }, NOW);
+
+    expect(outcome).toEqual({ requested: false, reason: 'unavailable' });
+    expect(mockRequestReview).not.toHaveBeenCalled();
+    expect(useStoreReviewStore.getState().lastPromptAt).toBeNull();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it('still counts the prompt when the native call throws', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockRequestReview.mockRejectedValue(new Error('native boom'));
+
+    const outcome = await requestStoreReviewIfEligible({ trackEvent }, NOW);
+
+    expect(outcome).toEqual({ requested: false, reason: 'error' });
+    expect(useStoreReviewStore.getState().lastPromptAt).toBe(NOW);
+    expect(trackEvent).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/app/tests/src/stores/kycFaucetNoticeStore.test.ts
+++ b/app/tests/src/stores/kycFaucetNoticeStore.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import {
+  showKycFaucetNotice,
+  useKycFaucetNoticeStore,
+} from '@/stores/kycFaucetNoticeStore';
+
+describe('useKycFaucetNoticeStore', () => {
+  beforeEach(() => {
+    useKycFaucetNoticeStore.getState().close();
+  });
+
+  it('opens with the provided handlers', () => {
+    const onContinue = jest.fn();
+    const onDecline = jest.fn();
+    showKycFaucetNotice({ onContinue, onDecline });
+
+    expect(useKycFaucetNoticeStore.getState()).toMatchObject({
+      isOpen: true,
+      isContinuing: false,
+      onContinue,
+      onDecline,
+    });
+  });
+
+  it('tracks the continuing state and clears everything on close', () => {
+    showKycFaucetNotice({ onContinue: jest.fn() });
+    useKycFaucetNoticeStore.getState().markContinuing();
+    expect(useKycFaucetNoticeStore.getState().isContinuing).toBe(true);
+
+    useKycFaucetNoticeStore.getState().close();
+    expect(useKycFaucetNoticeStore.getState()).toMatchObject({
+      isOpen: false,
+      isContinuing: false,
+      onContinue: null,
+      onDecline: null,
+    });
+  });
+});

--- a/app/tests/src/stores/storeReviewStore.test.ts
+++ b/app/tests/src/stores/storeReviewStore.test.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useStoreReviewStore } from '@/stores/storeReviewStore';
+import { STORE_REVIEW_POLICY } from '@/utils/storeReviewPolicy';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('useStoreReviewStore', () => {
+  beforeEach(() => {
+    useStoreReviewStore.setState({
+      successfulProofCount: 0,
+      successfulProofCountAtLastPrompt: 0,
+      lastPromptAt: null,
+      promptTimestamps: [],
+      lastFailureAt: null,
+      lastCountedProofSessionId: null,
+      promptArmed: false,
+    });
+  });
+
+  it('counts each proof session once', () => {
+    const { recordProofSuccess } = useStoreReviewStore.getState();
+    recordProofSuccess('session-a');
+    recordProofSuccess('session-a');
+    recordProofSuccess('session-b');
+
+    expect(useStoreReviewStore.getState().successfulProofCount).toBe(2);
+    expect(useStoreReviewStore.getState().lastCountedProofSessionId).toBe(
+      'session-b',
+    );
+  });
+
+  it('records failures and disarms any pending prompt', () => {
+    useStoreReviewStore.getState().armPrompt();
+    useStoreReviewStore.getState().recordProofFailure(1_000);
+
+    expect(useStoreReviewStore.getState()).toMatchObject({
+      lastFailureAt: 1_000,
+      promptArmed: false,
+    });
+  });
+
+  it('snapshots the proof count and prunes old prompts when a prompt is shown', () => {
+    const now = Date.UTC(2026, 8, 4);
+    const stale = now - STORE_REVIEW_POLICY.rollingYearMs - DAY_MS;
+    const recent = now - 10 * DAY_MS;
+    useStoreReviewStore.setState({
+      successfulProofCount: 7,
+      promptTimestamps: [stale, recent],
+    });
+
+    useStoreReviewStore.getState().recordPromptShown(now);
+
+    expect(useStoreReviewStore.getState()).toMatchObject({
+      lastPromptAt: now,
+      successfulProofCountAtLastPrompt: 7,
+      promptTimestamps: [recent, now],
+    });
+  });
+
+  it('arms and disarms the prompt flag', () => {
+    useStoreReviewStore.getState().armPrompt();
+    expect(useStoreReviewStore.getState().promptArmed).toBe(true);
+    useStoreReviewStore.getState().disarmPrompt();
+    expect(useStoreReviewStore.getState().promptArmed).toBe(false);
+  });
+
+  it('does not persist the session-only prompt flag', () => {
+    const persisted = useStoreReviewStore.persist.getOptions().partialize?.({
+      ...useStoreReviewStore.getState(),
+      promptArmed: true,
+    }) as Record<string, unknown>;
+
+    expect(persisted).not.toHaveProperty('promptArmed');
+    expect(persisted).toHaveProperty('successfulProofCount');
+  });
+});

--- a/app/tests/src/utils/storeReviewPolicy.test.ts
+++ b/app/tests/src/utils/storeReviewPolicy.test.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import {
+  evaluateStoreReviewPrompt,
+  pruneStoreReviewPrompts,
+  STORE_REVIEW_POLICY,
+  type StoreReviewSnapshot,
+} from '@/utils/storeReviewPolicy';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 8, 4);
+
+const snapshot = (
+  overrides: Partial<StoreReviewSnapshot> = {},
+): StoreReviewSnapshot => ({
+  successfulProofCount: 0,
+  successfulProofCountAtLastPrompt: 0,
+  lastPromptAt: null,
+  promptTimestamps: [],
+  lastFailureAt: null,
+  ...overrides,
+});
+
+describe('evaluateStoreReviewPrompt', () => {
+  it('waits for the first-prompt proof threshold', () => {
+    expect(
+      evaluateStoreReviewPrompt(
+        snapshot({
+          successfulProofCount:
+            STORE_REVIEW_POLICY.minSuccessfulProofsForFirstPrompt - 1,
+        }),
+        NOW,
+      ),
+    ).toEqual({ eligible: false, reason: 'not_enough_proofs' });
+
+    expect(
+      evaluateStoreReviewPrompt(
+        snapshot({
+          successfulProofCount:
+            STORE_REVIEW_POLICY.minSuccessfulProofsForFirstPrompt,
+        }),
+        NOW,
+      ),
+    ).toEqual({ eligible: true });
+  });
+
+  it('requires more proofs between prompts than before the first one', () => {
+    const lastPromptAt = NOW - 2 * STORE_REVIEW_POLICY.minMsBetweenPrompts;
+    const base = snapshot({
+      successfulProofCountAtLastPrompt: 2,
+      lastPromptAt,
+      promptTimestamps: [lastPromptAt],
+    });
+
+    expect(
+      evaluateStoreReviewPrompt(
+        {
+          ...base,
+          successfulProofCount:
+            2 + STORE_REVIEW_POLICY.minSuccessfulProofsBetweenPrompts - 1,
+        },
+        NOW,
+      ),
+    ).toEqual({ eligible: false, reason: 'not_enough_proofs' });
+
+    expect(
+      evaluateStoreReviewPrompt(
+        {
+          ...base,
+          successfulProofCount:
+            2 + STORE_REVIEW_POLICY.minSuccessfulProofsBetweenPrompts,
+        },
+        NOW,
+      ),
+    ).toEqual({ eligible: true });
+  });
+
+  it('enforces the cooldown since the last prompt', () => {
+    const lastPromptAt = NOW - STORE_REVIEW_POLICY.minMsBetweenPrompts + DAY_MS;
+    expect(
+      evaluateStoreReviewPrompt(
+        snapshot({
+          successfulProofCount: 20,
+          successfulProofCountAtLastPrompt: 2,
+          lastPromptAt,
+          promptTimestamps: [lastPromptAt],
+        }),
+        NOW,
+      ),
+    ).toEqual({ eligible: false, reason: 'prompt_cooldown' });
+  });
+
+  it('caps prompts within a rolling year and forgets older ones', () => {
+    const lastPromptAt = NOW - STORE_REVIEW_POLICY.minMsBetweenPrompts - DAY_MS;
+    const recent = [NOW - 300 * DAY_MS, NOW - 200 * DAY_MS, lastPromptAt];
+    const capped = snapshot({
+      successfulProofCount: 20,
+      successfulProofCountAtLastPrompt: 2,
+      lastPromptAt,
+      promptTimestamps: recent,
+    });
+    expect(evaluateStoreReviewPrompt(capped, NOW)).toEqual({
+      eligible: false,
+      reason: 'yearly_cap',
+    });
+
+    const aged = {
+      ...capped,
+      promptTimestamps: [NOW - 400 * DAY_MS, NOW - 200 * DAY_MS, lastPromptAt],
+    };
+    expect(evaluateStoreReviewPrompt(aged, NOW)).toEqual({ eligible: true });
+  });
+
+  it('holds back after a recent proof failure', () => {
+    expect(
+      evaluateStoreReviewPrompt(
+        snapshot({
+          successfulProofCount: 5,
+          lastFailureAt: NOW - STORE_REVIEW_POLICY.failureCooldownMs / 2,
+        }),
+        NOW,
+      ),
+    ).toEqual({ eligible: false, reason: 'recent_failure' });
+
+    expect(
+      evaluateStoreReviewPrompt(
+        snapshot({
+          successfulProofCount: 5,
+          lastFailureAt: NOW - STORE_REVIEW_POLICY.failureCooldownMs,
+        }),
+        NOW,
+      ),
+    ).toEqual({ eligible: true });
+  });
+
+  it('treats a clock that moved backwards as still cooling down', () => {
+    const lastPromptAt = NOW + DAY_MS;
+    expect(
+      evaluateStoreReviewPrompt(
+        snapshot({
+          successfulProofCount: 20,
+          successfulProofCountAtLastPrompt: 2,
+          lastPromptAt,
+          promptTimestamps: [lastPromptAt],
+        }),
+        NOW,
+      ),
+    ).toEqual({ eligible: false, reason: 'prompt_cooldown' });
+  });
+});
+
+describe('pruneStoreReviewPrompts', () => {
+  it('drops timestamps older than the rolling year', () => {
+    const kept = NOW - STORE_REVIEW_POLICY.rollingYearMs + 1;
+    const dropped = NOW - STORE_REVIEW_POLICY.rollingYearMs;
+    expect(pruneStoreReviewPrompts([dropped, kept, NOW], NOW)).toEqual([
+      kept,
+      NOW,
+    ]);
+  });
+});

--- a/packages/mobile-sdk-alpha/src/constants/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/constants/analytics.ts
@@ -21,6 +21,7 @@ export const AppEvents = {
   GET_STARTED: 'App: Get Started',
   GET_STARTED_AADHAAR: 'App: Get Started - Aadhaar',
   GET_STARTED_BIOMETRIC: 'App: Get Started - Biometric ID',
+  STORE_REVIEW_REQUESTED: 'App: Store Review Requested',
   SUPPORTED_BIOMETRIC_IDS: 'App: Supported Biometric IDs',
   UPDATE_MODAL_CLOSED: 'App: Update Modal Closed',
   UPDATE_MODAL_OPENED: 'App: Update Modal Opened',
@@ -84,6 +85,9 @@ export const DocumentEvents = {
 } as const;
 
 export const KycEvents = {
+  FAUCET_NOTICE_CONTINUED: 'KYC: Faucet Notice Continued',
+  FAUCET_NOTICE_DECLINED: 'KYC: Faucet Notice Declined',
+  FAUCET_NOTICE_SHOWN: 'KYC: Faucet Notice Shown',
   PROVIDER_CLOSED: 'KYC: Provider Closed',
   PROVIDER_OPENED: 'KYC: Provider Opened',
   RETRY_TRIGGERED: 'KYC: Retry Triggered',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       expo-file-system:
         specifier: 55.0.22
         version: 55.0.22(expo@55.0.20)(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))
+      expo-store-review:
+        specifier: 55.0.17
+        version: 55.0.17(expo@55.0.20)(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))
       lottie-react-native:
         specifier: 7.3.6
         version: 7.3.6(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
@@ -11489,6 +11492,12 @@ packages:
   expo-server@55.0.11:
     resolution: {integrity: sha512-AxRdHqcv0H1g4s923vu+5n1Nrhne23bjXbP+Vl7+Lwfpe7MG9PuU1IS95IJK6a+7BVV1mRN6QlZvs8Yv7EEXNQ==}
     engines: {node: '>=20.16.0'}
+
+  expo-store-review@55.0.17:
+    resolution: {integrity: sha512-plMqq6Grj97gU2MC/OKMDBnX+DDAx0CHdGclcG07b9hi1RZ7WqDHYuB06SImlcHdRjaVm4rU0oCHjtgrht/7Sw==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
 
   expo@55.0.20:
     resolution: {integrity: sha512-YY05NHHyEgHRWM1KswPkgeDnRssZ4S2H5Pwlt8q2NPVhXyhukHCxR8ighNndvSgqLo8yKzZMDyWlUZTPLyUERg==}
@@ -29911,6 +29920,11 @@ snapshots:
       react-native-worklets: 0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
 
   expo-server@55.0.11: {}
+
+  expo-store-review@55.0.17(expo@55.0.20)(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6)):
+    dependencies:
+      expo: 55.0.20(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      react-native: 0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6)
 
   expo@55.0.20(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.0)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@react-native/metro-config@0.83.9(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
…faucet notice on the KYC flow (#2288)

Store review
- Ask for a store rating through the native in-app review sheet (expo-store-review) instead of a custom dialog, as Apple and Google guidelines require.
- Prompt only after the user acknowledges a verified proof, and only once Home has settled, never on the proof screen or over a Modal route.
- Local policy mirrors the OS quotas so every request counts: 2 successful proofs before the first prompt, 5 more between prompts, 90-day cooldown, 3 prompts per rolling year, and a 24h hold after any failed proof.
- Persisted counters live in a dedicated zustand store; the armed flag is session-only so a killed app never resurrects a stale prompt.

KYC / Didit faucet notice
- Every Didit launch (launcher hook, chip-symbol "No" on logo confirmation, and the SDK ID-picker "kyc" selection) now shows an explicit notice that third-party verified IDs are not compatible with the Google USAT mainnet faucet, with Continue anyway / Go back.
- The notice reuses the single FeedbackProvider AlertModal where one is already on screen, and a store-driven modal at the navigation root for the provider path that sits above FeedbackProvider.
- New analytics: KYC faucet notice shown/continued/declined and App: Store Review Requested.

## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `pnpm lint && pnpm types` pass
- [ ] Bridge contract tests pass: `cd app && pnpm jest:run` and `pnpm --filter @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `pnpm --filter @selfxyz/mobile-sdk-alpha test && pnpm --filter @selfxyz/mobile-sdk-alpha types` pass
- [ ] Diff of `.kt`/`.swift` reviewed - no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent - flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) - relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) - **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a notice explaining faucet incompatibility before KYC verification, with options to continue or decline.
  - Added in-app store review prompts after successful proof completion, subject to eligibility limits and cooldowns.
  - Added analytics tracking for KYC notice interactions and store review requests.
- **Bug Fixes**
  - KYC verification no longer starts until the faucet compatibility notice is acknowledged.
- **Tests**
  - Added coverage for notice behavior, KYC flows, store review eligibility, persistence, and prompt timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->