### PR TITLE
fix(app): request the store review after the first verified proof

### DIFF
--- a/app/src/utils/storeReviewPolicy.ts
+++ b/app/src/utils/storeReviewPolicy.ts
@@ -8,7 +8,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 // applies an undocumented quota; both silently swallow anything beyond that,
 // so the local cap keeps every request we make count.
 export const STORE_REVIEW_POLICY = {
-  minSuccessfulProofsForFirstPrompt: 2,
+  minSuccessfulProofsForFirstPrompt: 1,
   minSuccessfulProofsBetweenPrompts: 5,
   minMsBetweenPrompts: 90 * DAY_MS,
   maxPromptsPerRollingYear: 3,

--- a/app/tests/src/services/storeReview.test.ts
+++ b/app/tests/src/services/storeReview.test.ts
@@ -49,7 +49,7 @@ describe('requestStoreReviewIfEligible', () => {
   });
 
   it('skips without touching the OS when the policy says no', async () => {
-    useStoreReviewStore.setState({ successfulProofCount: 1 });
+    useStoreReviewStore.setState({ successfulProofCount: 0 });
 
     const outcome = await requestStoreReviewIfEligible({ trackEvent }, NOW);
 


### PR DESCRIPTION
## Summary

Lowers `minSuccessfulProofsForFirstPrompt` from 2 to 1 in `storeReviewPolicy.ts`, so the native rating sheet is requested after the user acknowledges their **first** verified proof instead of the second.

The first verified proof is the strongest moment in the product and many users never do a second one, so the old threshold threw away most of the reach. Everything else in the policy is unchanged: 5 more proofs between prompts, 90-day cooldown, 3 prompts per rolling 365 days (Apple's own cap), and a 24h hold after any failed proof.

Reminder for testing: TestFlight builds never show the iOS rating sheet, by Apple's design. Use a debug build to see it, or check the `App: Store Review Requested` analytics event.

## Test plan

- [x] `cd app && pnpm jest:run` on the store review suites (policy, store, service, Home hook): 20 tests pass. The policy tests reference the constant, so they now assert 0 proofs is too few and 1 is enough; the service test that expects a skip now uses 0 proofs.
- [x] `cd app && pnpm types`, eslint on touched files
- [ ] **Human QA in a debug build:** complete one proof, tap OK, confirm the rating sheet appears on Home about a second later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The first store-review prompt can now appear after one successful proof instead of two.

* **Tests**
  * Updated coverage for the scenario where no successful proofs have been completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->