### PR TITLE
fix(app): request the store review after the first verified proof (dev)

### DIFF
--- a/app/src/utils/storeReviewPolicy.ts
+++ b/app/src/utils/storeReviewPolicy.ts
@@ -8,7 +8,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 // applies an undocumented quota; both silently swallow anything beyond that,
 // so the local cap keeps every request we make count.
 export const STORE_REVIEW_POLICY = {
-  minSuccessfulProofsForFirstPrompt: 2,
+  minSuccessfulProofsForFirstPrompt: 1,
   minSuccessfulProofsBetweenPrompts: 5,
   minMsBetweenPrompts: 90 * DAY_MS,
   maxPromptsPerRollingYear: 3,

--- a/app/tests/src/services/storeReview.test.ts
+++ b/app/tests/src/services/storeReview.test.ts
@@ -49,7 +49,7 @@ describe('requestStoreReviewIfEligible', () => {
   });
 
   it('skips without touching the OS when the policy says no', async () => {
-    useStoreReviewStore.setState({ successfulProofCount: 1 });
+    useStoreReviewStore.setState({ successfulProofCount: 0 });
 
     const outcome = await requestStoreReviewIfEligible({ trackEvent }, NOW);
 


### PR DESCRIPTION
Cherry-pick of d9cb4e29f (#2292, merged to staging only) onto dev, so the fix ships in the redeploy and isn't lost at the next staging snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Store review prompts can now appear after one successful proof when no previous prompt has been shown.
* **Tests**
  * Updated coverage to reflect the eligibility threshold for store review prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->